### PR TITLE
add extensions subcommands

### DIFF
--- a/cmd/src/cmd.go
+++ b/cmd/src/cmd.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"log"
 	"os"
+	"strings"
 )
 
 // command is a subcommand handler and its flag set.
@@ -125,3 +127,16 @@ type exitCodeError struct {
 const (
 	graphqlErrorsExitCode = 2
 )
+
+func didYouMeanOtherCommand(actual string, suggested []string) *command {
+	fullSuggestions := make([]string, len(suggested))
+	for i, s := range suggested {
+		fullSuggestions[i] = "src " + s
+	}
+	msg := fmt.Sprintf("src: unknown subcommand %q\n\nDid you mean:\n\n\t%s", actual, strings.Join(fullSuggestions, "\n\t"))
+	return &command{
+		flagSet:   flag.NewFlagSet(actual, flag.ExitOnError),
+		handler:   func(args []string) error { return errors.New(msg) },
+		usageFunc: func() { log.Println(msg) },
+	}
+}

--- a/cmd/src/extensions.go
+++ b/cmd/src/extensions.go
@@ -10,12 +10,15 @@ var extensionsCommands commander
 func init() {
 	usage := `'src extensions' is a tool that manages extensions in the extension registry on a Sourcegraph instance.
 
+EXPERIMENTAL: Extensions are experimental functionality on Sourcegraph and in the 'src' tool.
+
 Usage:
 
 	src extensions command [command options]
 
 The commands are:
 
+	publish    publish the extension in the current directory
 	list       lists extensions
 	get        gets an extension
 

--- a/cmd/src/extensions.go
+++ b/cmd/src/extensions.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+)
+
+var extensionsCommands commander
+
+func init() {
+	usage := `'src extensions' is a tool that manages extensions in the extension registry on a Sourcegraph instance.
+
+Usage:
+
+	src extensions command [command options]
+
+The commands are:
+
+	list       lists extensions
+	get        gets an extension
+
+Use "src extensions [command] -h" for more information about a command.
+
+Alias: "src ext"
+`
+
+	flagSet := flag.NewFlagSet("extensions", flag.ExitOnError)
+	handler := func(args []string) error {
+		extensionsCommands.run(flagSet, "src extensions", usage, args)
+		return nil
+	}
+
+	// Register the command.
+	commands = append(commands, &command{
+		flagSet: flagSet,
+		aliases: []string{"ext", "extension"},
+		handler: handler,
+		usageFunc: func() {
+			fmt.Println(usage)
+		},
+	})
+}
+
+const registryExtensionFragment = `
+fragment RegistryExtensionFields on RegistryExtension {
+    id
+    uuid
+    extensionID
+    name
+    createdAt
+    updatedAt
+    url
+    remoteURL
+    registryName
+    isLocal
+    manifest {
+        raw
+        title
+        description
+    }
+}
+`
+
+type Extension struct {
+	ID           string
+	UUID         string
+	ExtensionID  string
+	Name         string
+	CreatedAt    string
+	UpdatedAt    string
+	URL          string
+	RemoteURL    string
+	RegistryName string
+	IsLocal      bool
+	Manifest     struct {
+		Raw         string
+		Title       string
+		Description string
+	}
+}

--- a/cmd/src/extensions.go
+++ b/cmd/src/extensions.go
@@ -60,6 +60,7 @@ fragment RegistryExtensionFields on RegistryExtension {
         raw
         title
         description
+        bundleURL
     }
 }
 `
@@ -79,5 +80,6 @@ type Extension struct {
 		Raw         string
 		Title       string
 		Description string
+		BundleURL   string
 	}
 }

--- a/cmd/src/extensions_get.go
+++ b/cmd/src/extensions_get.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+)
+
+func init() {
+	usage := `
+Examples:
+
+  Get extension with extension ID "alice/myextension":
+
+    	$ src extensions get alice/myextension
+    	$ src extensions get -extension-id=alice/myextension
+
+`
+
+	flagSet := flag.NewFlagSet("get", flag.ExitOnError)
+	usageFunc := func() {
+		fmt.Fprintf(flag.CommandLine.Output(), "Usage of 'src extensions %s':\n", flagSet.Name())
+		flagSet.PrintDefaults()
+		fmt.Println(usage)
+	}
+	var (
+		extensionIDFlag = flagSet.String("extension-id", "", `Look up extension by extension ID. (e.g. "alice/myextension")`)
+		formatFlag      = flagSet.String("f", "{{.|json}}", `Format for the output, using the syntax of Go package text/template. (e.g. "{{.ExtensionID}}: {{.Manifest.Title}} ({{.RemoteURL}})" or "{{.|json}}")`)
+		apiFlags        = newAPIFlags(flagSet)
+	)
+
+	handler := func(args []string) error {
+		flagSet.Parse(args)
+
+		tmpl, err := parseTemplate(*formatFlag)
+		if err != nil {
+			return err
+		}
+
+		query := `query RegistryExtension(
+  $extensionID: String!,
+) {
+  extensionRegistry {
+    extension(
+      extensionID: $extensionID
+    ) {
+      ...RegistryExtensionFields
+    }
+  }
+}` + registryExtensionFragment
+
+		extensionID := *extensionIDFlag
+		if extensionID == "" && len(args) == 1 {
+			extensionID = args[0]
+		}
+
+		var result struct {
+			ExtensionRegistry struct {
+				Extension *Extension
+			}
+		}
+		return (&apiRequest{
+			query: query,
+			vars: map[string]interface{}{
+				"extensionID": extensionID,
+			},
+			result: &result,
+			done: func() error {
+				return execTemplate(tmpl, result.ExtensionRegistry.Extension)
+			},
+			flags: apiFlags,
+		}).do()
+	}
+
+	// Register the command.
+	extensionsCommands = append(extensionsCommands, &command{
+		flagSet:   flagSet,
+		handler:   handler,
+		usageFunc: usageFunc,
+	})
+}

