### PR TITLE
feat: add config subcommand to get/list/edit config

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,5 +9,6 @@ install:
   - echo %GOPATH%
   - go version
   - go env
+  - go get -t -v ./...
 build_script:
   - go test -v ./...

--- a/cmd/src/config.go
+++ b/cmd/src/config.go
@@ -1,0 +1,186 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+)
+
+var configCommands commander
+
+func init() {
+	usage := `'src config' is a tool that manages global, organization, and user settings on a Sourcegraph instance.
+
+The effective configuration is computed by shallow-merging the following settings, in order from lowest to highest precedence:
+
+- Global settings (site-wide)
+- Organization settings for the user's organizations (if any)
+- User settings
+- Client settings (when using a Sourcegraph browser or editor extension)
+
+For unauthenticated requests, the organization and user settings are empty.
+
+Usage:
+
+	src config command [command options]
+
+The commands are:
+
+	get       gets the effective (merged) configuration
+	edit      updates configuration settings
+	list      lists the partial settings (that, when merged, yield the effective configuration)
+
+Use "src config [command] -h" for more information about a command.
+`
+
+	flagSet := flag.NewFlagSet("config", flag.ExitOnError)
+	handler := func(args []string) error {
+		configCommands.run(flagSet, "src config", usage, args)
+		return nil
+	}
+
+	// Register the command.
+	commands = append(commands, &command{
+		flagSet: flagSet,
+		handler: handler,
+		usageFunc: func() {
+			fmt.Println(usage)
+		},
+	})
+}
+
+const configurationSubjectFragment = `
+fragment ConfigurationSubjectFields on ConfigurationSubject {
+    id
+    latestSettings {
+        id
+        configuration {
+            ...ConfigurationFields
+        }
+        author {
+            ...UserFields
+        }
+        createdAt
+    }
+    settingsURL
+    viewerCanAdminister
+}
+`
+
+type ConfigurationSubject struct {
+	ID                   string
+	LatestSettings       *Settings
+	SettingsURL          string
+	ViewerCanAdminister  bool
+	ConfigurationCascade ConfigurationCascade
+}
+
+type Settings struct {
+	ID            int32
+	Configuration Configuration
+	Author        *User
+	CreatedAt     string
+}
+
+const configurationCascadeFragment = `
+fragment ConfigurationCascadeFields on ConfigurationCascade {
+    subjects {
+        ...ConfigurationSubjectFields
+    }
+    merged {
+        ...ConfigurationFields
+    }
+}
+`
+
+type ConfigurationCascade struct {
+	Subjects []ConfigurationSubject
+	Merged   Configuration
+}
+
+const configurationFragment = `
+fragment ConfigurationFields on Configuration {
+    contents
+    messages
+}
+`
+
+type Configuration struct {
+	Contents string
+	Messages []string
+}
+
+const viewerConfigurationQuery = `query ViewerConfiguration {
+  viewerConfiguration {
+    ...ConfigurationCascadeFields
+  }
+}` + configurationCascadeFragment + configurationSubjectFragment + configurationFragment + userFragment
+
+const configurationSubjectCascadeQuery = `query ConfigurationSubjectCascade($subject: ID!) {
+  configurationSubject(id: $subject) {
+    configurationCascade {
+      ...ConfigurationCascadeFields
+    }
+  }
+}` + configurationCascadeFragment + configurationSubjectFragment + configurationFragment + userFragment
+
+type KeyPath struct {
+	Property string `json:"property,omitempty"`
+	Index    int    `json:"index,omitempty"`
+}
+
+func getViewerUserID() (string, error) {
+	var result struct {
+		CurrentUser *struct{ ID string }
+	}
+	req := &apiRequest{
+		query: `
+query ViewerUserID {
+  currentUser {
+    id
+  }
+}
+`,
+		result: &result,
+	}
+	if err := req.do(); err != nil {
+		return "", err
+	}
+	if result.CurrentUser == nil || result.CurrentUser.ID == "" {
+		return "", errors.New("unable to determine current user ID (ensure the access token you're using to authenticate the CLI is correct, or provide one if none exists; see 'src -h' for more information)")
+	}
+	return result.CurrentUser.ID, nil
+}
+
+func getConfigurationSubjectLatestSettingsID(subjectID string) (*int, error) {
+	var result struct {
+		ConfigurationSubject *struct {
+			LatestSettings *struct {
+				ID int
+			}
+		}
+	}
+	req := &apiRequest{
+		query: `
+query ConfigurationSubjectLatestSettingsID($subject: ID!) {
+  configurationSubject(id: $subject) {
+    latestSettings {
+      id
+    }
+  }
+}
+`,
+		vars:   map[string]interface{}{"subject": subjectID},
+		result: &result,
+	}
+	if err := req.do(); err != nil {
+		return nil, err
+	}
+	if result.ConfigurationSubject == nil {
+		return nil, fmt.Errorf("unable to find configuration subject with ID %s", subjectID)
+	}
+	if result.ConfigurationSubject.LatestSettings == nil {
+		return nil, nil
+	}
+	return &result.ConfigurationSubject.LatestSettings.ID, nil
+}

