### PR TITLE
Add `src repos list|enable|disable` commands

### DIFF
--- a/cmd/src/api.go
+++ b/cmd/src/api.go
@@ -49,9 +49,11 @@ Examples:
 		flagSet.PrintDefaults()
 		fmt.Println(usage)
 	}
-	queryFlag := flagSet.String("query", "", "GraphQL query to execute, e.g. 'query { currentUser { username } }' (stdin otherwise)")
-	varsFlag := flagSet.String("vars", "", `GraphQL query variables to include as JSON string, e.g. '{"var": "val", "var2": "val2"}'`)
-	apiFlags := newAPIFlags(flagSet)
+	var (
+		queryFlag = flagSet.String("query", "", "GraphQL query to execute, e.g. 'query { currentUser { username } }' (stdin otherwise)")
+		varsFlag  = flagSet.String("vars", "", `GraphQL query variables to include as JSON string, e.g. '{"var": "val", "var2": "val2"}'`)
+		apiFlags  = newAPIFlags(flagSet)
+	)
 
 	handler := func(args []string) error {
 		flagSet.Parse(args)

--- a/cmd/src/api.go
+++ b/cmd/src/api.go
@@ -290,3 +290,17 @@ func (g *graphqlError) Error() string {
 	j, _ := json.MarshalIndent(g.Errors, "", "  ")
 	return string(j)
 }
+
+func nullInt(n int) *int {
+	if n == -1 {
+		return nil
+	}
+	return &n
+}
+
+func nullString(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}

--- a/cmd/src/api.go
+++ b/cmd/src/api.go
@@ -183,6 +183,17 @@ func (a *apiRequest) do() error {
 	}
 	defer resp.Body.Close()
 
+	// Our request may have failed before the reaching GraphQL endpoint, so
+	// confirm the status code. You can test this easily with e.g. an invalid
+	// endpoint like -endpoint=https://google.com
+	if resp.StatusCode != http.StatusOK {
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return err
+		}
+		return fmt.Errorf("error: %s\n\n%s", resp.Status, body)
+	}
+
 	// Decode the response.
 	if err := json.NewDecoder(resp.Body).Decode(&a.result); err != nil {
 		return err

--- a/cmd/src/api.go
+++ b/cmd/src/api.go
@@ -148,7 +148,7 @@ type apiRequest struct {
 	query  string                 // the GraphQL query
 	vars   map[string]interface{} // the GraphQL query variables
 	result interface{}            // where to store the result
-	done   func() error           // a function to invoke for handling the response
+	done   func() error           // a function to invoke for handling the response. If nil, flags like -get-curl are ignored.
 	flags  *apiFlags              // the API flags previously created via newAPIFlags
 
 	// If true, errors will not be unpacked.
@@ -172,14 +172,18 @@ type apiRequest struct {
 // the request is finished a.done is invoked to handle the response (which is
 // stored in a.result).
 func (a *apiRequest) do() error {
-	// Handle the get-curl flag now.
-	if *a.flags.getCurl {
-		curl, err := curlCmd(cfg.Endpoint, cfg.AccessToken, a.query, a.vars)
-		if err != nil {
-			return err
+	if a.done != nil {
+		// Handle the get-curl flag now.
+		if *a.flags.getCurl {
+			curl, err := curlCmd(cfg.Endpoint, cfg.AccessToken, a.query, a.vars)
+			if err != nil {
+				return err
+			}
+			fmt.Println(curl)
+			return nil
 		}
-		fmt.Println(curl)
-		return nil
+	} else {
+		a.done = func() error { return nil }
 	}
 
 	// Create the JSON object.

--- a/cmd/src/cmd.go
+++ b/cmd/src/cmd.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+)
+
+// command is a subcommand handler and its flag set.
+type command struct {
+	// flagSet is the flag set for the command.
+	flagSet *flag.FlagSet
+
+	// aliases for the command.
+	aliases []string
+
+	// handler is the function that is invoked to handle this command.
+	handler func(args []string) error
+
+	// flagSet.Usage function to invoke on e.g. -h flag. If nil, a default one
+	// one is used.
+	usageFunc func()
+}
+
+// matches tells if the given name matches this command or one of its aliases.
+func (c *command) matches(name string) bool {
+	if name == c.flagSet.Name() {
+		return true
+	}
+	for _, alias := range c.aliases {
+		if name == alias {
+			return true
+		}
+	}
+	return false
+}
+
+// commander represents a top-level command with subcommands.
+type commander []*command
+
+// run runs the command.
+func (c commander) run(flagSet *flag.FlagSet, cmdName, usageText string, args []string) {
+	// Parse flags.
+	flagSet.Usage = func() {
+		fmt.Fprintf(flag.CommandLine.Output(), usageText)
+	}
+	if !flagSet.Parsed() {
+		flagSet.Parse(args)
+	}
+
+	// Print usage if the command is "help".
+	if flagSet.Arg(0) == "help" || flagSet.NArg() == 0 {
+		flagSet.Usage()
+		os.Exit(0)
+	}
+
+	// Configure default usage funcs for commands.
+	for _, cmd := range c {
+		if cmd.usageFunc != nil {
+			cmd.flagSet.Usage = cmd.usageFunc
+			continue
+		}
+		cmd.flagSet.Usage = func() {
+			fmt.Fprintf(flag.CommandLine.Output(), "Usage of '%s %s':\n", cmdName, cmd.flagSet.Name())
+			cmd.flagSet.PrintDefaults()
+		}
+	}
+
+	// Find the subcommand to execute.
+	name := flagSet.Arg(0)
+	for _, cmd := range c {
+		if !cmd.matches(name) {
+			continue
+		}
+
+		// Read global configuration now.
+		var err error
+		cfg, err = readConfig()
+		if err != nil {
+			log.Fatal("reading config: ", err)
+		}
+
+		// Parse subcommand flags.
+		args := flagSet.Args()[1:]
+		if err := cmd.flagSet.Parse(args); err != nil {
+			panic(fmt.Sprintf("all registered commands should use flag.ExitOnError: error: %s", err))
+		}
+
+		// Execute the subcommand.
+		if err := cmd.handler(flagSet.Args()[1:]); err != nil {
+			if _, ok := err.(*usageError); ok {
+				log.Println(err)
+				cmd.flagSet.Usage()
+				os.Exit(2)
+			}
+			log.Fatal(err)
+		}
+		os.Exit(0)
+	}
+	log.Printf("%s: unknown subcommand %q", cmdName, name)
+	log.Fatalf("Run '%s help' for usage.", cmdName)
+}
+
+// usageError is an error type that subcommands can return in order to signal
+// that a usage error has occurred.
+type usageError struct {
+	error
+}

--- a/cmd/src/cmd.go
+++ b/cmd/src/cmd.go
@@ -57,6 +57,7 @@ func (c commander) run(flagSet *flag.FlagSet, cmdName, usageText string, args []
 
 	// Configure default usage funcs for commands.
 	for _, cmd := range c {
+		cmd := cmd
 		if cmd.usageFunc != nil {
 			cmd.flagSet.Usage = cmd.usageFunc
 			continue

--- a/cmd/src/cmd.go
+++ b/cmd/src/cmd.go
@@ -94,6 +94,12 @@ func (c commander) run(flagSet *flag.FlagSet, cmdName, usageText string, args []
 				cmd.flagSet.Usage()
 				os.Exit(2)
 			}
+			if e, ok := err.(*exitCodeError); ok {
+				if e.error != nil {
+					log.Println(e.error)
+				}
+				os.Exit(e.exitCode)
+			}
 			log.Fatal(err)
 		}
 		os.Exit(0)
@@ -107,3 +113,14 @@ func (c commander) run(flagSet *flag.FlagSet, cmdName, usageText string, args []
 type usageError struct {
 	error
 }
+
+// exitCodeError is an error type that subcommands can return in order to
+// specify the exact exit code.
+type exitCodeError struct {
+	error
+	exitCode int
+}
+
+const (
+	graphqlErrorsExitCode = 2
+)

--- a/cmd/src/main.go
+++ b/cmd/src/main.go
@@ -25,7 +25,8 @@ The options are:
 
 The commands are:
 
-	api    interact with the Sourcegraph GraphQL API
+	api           interact with the Sourcegraph GraphQL API
+	repos,repo    manage repositories 
 
 Use "src [command] -h" for more information about a command.
 
@@ -36,108 +37,15 @@ var (
 	endpoint   = flag.String("endpoint", "", "")
 )
 
-// command is a subcommand handler and its flag set.
-type command struct {
-	// flagSet is the flag set for the command.
-	flagSet *flag.FlagSet
-
-	// aliases for the command.
-	aliases []string
-
-	// handler is the function that is invoked to handle this command.
-	handler func(args []string) error
-
-	// flagSet.Usage function to invoke on e.g. -h flag. If nil, a default one
-	// one is used.
-	usageFunc func()
-}
-
-// matches tells if the given name matches this command or one of its aliases.
-func (c *command) matches(name string) bool {
-	if name == c.flagSet.Name() {
-		return true
-	}
-	for _, alias := range c.aliases {
-		if name == alias {
-			return true
-		}
-	}
-	return false
-}
-
 // commands contains all registered subcommands.
-var commands []*command
+var commands commander
 
 func main() {
 	// Configure logging.
 	log.SetFlags(0)
 	log.SetPrefix("")
 
-	// Configure usage.
-	flag.Usage = func() {
-		fmt.Fprintf(flag.CommandLine.Output(), usageText)
-	}
-
-	// Parse flags.
-	flag.Parse()
-
-	// Print usage if the command is "help".
-	if flag.Arg(0) == "help" || flag.NArg() == 0 {
-		flag.Usage()
-		os.Exit(0)
-	}
-
-	// Configure default usage funcs for commands.
-	for _, cmd := range commands {
-		if cmd.usageFunc != nil {
-			cmd.flagSet.Usage = cmd.usageFunc
-			continue
-		}
-		cmd.flagSet.Usage = func() {
-			fmt.Fprintf(flag.CommandLine.Output(), "Usage of 'src %s':\n", cmd.flagSet.Name())
-			cmd.flagSet.PrintDefaults()
-		}
-	}
-
-	// Find the subcommand to execute.
-	name := flag.Arg(0)
-	for _, cmd := range commands {
-		if !cmd.matches(name) {
-			continue
-		}
-
-		// Read global configuration now.
-		var err error
-		cfg, err = readConfig()
-		if err != nil {
-			log.Fatal("reading config: ", err)
-		}
-
-		// Parse subcommand flags.
-		args := flag.Args()[1:]
-		if err := cmd.flagSet.Parse(args); err != nil {
-			panic(fmt.Sprintf("all registered commands should use flag.ExitOnError: error: %s", err))
-		}
-
-		// Execute the subcommand.
-		if err := cmd.handler(flag.Args()[1:]); err != nil {
-			if _, ok := err.(*usageError); ok {
-				log.Println(err)
-				cmd.flagSet.Usage()
-				os.Exit(2)
-			}
-			log.Fatal(err)
-		}
-		os.Exit(0)
-	}
-	log.Printf("src: unknown subcommand %q", name)
-	log.Fatal("Run 'src help' for usage.")
-}
-
-// usageError is an error type that subcommands can return in order to signal
-// that a usage error has occurred.
-type usageError struct {
-	error
+	commands.run(flag.CommandLine, "src", usageText, os.Args[1:])
 }
 
 var cfg *config

--- a/cmd/src/main.go
+++ b/cmd/src/main.go
@@ -41,12 +41,28 @@ type command struct {
 	// flagSet is the flag set for the command.
 	flagSet *flag.FlagSet
 
+	// aliases for the command.
+	aliases []string
+
 	// handler is the function that is invoked to handle this command.
 	handler func(args []string) error
 
 	// flagSet.Usage function to invoke on e.g. -h flag. If nil, a default one
 	// one is used.
 	usageFunc func()
+}
+
+// matches tells if the given name matches this command or one of its aliases.
+func (c *command) matches(name string) bool {
+	if name == c.flagSet.Name() {
+		return true
+	}
+	for _, alias := range c.aliases {
+		if name == alias {
+			return true
+		}
+	}
+	return false
 }
 
 // commands contains all registered subcommands.
@@ -86,7 +102,7 @@ func main() {
 	// Find the subcommand to execute.
 	name := flag.Arg(0)
 	for _, cmd := range commands {
-		if name != cmd.flagSet.Name() {
+		if !cmd.matches(name) {
 			continue
 		}
 

--- a/cmd/src/repos.go
+++ b/cmd/src/repos.go
@@ -17,6 +17,8 @@ Usage:
 The commands are:
 
 	list       lists repositories
+	enable     enables repositories
+	disable    disables repositories
 
 Use "src repos [command] -h" for more information about a command.
 `

--- a/cmd/src/repos.go
+++ b/cmd/src/repos.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+)
+
+var reposCommands commander
+
+func init() {
+	usage := `'src repos' is a tool that manages repositories on a Sourcegraph instance.
+
+Usage:
+
+	src repos command [command options]
+
+The commands are:
+
+	list       lists repositories
+
+Use "src repos [command] -h" for more information about a command.
+`
+
+	flagSet := flag.NewFlagSet("repos", flag.ExitOnError)
+	handler := func(args []string) error {
+		reposCommands.run(flagSet, "src repos", usage, args)
+		return nil
+	}
+
+	// Register the command.
+	commands = append(commands, &command{
+		flagSet: flagSet,
+		aliases: []string{"repo"},
+		handler: handler,
+		usageFunc: func() {
+			fmt.Println(usage)
+		},
+	})
+}

--- a/cmd/src/repos_enable_disable.go
+++ b/cmd/src/repos_enable_disable.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"log"
+)
+
+func init() {
+	initEnableDisable("disable", false, `
+Examples:
+
+Disable one or more repositories:
+
+	$ src repos disable github.com/my/repo github.com/my/repo2
+
+`)
+
+	initEnableDisable("enable", true, `
+Examples:
+
+Enable one or more repositories:
+
+	$ src repos enable github.com/my/repo github.com/my/repo2
+
+`)
+}
+
+func initEnableDisable(cmdName string, enabled bool, usage string) {
+	flagSet := flag.NewFlagSet(cmdName, flag.ExitOnError)
+	usageFunc := func() {
+		fmt.Fprintf(flag.CommandLine.Output(), "Usage of 'src repos %s':\n", flagSet.Name())
+		flagSet.PrintDefaults()
+		fmt.Println(usage)
+	}
+	apiFlags := newAPIFlags(flagSet)
+
+	setRepositoryEnabled := func(repoName string, enabled bool) error {
+		repoID, err := fetchRepositoryID(repoName)
+		if err != nil {
+			return err
+		}
+
+		query := `mutation SetRepositoryEnabled($repoID: ID!, $enabled: Boolean!){
+  setRepositoryEnabled(repository: $repoID, enabled: $enabled) {
+    alwaysNil
+  }
+}`
+
+		var result struct{}
+		return (&apiRequest{
+			query: query,
+			vars: map[string]interface{}{
+				"repoID":  repoID,
+				"enabled": enabled,
+			},
+			result: &result,
+			done: func() error {
+				fmt.Printf("repository %sd: %s\n", cmdName, repoName)
+				return nil
+			},
+			flags: apiFlags,
+		}).do()
+	}
+
+	handler := func(args []string) error {
+		flagSet.Parse(args)
+
+		errs := false
+		for _, repoName := range flagSet.Args() {
+			if err := setRepositoryEnabled(repoName, enabled); err != nil {
+				errs = true
+				log.Println(err)
+			}
+		}
+		if errs {
+			return errors.New("(errors occurred)")
+		}
+		return nil
+	}
+
+	// Register the command.
+	reposCommands = append(reposCommands, &command{
+		flagSet:   flagSet,
+		handler:   handler,
+		usageFunc: usageFunc,
+	})
+}
+
+func fetchRepositoryID(repoName string) (string, error) {
+	query := `query RepositoryID($repoName: String!) {
+  repository(name: $repoName) {
+    id
+  }
+}`
+
+	var result struct {
+		Repository struct {
+			ID string
+		}
+	}
+	err := (&apiRequest{
+		query: query,
+		vars: map[string]interface{}{
+			"repoName": repoName,
+		},
+		result: &result,
+	}).do()
+	if err != nil {
+		return "", err
+	}
+	if result.Repository.ID == "" {
+		return "", fmt.Errorf("repository not found: %s", repoName)
+	}
+	return result.Repository.ID, nil
+}

--- a/cmd/src/repos_list.go
+++ b/cmd/src/repos_list.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+)
+
+func init() {
+	usage := `
+Examples:
+
+  List repositories:
+
+    	$ src repos list
+
+  List *all* repositories (may be slow!):
+
+    	$ src repos list -first='-1'
+
+  List repositories whose names match a query:
+
+    	$ src repos list -query='myquery'
+
+  Include repositories that are disabled:
+
+    	$ src repos list -query='myquery' -disabled
+
+`
+
+	flagSet := flag.NewFlagSet("list", flag.ExitOnError)
+	usageFunc := func() {
+		fmt.Fprintf(flag.CommandLine.Output(), "Usage of 'src repos %s':\n", flagSet.Name())
+		flagSet.PrintDefaults()
+		fmt.Println(usage)
+	}
+	var (
+		firstFlag           = flagSet.Int("first", 1000, "Returns the first n repositories from the list. (use -1 for unlimited)")
+		queryFlag           = flagSet.String("query", "", `Returns repositories whose names match the query. (e.g. "myorg/"`)
+		enabledFlag         = flagSet.Bool("enabled", true, "Include enabled repositories.")
+		disabledFlag        = flagSet.Bool("disabled", false, "Include disabled repositories.")
+		clonedFlag          = flagSet.Bool("cloned", true, "Include cloned repositories.")
+		cloneInProgressFlag = flagSet.Bool("clone-in-progress", true, "Include repositories that are currently being cloned.")
+		notClonedFlag       = flagSet.Bool("not-cloned", true, "Include repositories that are not yet cloned and for which cloning is not in progress.")
+		indexedFlag         = flagSet.Bool("indexed", true, "Include repositories that have a text search index.")
+		notIndexedFlag      = flagSet.Bool("not-indexed", true, "Include repositories that do not have a text search index.")
+		ciIndexedFlag       = flagSet.Bool("ci-indexed", false, "Filter for repositories that have been indexed for cross-repository code intelligence.")
+		notCIIndexedFlag    = flagSet.Bool("not-ci-indexed", false, "Filter for repositories that have NOT been indexed for cross-repository code intelligence.")
+		orderByFlag         = flagSet.String("order-by", "name", `How to order the results; possible choices are: "name", "created-at"`)
+		descendingFlag      = flagSet.Bool("descending", false, "Whether or not results should be in descending order.")
+		apiFlags            = newAPIFlags(flagSet)
+	)
+
+	handler := func(args []string) error {
+		flagSet.Parse(args)
+
+		query := `query Repositories(
+  $first: Int,
+  $query: String,
+  $enabled: Boolean,
+  $disabled: Boolean,
+  $cloned: Boolean,
+  $cloneInProgress: Boolean,
+  $notCloned: Boolean,
+  $indexed: Boolean,
+  $notIndexed: Boolean,
+  $ciIndexed: Boolean,
+  $notCIIndexed: Boolean,
+  $orderBy: RepoOrderBy,
+  $descending: Boolean,
+) {
+  repositories(
+    first: $first,
+    query: $query,
+    enabled: $enabled,
+    disabled: $disabled,
+    cloned: $cloned,
+    cloneInProgress: $cloneInProgress,
+    notCloned: $notCloned,
+    indexed: $indexed,
+    notIndexed: $notIndexed,
+    ciIndexed: $ciIndexed,
+    notCIIndexed: $notCIIndexed,
+    orderBy: $orderBy,
+    descending: $descending,
+  ) {
+    nodes {
+      name
+    }
+  }
+}`
+
+		var orderBy string
+		switch *orderByFlag {
+		case "name":
+			orderBy = "REPO_URI"
+		case "created-at":
+			orderBy = "REPO_CREATED_AT"
+		default:
+			return fmt.Errorf("invalid -order-by flag value: %q", *orderByFlag)
+		}
+
+		var result struct {
+			Repositories struct {
+				Nodes []struct {
+					Name string
+				}
+			}
+		}
+		return (&apiRequest{
+			query: query,
+			vars: map[string]interface{}{
+				"first":           nullInt(*firstFlag),
+				"query":           nullString(*queryFlag),
+				"enabled":         *enabledFlag,
+				"disabled":        *disabledFlag,
+				"cloned":          *clonedFlag,
+				"cloneInProgress": *cloneInProgressFlag,
+				"notCloned":       *notClonedFlag,
+				"indexed":         *indexedFlag,
+				"notIndexed":      *notIndexedFlag,
+				"ciIndexed":       *ciIndexedFlag,
+				"notCIIndexed":    *notCIIndexedFlag,
+				"orderBy":         orderBy,
+				"descending":      *descendingFlag,
+			},
+			result: &result,
+			done: func() error {
+				for _, repo := range result.Repositories.Nodes {
+					fmt.Println(repo.Name)
+				}
+				return nil
+			},
+			flags: apiFlags,
+		}).do()
+	}
+
+	// Register the command.
+	reposCommands = append(reposCommands, &command{
+		flagSet:   flagSet,
+		handler:   handler,
+		usageFunc: usageFunc,
+	})
+}

--- a/cmd/src/repos_list.go
+++ b/cmd/src/repos_list.go
@@ -25,6 +25,10 @@ Examples:
 
     	$ src repos list -query='myquery' -disabled
 
+  List only repositories that are disabled:
+
+    	$ src repos list -disabled -enabled=false -query='github.com/slimsag/'
+
 `
 
 	flagSet := flag.NewFlagSet("list", flag.ExitOnError)


### PR DESCRIPTION
This PR adds a new top-level command `src repos` (alias: `src repo`) with three new subcommands: `src repos list`, `src repos enable` and `src repos disable`.

# Examples

For command-specific examples see the help flag (`src repos list -h`). In this section I'll write examples of how you can combine these for useful effects.

### List all repositories that are disabled on Sourcegraph

The following will list *all* repositories on Sourcegraph that are disabled, while excluding enabled ones:

```bash
src repos list -first=-1 -disabled -enabled=false
```

(add ` -query='github.com/slimsag/'` to match a query string if you only want a subset, or pipe to grep)

### Enable all disable repositories on Sourcegraph matching a query string

The following will enable any disabled repository on Sourcegraph whose name matches the query string `github.com/slimsag/`

```bash
src repos list -first=-1 -disabled -enabled=false -query='github.com/slimsag/' | xargs src repos enable
```

# Other notes/changes

- `src repos list` takes a variety of arguments, see `src repos list -h` for info.
    - By default, I've set the `-first` limit flag to 1000 to avoid doing too much intensive work by default. Many users may want to specify `-1` for this if they truly want all repositories.
- `src repos enable` and `src repos disable` take a list of repositories to enable/disable, e.g. `src repos enable github.com/my/repo1 github.com/my/repo2`. See `src repos enable -h` for more information.

- A number of refactors have been. Best review this PR as individual commits.
- Added support for nested subcommands (like `src repos list`, whereas before we only had one level deep `src api`) and command aliases (`src repo` is an alias for `src repos`)
- Added support for other non-`src api` commands to invoke the GraphQL API (needed for basically everything we'll want to add in the future).
- Added proper error checking for invalid HTTP responses with non-200 status codes.
- `src api` and other commands now emit a separate exit code `2` any time the actual request went through but GraphQL responded with `{data: ?, errors: ["some errors"]}`. This will let people easily detect GraphQL errors from e.g. bash scripts.
