### PR TITLE
Remove positional vars

### DIFF
--- a/cmd/src/api.go
+++ b/cmd/src/api.go
@@ -25,7 +25,7 @@ Examples:
 
   Specify query variables:
 
-    	$ echo '<query>' | src api 'var1=val1' 'var2=val2'
+    	$ echo '<query>' | src api -vars '{"var1":"val1, "var2":"val2"}'
 
   Searching for "Router" and getting result count:
 
@@ -70,15 +70,6 @@ Examples:
 			if err := json.Unmarshal([]byte(*varsFlag), &vars); err != nil {
 				return err
 			}
-		}
-		for _, arg := range flagSet.Args() {
-			idx := strings.Index(arg, "=")
-			if idx == -1 {
-				return &usageError{fmt.Errorf("parsing argument %q expected 'variable=value' syntax (missing equals)", arg)}
-			}
-			key := arg[:idx]
-			value := arg[idx+1:]
-			vars[key] = value
 		}
 
 		// Handle the get-curl flag now.


### PR DESCRIPTION
Previously there were 2 ways of specifying variables: positional and JSON.

You can still provide vars in JSON format:

```
echo '<query>' | src api -vars '{"var1":"val1, "var2":"val2"}'
```