--- a/cmd/src/config_edit.go
+++ b/cmd/src/config_edit.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io/ioutil"
+)
+
+func init() {
+	usage := `
+Examples:
+
+  Edit configuration property for the current user (authenticated by the src CLI's access token, if any):
+
+    	$ src config edit -property motd -value '["Hello!"]'
+
+  Overwrite all configuration settings for the current user:
+
+    	$ src config edit -overwrite -value '{"motd":["Hello!"]}'
+
+  Overwrite all configuration settings for the current user with the file contents:
+
+    	$ src config edit -overwrite -value-file myconfig.json
+
+  Edit a configuration property for the user with username alice:
+
+    	$ src config edit -subject=$(src users get -f '{{.ID}}' -username=alice) -property motd -value '["Hello!"]'
+
+  Overwrite all configuration settings for the organization named abc-org:
+
+    	$ src config edit -subject=$(src orgs get -f '{{.ID}}' -name=abc-org) -overwrite -value '{"motd":["Hello!"]}'
+
+`
+
+	flagSet := flag.NewFlagSet("edit", flag.ExitOnError)
+	usageFunc := func() {
+		fmt.Fprintf(flag.CommandLine.Output(), "Usage of 'src config %s':\n", flagSet.Name())
+		flagSet.PrintDefaults()
+		fmt.Println(usage)
+	}
+	var (
+		subjectFlag   = flagSet.String("subject", "", "The ID of the configuration subject whose configuration to edit. (default: authenticated user)")
+		propertyFlag  = flagSet.String("property", "", "The name of the configuration property to set.")
+		valueFlag     = flagSet.String("value", "", "The value for the configuration property (when used with -property).")
+		valueFileFlag = flagSet.String("value-file", "", "Read the value from this file instead of from the -value command-line option.")
+		overwriteFlag = flagSet.Bool("overwrite", false, "Overwrite the entire settings with the value given in -value (not just a single property).")
+		apiFlags      = newAPIFlags(flagSet)
+	)
+
+	handler := func(args []string) error {
+		flagSet.Parse(args)
+
+		keyPath := []KeyPath{}
+		if *propertyFlag != "" {
+			keyPath = []KeyPath{{Property: *propertyFlag}}
+		} else if !*overwriteFlag {
+			return &usageError{errors.New("either -property or -overwrite must be used")}
+		}
+
+		var value string
+		if *valueFlag != "" {
+			value = *valueFlag
+		} else if *valueFileFlag != "" {
+			data, err := ioutil.ReadFile(*valueFileFlag)
+			if err != nil {
+				return err
+			}
+			value = string(data)
+		} else {
+			return &usageError{errors.New("either -value or -value-file must be used")}
+		}
+
+		var subjectID string
+		if *subjectFlag == "" {
+			userID, err := getViewerUserID()
+			if err != nil {
+				return err
+			}
+			subjectID = userID
+		} else {
+			subjectID = *subjectFlag
+		}
+
+		lastID, err := getConfigurationSubjectLatestSettingsID(subjectID)
+		if err != nil {
+			return err
+		}
+
+		query := `
+mutation EditConfiguration($input: ConfigurationMutationGroupInput!, $edit: ConfigurationEdit!) {
+  configurationMutation(input: $input) {
+    editConfiguration(edit: $edit) {
+      empty {
+        alwaysNil
+      }
+    }
+  }
+}`
+		queryVars := map[string]interface{}{
+			"input": map[string]interface{}{
+				"subject": subjectID,
+				"lastID":  lastID,
+			},
+			"edit": map[string]interface{}{
+				"keyPath":                   keyPath,
+				"value":                     value,
+				"valueIsJSONCEncodedString": true,
+			},
+		}
+
+		var result struct {
+			ViewerConfiguration  *ConfigurationCascade
+			ConfigurationSubject *ConfigurationSubject
+		}
+		return (&apiRequest{
+			query:  query,
+			vars:   queryVars,
+			result: &result,
+			flags:  apiFlags,
+		}).do()
+	}
+
+	// Register the command.
+	configCommands = append(configCommands, &command{
+		flagSet:   flagSet,
+		handler:   handler,
+		usageFunc: usageFunc,
+	})
+}