--- a/cmd/src/extensions_list.go
+++ b/cmd/src/extensions_list.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+)
+
+func init() {
+	usage := `
+Examples:
+
+  List extensions:
+
+    	$ src extensions list
+
+  List extensions whose names match the query:
+
+    	$ src extensions list -query='myquery'
+
+  List *all* extensions (may be slow!):
+
+    	$ src extensions list -first='-1'
+
+`
+
+	flagSet := flag.NewFlagSet("list", flag.ExitOnError)
+	usageFunc := func() {
+		fmt.Fprintf(flag.CommandLine.Output(), "Usage of 'src extensions %s':\n", flagSet.Name())
+		flagSet.PrintDefaults()
+		fmt.Println(usage)
+	}
+	var (
+		firstFlag  = flagSet.Int("first", 1000, "Returns the first n extensions from the list. (use -1 for unlimited)")
+		queryFlag  = flagSet.String("query", "", `Returns extensions whose extension IDs match the query. (e.g. "myextension")`)
+		formatFlag = flagSet.String("f", "{{.ExtensionID}}", `Format for the output, using the syntax of Go package text/template. (e.g. "{{.ExtensionID}}: {{.Manifest.Title}} ({{.RemoteURL}})" or "{{.|json}}")`)
+		apiFlags   = newAPIFlags(flagSet)
+	)
+
+	handler := func(args []string) error {
+		flagSet.Parse(args)
+
+		tmpl, err := parseTemplate(*formatFlag)
+		if err != nil {
+			return err
+		}
+
+		query := `query RegistryExtensions(
+  $first: Int,
+  $query: String,
+) {
+  extensionRegistry {
+    extensions(
+      first: $first,
+      query: $query,
+    ) {
+      nodes {
+        ...RegistryExtensionFields
+      }
+    }
+  }
+}` + registryExtensionFragment
+
+		var result struct {
+			ExtensionRegistry struct {
+				Extensions struct {
+					Nodes []Extension
+				}
+			}
+		}
+		return (&apiRequest{
+			query: query,
+			vars: map[string]interface{}{
+				"first": nullInt(*firstFlag),
+				"query": nullString(*queryFlag),
+			},
+			result: &result,
+			done: func() error {
+				for _, extension := range result.ExtensionRegistry.Extensions.Nodes {
+					if err := execTemplate(tmpl, extension); err != nil {
+						return err
+					}
+				}
+				return nil
+			},
+			flags: apiFlags,
+		}).do()
+	}
+
+	// Register the command.
+	extensionsCommands = append(extensionsCommands, &command{
+		flagSet:   flagSet,
+		handler:   handler,
+		usageFunc: usageFunc,
+	})
+}

