### PR TITLE
feat: add users tag subcommand to add/rm user tags, and listing users by tag

### DIFF
--- a/cmd/src/users.go
+++ b/cmd/src/users.go
@@ -20,6 +20,7 @@ The commands are:
 	get        gets a user
 	create     creates a user account
 	delete     deletes a user account
+	tag        add/remove a tag on a user
 
 Use "src users [command] -h" for more information about a command.
 `

--- a/cmd/src/users_list.go
+++ b/cmd/src/users_list.go
@@ -21,6 +21,10 @@ Examples:
 
     	$ src users list -query='myquery'
 
+  List all users with the "foo" tag:
+
+    	$ src users list -tag=foo
+
 `
 
 	flagSet := flag.NewFlagSet("list", flag.ExitOnError)
@@ -32,6 +36,7 @@ Examples:
 	var (
 		firstFlag  = flagSet.Int("first", 1000, "Returns the first n users from the list. (use -1 for unlimited)")
 		queryFlag  = flagSet.String("query", "", `Returns users whose names match the query. (e.g. "alice")`)
+		tagFlag    = flagSet.String("tag", "", `Returns users with the given tag.`)
 		formatFlag = flagSet.String("f", "{{.Username}}", `Format for the output, using the syntax of Go package text/template. (e.g. "{{.ID}}: {{.Username}} ({{.DisplayName}})" or "{{.|json}}")`)
 		apiFlags   = newAPIFlags(flagSet)
 	)
@@ -47,10 +52,12 @@ Examples:
 		query := `query Users(
   $first: Int,
   $query: String,
+  $tag: String,
 ) {
   users(
     first: $first,
     query: $query,
+    tag: $tag,
   ) {
     nodes {
       ...UserFields
@@ -68,6 +75,7 @@ Examples:
 			vars: map[string]interface{}{
 				"first": nullInt(*firstFlag),
 				"query": nullString(*queryFlag),
+				"tag":   nullString(*tagFlag),
 			},
 			result: &result,
 			done: func() error {

--- a/cmd/src/users_tag.go
+++ b/cmd/src/users_tag.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+)
+
+func init() {
+	usage := `
+Examples:
+
+  Add a tag "foo" to a user:
+
+    	$ src users tag -user-id=$(src users get -f '{{.ID}}' -username=alice) -tag=foo
+
+  Remove a tag "foo" to a user:
+
+    	$ src users tag -user-id=$(src users get -f '{{.ID}}' -username=alice) -remove -tag=foo
+
+Related examples:
+
+  List all users with the "foo" tag:
+
+    	$ src users list -tag=foo
+
+`
+
+	flagSet := flag.NewFlagSet("tag", flag.ExitOnError)
+	usageFunc := func() {
+		fmt.Fprintf(flag.CommandLine.Output(), "Usage of 'src users %s':\n", flagSet.Name())
+		flagSet.PrintDefaults()
+		fmt.Println(usage)
+	}
+	var (
+		userIDFlag = flagSet.String("user-id", "", `The ID of the user to tag. (required)`)
+		tagFlag    = flagSet.String("tag", "", `The tag to set on the user. (required)`)
+		removeFlag = flagSet.Bool("remove", false, `Remove the tag. (default: add the tag`)
+		apiFlags   = newAPIFlags(flagSet)
+	)
+
+	handler := func(args []string) error {
+		flagSet.Parse(args)
+
+		query := `mutation SetUserTag(
+  $user: ID!,
+  $tag: String!,
+  $present: Boolean!
+) {
+  setTag(
+    node: $user,
+    tag: $tag,
+    present: $present
+  ) {
+    alwaysNil
+  }
+}`
+
+		return (&apiRequest{
+			query: query,
+			vars: map[string]interface{}{
+				"user":    *userIDFlag,
+				"tag":     *tagFlag,
+				"present": !*removeFlag,
+			},
+			result: &struct{}{},
+			flags:  apiFlags,
+		}).do()
+	}
+
+	// Register the command.
+	usersCommands = append(usersCommands, &command{
+		flagSet:   flagSet,
+		handler:   handler,
+		usageFunc: usageFunc,
+	})
+}


### PR DESCRIPTION
User tags are used for internal Sourcegraph feature flags to enable certain features for specific users.