--- a/cmd/src/config_get.go
+++ b/cmd/src/config_get.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+)
+
+func init() {
+	usage := `
+Examples:
+
+  Get configuration for the current user (authenticated by the src CLI's access token, if any):
+
+    	$ src config get
+
+  Get configuration for the user with username alice:
+
+    	$ src config get -subject=$(src users get -f '{{.ID}}' -username=alice)
+
+  Get configuration for the organization named abc-org:
+
+    	$ src config get -subject=$(src orgs get -f '{{.ID}}' -name=abc-org)
+
+`
+
+	flagSet := flag.NewFlagSet("get", flag.ExitOnError)
+	usageFunc := func() {
+		fmt.Fprintf(flag.CommandLine.Output(), "Usage of 'src config %s':\n", flagSet.Name())
+		flagSet.PrintDefaults()
+		fmt.Println(usage)
+	}
+	var (
+		subjectFlag = flagSet.String("subject", "", "The ID of the configuration subject whose configuration to get. (default: authenticated user)")
+		formatFlag  = flagSet.String("f", "{{.Contents|jsonIndent}}", `Format for the output, using the syntax of Go package text/template. (e.g. "{{.|json}}")`)
+		apiFlags    = newAPIFlags(flagSet)
+	)
+
+	handler := func(args []string) error {
+		flagSet.Parse(args)
+
+		tmpl, err := parseTemplate(*formatFlag)
+		if err != nil {
+			return err
+		}
+
+		var query string
+		var queryVars map[string]interface{}
+		if *subjectFlag == "" {
+			query = viewerConfigurationQuery
+		} else {
+			query = configurationSubjectCascadeQuery
+			queryVars = map[string]interface{}{
+				"subject": nullString(*subjectFlag),
+			}
+		}
+
+		var result struct {
+			ViewerConfiguration  *ConfigurationCascade
+			ConfigurationSubject *ConfigurationSubject
+		}
+		return (&apiRequest{
+			query:  query,
+			vars:   queryVars,
+			result: &result,
+			done: func() error {
+				var merged Configuration
+				if result.ViewerConfiguration != nil {
+					merged = result.ViewerConfiguration.Merged
+				} else if result.ConfigurationSubject != nil {
+					merged = result.ConfigurationSubject.ConfigurationCascade.Merged
+				}
+				return execTemplate(tmpl, merged)
+			},
+			flags: apiFlags,
+		}).do()
+	}
+
+	// Register the command.
+	configCommands = append(configCommands, &command{
+		flagSet:   flagSet,
+		handler:   handler,
+		usageFunc: usageFunc,
+	})
+}