--- a/cmd/src/extensions_publish.go
+++ b/cmd/src/extensions_publish.go
@@ -1,0 +1,156 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io/ioutil"
+)
+
+func init() {
+	usage := `
+Publish an extension to Sourcegraph, creating it (if necessary).
+
+Examples:
+
+  Publish the "alice/myextension" extension described by package.json in the current directory:
+
+    	$ cat package.json
+        {
+          "name":      "myextension",
+          "publisher": "alice",
+          "title":     "My Extension",
+          "url":       "https://example.com/bundled-extension.js"
+        }
+    	$ src extensions publish
+
+`
+
+	flagSet := flag.NewFlagSet("publish", flag.ExitOnError)
+	usageFunc := func() {
+		fmt.Fprintf(flag.CommandLine.Output(), "Usage of 'src extensions %s':\n", flagSet.Name())
+		flagSet.PrintDefaults()
+		fmt.Println(usage)
+	}
+	var (
+		extensionIDFlag = flagSet.String("extension-id", "", `Override the extension ID in the manifest. (default: read from -manifest file)`)
+		manifestFlag    = flagSet.String("manifest", "package.json", `The extension manifest file.`)
+		forceFlag       = flagSet.Bool("force", false, `Force publish the extension, even if there are validation problems or other warnings.`)
+		apiFlags        = newAPIFlags(flagSet)
+	)
+
+	handler := func(args []string) error {
+		flagSet.Parse(args)
+
+		manifest, err := ioutil.ReadFile(*manifestFlag)
+		if err != nil {
+			return fmt.Errorf("%s\n\nRun this command in a directory with a %s file for an extension.\n\nSee 'src extensions %s -h' for help.", err, *manifestFlag, flagSet.Name())
+		}
+		extensionID := *extensionIDFlag
+		if extensionID == "" {
+			extensionID, err = readExtensionIDFromManifest(manifest)
+			if err != nil {
+				return err
+			}
+		}
+		manifest, err = updateExtensionIDInManifest(manifest, extensionID)
+		if err != nil {
+			return err
+		}
+
+		query := `mutation PublishExtension(
+  $extensionID: String!,
+  $manifest: String!,
+  $force: Boolean!,
+) {
+  extensionRegistry {
+    publishExtension(
+      extensionID: $extensionID,
+      manifest: $manifest,
+      force: $force,
+    ) {
+      extension {
+        extensionID
+        url
+      }
+    }
+  }
+}`
+
+		var result struct {
+			ExtensionRegistry struct {
+				PublishExtension struct {
+					Extension struct {
+						ExtensionID string
+						URL         string
+					}
+				}
+			}
+		}
+		return (&apiRequest{
+			query: query,
+			vars: map[string]interface{}{
+				"extensionID": extensionID,
+				"manifest":    string(manifest),
+				"force":       *forceFlag,
+			},
+			result: &result,
+			done: func() error {
+				fmt.Println("Extension published!")
+				fmt.Println()
+				fmt.Printf("\tExtension ID: %s\n\n", result.ExtensionRegistry.PublishExtension.Extension.ExtensionID)
+				fmt.Printf("View, enable, and configure it at: %s\n", cfg.Endpoint+result.ExtensionRegistry.PublishExtension.Extension.URL)
+				return nil
+			},
+			flags: apiFlags,
+		}).do()
+	}
+
+	// Register the command.
+	extensionsCommands = append(extensionsCommands, &command{
+		flagSet:   flagSet,
+		handler:   handler,
+		usageFunc: usageFunc,
+	})
+
+	// Catch the mistake of omitting the "extensions" subcommand.
+	commands = append(commands, didYouMeanOtherCommand("publish", []string{"extensions publish", "ext publish        (alias)"}))
+}
+
+func readExtensionIDFromManifest(manifest []byte) (string, error) {
+	var o map[string]interface{}
+	if err := json.Unmarshal(manifest, &o); err != nil {
+		return "", err
+	}
+
+	extensionID, _ := o["extensionID"].(string)
+	if extensionID != "" {
+		return extensionID, nil
+	}
+
+	name, _ := o["name"].(string)
+	publisher, _ := o["publisher"].(string)
+	if name == "" && publisher == "" {
+		return "", errors.New(`extension manifest must contain "name" and "publisher" string properties (the extension ID is of the form "publisher/name" and uses these values)`)
+	}
+	if name == "" {
+		return "", fmt.Errorf(`extension manifest must contain a "name" string property for the extension name (the extension ID will be %q)`, publisher+"/name")
+	}
+	if publisher == "" {
+		return "", fmt.Errorf(`extension manifest must contain a "publisher" string property referring to a username or organization name on Sourcegraph (the extension ID will be %q)`, "publisher/"+name)
+	}
+	return publisher + "/" + name, nil
+}
+
+func updateExtensionIDInManifest(manifest []byte, extensionID string) (updatedManifest []byte, err error) {
+	var o map[string]interface{}
+	if err := json.Unmarshal(manifest, &o); err != nil {
+		return nil, err
+	}
+	if o == nil {
+		o = map[string]interface{}{}
+	}
+	o["extensionID"] = extensionID
+	return json.MarshalIndent(o, "", "  ")
+}