--- a/cmd/src/config_list.go
+++ b/cmd/src/config_list.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+)
+
+func init() {
+	usage := `
+Examples:
+
+  List configuration settings for the current user (authenticated by the src CLI's access token, if any):
+
+    	$ src config list
+
+  List configuration settings for the user with username alice:
+
+    	$ src config list -subject=$(src users get -f '{{.ID}}' -username=alice)
+
+`
+
+	flagSet := flag.NewFlagSet("list", flag.ExitOnError)
+	usageFunc := func() {
+		fmt.Fprintf(flag.CommandLine.Output(), "Usage of 'src config %s':\n", flagSet.Name())
+		flagSet.PrintDefaults()
+		fmt.Println(usage)
+	}
+	var (
+		subjectFlag = flagSet.String("subject", "", "The ID of the configuration subject whose configuration to list. (default: authenticated user)")
+		formatFlag  = flagSet.String("f", "", `Format for the output, using the syntax of Go package text/template. (e.g. "{{.|json}}")`)
+		apiFlags    = newAPIFlags(flagSet)
+	)
+
+	handler := func(args []string) error {
+		flagSet.Parse(args)
+
+		var formatStr string
+		if *formatFlag != "" {
+			formatStr = *formatFlag
+		} else {
+			// Set default here instead of in flagSet.String because it is very long and makes the usage message ugly.
+			formatStr = `{{range .Subjects -}}
+# {{.SettingsURL}}:{{with .LatestSettings}}
+{{.Configuration.Contents}}
+{{- else}} (empty){{- end}}
+{{end}}`
+		}
+		tmpl, err := parseTemplate(formatStr)
+		if err != nil {
+			return err
+		}
+
+		var query string
+		var queryVars map[string]interface{}
+		if *subjectFlag == "" {
+			query = viewerConfigurationQuery
+		} else {
+			query = configurationSubjectCascadeQuery
+			queryVars = map[string]interface{}{
+				"subject": nullString(*subjectFlag),
+			}
+		}
+
+		var result struct {
+			ViewerConfiguration  *ConfigurationCascade
+			ConfigurationSubject *ConfigurationSubject
+		}
+		return (&apiRequest{
+			query:  query,
+			vars:   queryVars,
+			result: &result,
+			done: func() error {
+				var cascade *ConfigurationCascade
+				if result.ViewerConfiguration != nil {
+					cascade = result.ViewerConfiguration
+				} else if result.ConfigurationSubject != nil {
+					cascade = &result.ConfigurationSubject.ConfigurationCascade
+				}
+				return execTemplate(tmpl, cascade)
+			},
+			flags: apiFlags,
+		}).do()
+	}
+
+	// Register the command.
+	configCommands = append(configCommands, &command{
+		flagSet:   flagSet,
+		handler:   handler,
+		usageFunc: usageFunc,
+	})
+}

--- a/cmd/src/format.go
+++ b/cmd/src/format.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	humanize "github.com/dustin/go-humanize"
+	"github.com/sourcegraph/jsonx"
 )
 
 func parseTemplate(text string) (*template.Template, error) {
@@ -18,6 +19,9 @@ func parseTemplate(text string) (*template.Template, error) {
 		"json": func(v interface{}) (string, error) {
 			b, err := marshalIndent(v)
 			return string(b), err
+		},
+		"jsonIndent": func(jsonStr string) (string, error) {
+			return jsonx.ApplyEdits(jsonStr, jsonx.Format(jsonStr, jsonx.FormatOptions{TabSize: 2})...)
 		},
 		"msDuration": func(ms int) time.Duration {
 			return time.Duration(ms) * time.Millisecond

--- a/cmd/src/main.go
+++ b/cmd/src/main.go
@@ -30,6 +30,7 @@ The commands are:
 	repos,repo      manages repositories
 	users,user      manages users
 	orgs,org        manages organizations
+	config          manages global, org, and user settings
 	extensions,ext  manages extensions (experimental)
 
 Use "src [command] -h" for more information about a command.


### PR DESCRIPTION
This adds the following subcommands:

- src config get (for seeing final merged configuration)
- src config edit (for updating or overwriting settings)
- src config list (for listing all configuration subjects)