--- a/cmd/src/extensions_publish_test.go
+++ b/cmd/src/extensions_publish_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestReadExtensionIDFromManifest(t *testing.T) {
+	tests := map[string]string{
+		`{"name": "a", "publisher": "b"}`:                     "b/a",
+		`{"name": "a", "publisher": "b", "extensionID": "c"}`: "c",
+		`{"extensionID": "c"}`:                                "c",
+	}
+	for manifest, want := range tests {
+		t.Run(manifest, func(t *testing.T) {
+			got, err := readExtensionIDFromManifest([]byte(manifest))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != want {
+				t.Errorf("got %q, want %q", got, want)
+			}
+		})
+	}
+
+	t.Run("no name", func(t *testing.T) {
+		if _, err := readExtensionIDFromManifest([]byte(`{}`)); err == nil {
+			t.Fatal()
+		}
+	})
+
+	t.Run("no publisher", func(t *testing.T) {
+		if _, err := readExtensionIDFromManifest([]byte(`{"name":"a"}`)); err == nil {
+			t.Fatal()
+		}
+	})
+}
+
+func TestUpdateExtensionIDInManifest(t *testing.T) {
+	tests := map[string]string{
+		`{}`:                  `{"extensionID": "x"}`,
+		`{"a":1}`:             `{"a":1, "extensionID": "x"}`,
+		`{"extensionID":"a"}`: `{"extensionID": "x"}`,
+	}
+	for manifest, want := range tests {
+		t.Run(manifest, func(t *testing.T) {
+			got, err := updateExtensionIDInManifest([]byte(manifest), "x")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !jsonDeepEqual(string(got), want) {
+				t.Errorf("got %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+func jsonDeepEqual(a, b string) bool {
+	var va, vb interface{}
+	if err := json.Unmarshal([]byte(a), &va); err != nil {
+		panic(err)
+	}
+	if err := json.Unmarshal([]byte(b), &vb); err != nil {
+		panic(err)
+	}
+	return reflect.DeepEqual(va, vb)
+}

--- a/cmd/src/extensions_publish_test.go
+++ b/cmd/src/extensions_publish_test.go
@@ -37,15 +37,15 @@ func TestReadExtensionIDFromManifest(t *testing.T) {
 	})
 }
 
-func TestUpdateExtensionIDInManifest(t *testing.T) {
+func TestUpdatePropertyInManifest(t *testing.T) {
 	tests := map[string]string{
-		`{}`:                  `{"extensionID": "x"}`,
-		`{"a":1}`:             `{"a":1, "extensionID": "x"}`,
-		`{"extensionID":"a"}`: `{"extensionID": "x"}`,
+		`{}`:        `{"p": "x"}`,
+		`{"a":1}`:   `{"a":1, "p": "x"}`,
+		`{"p":"a"}`: `{"p": "x"}`,
 	}
 	for manifest, want := range tests {
 		t.Run(manifest, func(t *testing.T) {
-			got, err := updateExtensionIDInManifest([]byte(manifest), "x")
+			got, err := updatePropertyInManifest([]byte(manifest), "p", "x")
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/cmd/src/main.go
+++ b/cmd/src/main.go
@@ -25,11 +25,12 @@ The options are:
 
 The commands are:
 
-	search        search for results on Sourcegraph
-	api           interacts with the Sourcegraph GraphQL API
-	repos,repo    manages repositories
-	users,user    manages users
-	orgs,org      manages organizations
+	search          search for results on Sourcegraph
+	api             interacts with the Sourcegraph GraphQL API
+	repos,repo      manages repositories
+	users,user      manages users
+	orgs,org        manages organizations
+	extensions,ext  manages extensions (experimental)
 
 Use "src [command] -h" for more information about a command.
 


### PR DESCRIPTION
Adds the following subcommands for managing extensions:

- src extensions list
- src extensions get
- src extensions publish

These are marked as experimental. The API that they use is not yet deployed to Sourcegraph.com.