### PR TITLE
Allow environment overrides for all config knobs

### DIFF
--- a/cmd/src/api.go
+++ b/cmd/src/api.go
@@ -308,6 +308,9 @@ func nullInt(n int) *int {
 	return &n
 }
 
+// If the provided `s` is empty, `nil` is returned instead.
+// No trimming or other alteration is done to the provided,
+// nor returned, string
 func nullString(s string) *string {
 	if s == "" {
 		return nil

--- a/cmd/src/main.go
+++ b/cmd/src/main.go
@@ -12,11 +12,11 @@ import (
 )
 
 const (
-	AccessTokenEnvVar = "SRC_ACCESS_TOKEN"
-	ConfigEnvVar      = "SRC_CONFIG"
-	ConfigFilename    = "src-config.json"
-	DefaultEndpoint   = "https://sourcegraph.com"
-	EndpointEnvVar    = "SRC_ENDPOINT"
+	accessTokenEnvVar = "SRC_ACCESS_TOKEN"
+	configEnvVar      = "SRC_CONFIG"
+	configFilename    = "src-config.json"
+	defaultEndpoint   = "https://sourcegraph.com"
+	endpointEnvVar    = "SRC_ENDPOINT"
 )
 
 const usageText = `src is a tool that provides access to Sourcegraph instances.
@@ -88,7 +88,7 @@ func readConfig() (*config, error) {
 	cfgPath := *configPath
 	userSpecified := cfgPath != ""
 	if !userSpecified {
-		if cfgEnvPath := os.Getenv(ConfigEnvVar); cfgEnvPath != "" {
+		if cfgEnvPath := os.Getenv(configEnvVar); cfgEnvPath != "" {
 			cfgPath = cfgEnvPath
 			userSpecified = true
 		}
@@ -98,7 +98,7 @@ func readConfig() (*config, error) {
 		if err != nil {
 			return nil, err
 		}
-		cfgPath = filepath.Join(currentUser.HomeDir, ConfigFilename)
+		cfgPath = filepath.Join(currentUser.HomeDir, configFilename)
 	}
 	data, err := ioutil.ReadFile(os.ExpandEnv(cfgPath))
 	if err != nil && (!os.IsNotExist(err) || userSpecified) {
@@ -112,18 +112,18 @@ func readConfig() (*config, error) {
 	}
 
 	// Apply config overrides.
-	if envToken := os.Getenv(AccessTokenEnvVar); envToken != "" {
+	if envToken := os.Getenv(accessTokenEnvVar); envToken != "" {
 		cfg.AccessToken = envToken
 	}
 	userEndpoint := *endpoint
-	if envEndpoint := os.Getenv(EndpointEnvVar); userEndpoint == "" && envEndpoint != "" {
+	if envEndpoint := os.Getenv(endpointEnvVar); userEndpoint == "" && envEndpoint != "" {
 		userEndpoint = envEndpoint
 	}
 	if userEndpoint != "" {
 		cfg.Endpoint = strings.TrimSuffix(userEndpoint, "/")
 	}
 	if cfg.Endpoint == "" {
-		cfg.Endpoint = DefaultEndpoint
+		cfg.Endpoint = defaultEndpoint
 	}
 	return &cfg, nil
 }

--- a/cmd/src/main.go
+++ b/cmd/src/main.go
@@ -29,21 +29,7 @@ Usage:
 The options are:
 
 	-config=$HOME/src-config.json    specifies a file containing {"accessToken": "<secret>", "endpoint": "https://sourcegraph.com"}
-      You can use "${}" syntax to reference environment variables, even on Windows,
-      but you may wish to use single-quotes to protect that syntax from shell expansion:
-
-      -config=${UserProfile}/src-config.json or
-      -config='${TMPDIR}/my-config.json'
-
-      [Environment Variables]
-      $SRC_CONFIG       can point to the config file
-                        although the -config option is always authoritative
-      $SRC_ACCESS_TOKEN can specify, or supersede, the access token
-
 	-endpoint=                       specifies the endpoint to use e.g. "https://sourcegraph.com" (overrides -config, if any)
-      [Environment Variables]
-      $SRC_ENDPOINT     can specify, or supersede, the value in -config
-                        although the -endpoint option is always authoritative
 
 The commands are:
 

--- a/cmd/src/main_test.go
+++ b/cmd/src/main_test.go
@@ -44,7 +44,7 @@ func TestReadConfig(parentT *testing.T) {
 		}
 		expected := config{
 			AccessToken: "",
-			Endpoint:    DefaultEndpoint,
+			Endpoint:    defaultEndpoint,
 		}
 		testCase.Run(func() {
 			runAndAssert(expected, t)
@@ -60,7 +60,7 @@ func TestReadConfig(parentT *testing.T) {
 		}
 		expected := config{
 			AccessToken: "abcdef-ghi",
-			Endpoint:    DefaultEndpoint,
+			Endpoint:    defaultEndpoint,
 		}
 		testCase.Run(func() {
 			runAndAssert(expected, t)
@@ -75,7 +75,7 @@ func TestReadConfig(parentT *testing.T) {
 		}
 		expected := config{
 			AccessToken: "secret-file-value",
-			Endpoint:    DefaultEndpoint,
+			Endpoint:    defaultEndpoint,
 		}
 		testCase.Run(func() {
 			runAndAssert(expected, t)
@@ -91,7 +91,7 @@ func TestReadConfig(parentT *testing.T) {
 		}
 		expected := config{
 			AccessToken: "secret-value-here",
-			Endpoint:    DefaultEndpoint,
+			Endpoint:    defaultEndpoint,
 		}
 		testCase.Run(func() {
 			runAndAssert(expected, t)
@@ -108,7 +108,7 @@ func TestReadConfig(parentT *testing.T) {
 		}
 		expected := config{
 			AccessToken: "supersede-access-token",
-			Endpoint:    DefaultEndpoint,
+			Endpoint:    defaultEndpoint,
 		}
 		testCase.Run(func() {
 			runAndAssert(expected, t)
@@ -125,7 +125,7 @@ func TestReadConfig(parentT *testing.T) {
 		}
 		expected := config{
 			AccessToken: "this-access-token",
-			Endpoint:    DefaultEndpoint,
+			Endpoint:    defaultEndpoint,
 		}
 		testCase.Run(func() {
 			runAndAssert(expected, t)
@@ -143,7 +143,7 @@ func TestReadConfig(parentT *testing.T) {
 		}
 		expected := config{
 			AccessToken: "highest-priority-access-token",
-			Endpoint:    DefaultEndpoint,
+			Endpoint:    defaultEndpoint,
 		}
 		testCase.Run(func() {
 			runAndAssert(expected, t)
@@ -160,7 +160,7 @@ func TestReadConfig(parentT *testing.T) {
 		}
 		expected := config{
 			AccessToken: "flag-config-should-win",
-			Endpoint:    DefaultEndpoint,
+			Endpoint:    defaultEndpoint,
 		}
 		testCase.Run(func() {
 			runAndAssert(expected, t)
@@ -233,9 +233,9 @@ func TestReadConfig(parentT *testing.T) {
 	})
 
 	parentT.Run("ensure env-vars do not leak", func(t *testing.T) {
-		assertEquals(os.Getenv(AccessTokenEnvVar), "", t)
-		assertEquals(os.Getenv(ConfigEnvVar), "", t)
-		assertEquals(os.Getenv(EndpointEnvVar), "", t)
+		assertEquals(os.Getenv(accessTokenEnvVar), "", t)
+		assertEquals(os.Getenv(configEnvVar), "", t)
+		assertEquals(os.Getenv(endpointEnvVar), "", t)
 	})
 }
 
@@ -258,11 +258,11 @@ func (testCase *FlagTestCaseInput) setUp() []func() error {
 	var cleanupFuncs []func() error
 
 	if testCase.accessTokenEnv != "" {
-		cleanup := pushSetenv(AccessTokenEnvVar, testCase.accessTokenEnv)
+		cleanup := pushSetenv(accessTokenEnvVar, testCase.accessTokenEnv)
 		cleanupFuncs = append(cleanupFuncs, cleanup)
 	}
 	if testCase.endpointEnv != "" {
-		cleanup := pushSetenv(EndpointEnvVar, testCase.endpointEnv)
+		cleanup := pushSetenv(endpointEnvVar, testCase.endpointEnv)
 		cleanupFuncs = append(cleanupFuncs, cleanup)
 	}
 
@@ -278,7 +278,7 @@ func (testCase *FlagTestCaseInput) setUp() []func() error {
 	if testCase.configJsonEnvContents != "" {
 		configFile := writeTempConfigFile(testCase.configJsonEnvContents, testCase.testState)
 		configFilename := configFile.Name()
-		cleanup := pushSetenv(ConfigEnvVar, configFilename)
+		cleanup := pushSetenv(configEnvVar, configFilename)
 		cleanupFuncs = append(cleanupFuncs, cleanup)
 		cleanupFuncs = append(cleanupFuncs, func() error {
 			return os.Remove(configFilename)

--- a/cmd/src/main_test.go
+++ b/cmd/src/main_test.go
@@ -1,0 +1,337 @@
+package main
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+type FlagTestCaseInput struct {
+	testState *testing.T
+	// any env-var contents for the access token
+	accessTokenEnv string
+	// any env-var contents for the endpoint
+	endpointEnv string
+	// any value to be provided to the endpoint flag
+	endpointFlag string
+	// any contents to be serialized to a file and specified as an env-var
+	configJsonEnvContents string
+	// any contents to be serialized to a file and specified as a flag
+	configJsonFlagContents string
+}
+
+// Access Token Env | Access Token in Config(Flag) | Access Token in Config(Env)
+// Endpoint Env     | Endpoint in Config(Env)      | Endpoint in Flag
+func TestReadConfig(parentT *testing.T) {
+
+	// it seemed less opaque to put these steps here than in a top-level func
+	runAndAssert := func(expectedConfig config, t *testing.T) {
+		var actualConfig *config
+		if c, cfgErr := readConfig(); cfgErr == nil {
+			actualConfig = c
+		} else {
+			t.Fatal(cfgErr)
+		}
+
+		assertEquals(actualConfig.AccessToken, expectedConfig.AccessToken, t)
+		assertEquals(actualConfig.Endpoint, expectedConfig.Endpoint, t)
+	}
+
+	parentT.Run("pure defaults", func(t *testing.T) {
+		testCase := FlagTestCaseInput{
+			testState: t,
+			// intentionally blank
+		}
+		expected := config{
+			AccessToken: "",
+			Endpoint:    DefaultEndpoint,
+		}
+		testCase.Run(func() {
+			runAndAssert(expected, t)
+		})
+	})
+
+	// Access Token Env [X] | Access Token in Config(Flag) | Access Token in Config(Env)
+	parentT.Run("accessToken in the environment", func(t *testing.T) {
+		testCase := FlagTestCaseInput{
+			testState: t,
+
+			accessTokenEnv: "abcdef-ghi",
+		}
+		expected := config{
+			AccessToken: "abcdef-ghi",
+			Endpoint:    DefaultEndpoint,
+		}
+		testCase.Run(func() {
+			runAndAssert(expected, t)
+		})
+	})
+
+	// Access Token Env | Access Token in Config(Flag) [X] | Access Token in Config(Env)
+	parentT.Run("accessToken in the -config flag", func(t *testing.T) {
+		testCase := FlagTestCaseInput{
+			testState:              t,
+			configJsonFlagContents: `{"accessToken": "secret-file-value"}`,
+		}
+		expected := config{
+			AccessToken: "secret-file-value",
+			Endpoint:    DefaultEndpoint,
+		}
+		testCase.Run(func() {
+			runAndAssert(expected, t)
+		})
+	})
+
+	// Access Token Env | Access Token in Config(Flag) | Access Token in Config(Env) [X]
+	parentT.Run("accessToken in a file identified by the SRC_CONFIG env", func(t *testing.T) {
+		testCase := FlagTestCaseInput{
+			testState: t,
+
+			configJsonEnvContents: `{"accessToken": "secret-value-here"}`,
+		}
+		expected := config{
+			AccessToken: "secret-value-here",
+			Endpoint:    DefaultEndpoint,
+		}
+		testCase.Run(func() {
+			runAndAssert(expected, t)
+		})
+	})
+
+	// Access Token Env [X] | Access Token in Config(Flag) [X] | Access Token in Config(Env)
+	parentT.Run("accessToken in the env, superseding -config file", func(t *testing.T) {
+		testCase := FlagTestCaseInput{
+			testState: t,
+
+			accessTokenEnv:         "supersede-access-token",
+			configJsonFlagContents: `{"accessToken": "old-value-here"}`,
+		}
+		expected := config{
+			AccessToken: "supersede-access-token",
+			Endpoint:    DefaultEndpoint,
+		}
+		testCase.Run(func() {
+			runAndAssert(expected, t)
+		})
+	})
+
+	// Access Token Env [X] | Access Token in Config(Flag) | Access Token in Config(Env) [X]
+	parentT.Run("accessToken in the env, superseding SRC_CONFIG file", func(t *testing.T) {
+		testCase := FlagTestCaseInput{
+			testState: t,
+
+			accessTokenEnv:        "this-access-token",
+			configJsonEnvContents: `{"accessToken": "not-this-one"}`,
+		}
+		expected := config{
+			AccessToken: "this-access-token",
+			Endpoint:    DefaultEndpoint,
+		}
+		testCase.Run(func() {
+			runAndAssert(expected, t)
+		})
+	})
+
+	// Access Token Env [X] | Access Token in Config(Flag) [X] | Access Token in Config(Env) [X]
+	parentT.Run("accessToken in the env, superseding -config, with SRC_CONFIG set", func(t *testing.T) {
+		testCase := FlagTestCaseInput{
+			testState: t,
+
+			accessTokenEnv:         "highest-priority-access-token",
+			configJsonEnvContents:  `{"accessToken": "not-this-one"}`,
+			configJsonFlagContents: `{"accessToken": "or-this-one"}`,
+		}
+		expected := config{
+			AccessToken: "highest-priority-access-token",
+			Endpoint:    DefaultEndpoint,
+		}
+		testCase.Run(func() {
+			runAndAssert(expected, t)
+		})
+	})
+
+	// Access Token Env | Access Token in Config(Flag) [X] | Access Token in Config(Env) [X]
+	parentT.Run("accessToken in -config, with SRC_CONFIG set", func(t *testing.T) {
+		testCase := FlagTestCaseInput{
+			testState: t,
+
+			configJsonEnvContents:  `{"accessToken": "not-this-one"}`,
+			configJsonFlagContents: `{"accessToken": "flag-config-should-win"}`,
+		}
+		expected := config{
+			AccessToken: "flag-config-should-win",
+			Endpoint:    DefaultEndpoint,
+		}
+		testCase.Run(func() {
+			runAndAssert(expected, t)
+		})
+	})
+
+	// Endpoint Env [X] | Endpoint in Config(Env) | Endpoint in Flag
+	parentT.Run("endpoint in SRC_ENDPOINT", func(t *testing.T) {
+		testCase := FlagTestCaseInput{
+			testState: t,
+
+			// go ahead and toss in a "make sure it trims the same" case, too
+			endpointEnv: "urn:uuid:hello-from-env/",
+		}
+		expected := config{
+			Endpoint: "urn:uuid:hello-from-env",
+		}
+		testCase.Run(func() {
+			runAndAssert(expected, t)
+		})
+	})
+
+	// Endpoint Env [X] | Endpoint in Config(Env) [X] | Endpoint in Flag
+	parentT.Run("endpoint in SRC_ENDPOINT, superseding -config", func(t *testing.T) {
+		testCase := FlagTestCaseInput{
+			testState:   t,
+			endpointEnv: "urn:uuid:hello-from-env/",
+		}
+		expected := config{
+			AccessToken: "",
+			Endpoint:    "urn:uuid:hello-from-env",
+		}
+		testCase.Run(func() {
+			runAndAssert(expected, t)
+		})
+	})
+
+	// Endpoint Env [X] | Endpoint in Config(Env) [X] | Endpoint in Flag [X]
+	parentT.Run("endpoint in SRC_ENDPOINT, and -config, -endpoint wins", func(t *testing.T) {
+		testCase := FlagTestCaseInput{
+			testState:             t,
+			endpointEnv:           "urn:hello-from-env",
+			endpointFlag:          "urn:this-endpoint-wins",
+			configJsonEnvContents: `{"endpoint": "urn:not-this-one"}`,
+		}
+		expected := config{
+			AccessToken: "",
+			Endpoint:    "urn:this-endpoint-wins",
+		}
+		testCase.Run(func() {
+			runAndAssert(expected, t)
+		})
+	})
+
+	// Endpoint Env | Endpoint in Config(Env) [X] | Endpoint in Flag [X]
+	parentT.Run("endpoint in -config, but -endpoint wins", func(t *testing.T) {
+		testCase := FlagTestCaseInput{
+			testState: t,
+
+			endpointFlag:          "urn:look-at-me-instead",
+			configJsonEnvContents: `{"endpoint": "urn:nothing-to-see-here"}`,
+		}
+		expected := config{
+			AccessToken: "",
+			Endpoint:    "urn:look-at-me-instead",
+		}
+		testCase.Run(func() {
+			runAndAssert(expected, t)
+		})
+	})
+
+	parentT.Run("ensure env-vars do not leak", func(t *testing.T) {
+		assertEquals(os.Getenv(AccessTokenEnvVar), "", t)
+		assertEquals(os.Getenv(ConfigEnvVar), "", t)
+		assertEquals(os.Getenv(EndpointEnvVar), "", t)
+	})
+}
+
+// will run my setup logic, then the provided function, and then clean up after myself
+// any encountered `error`s are handled via the testing.T functions for that purpose
+func (testCase *FlagTestCaseInput) Run(inner func()) {
+	cleanupFuncs := testCase.setUp()
+	inner()
+	for _, fn := range cleanupFuncs {
+		if e := fn(); e != nil {
+			testCase.testState.Fatal(e)
+		}
+	}
+}
+
+// Evaluate this test case input, which may involve altering the `os.Setenv`
+// but the returned callbacks are cleanup functions that will tear down any changes made by setUp
+func (testCase *FlagTestCaseInput) setUp() []func() error {
+	// any post-test cleanup action
+	var cleanupFuncs []func() error
+
+	if testCase.accessTokenEnv != "" {
+		cleanup := pushSetenv(AccessTokenEnvVar, testCase.accessTokenEnv)
+		cleanupFuncs = append(cleanupFuncs, cleanup)
+	}
+	if testCase.endpointEnv != "" {
+		cleanup := pushSetenv(EndpointEnvVar, testCase.endpointEnv)
+		cleanupFuncs = append(cleanupFuncs, cleanup)
+	}
+
+	if testCase.endpointFlag != "" {
+		oldEndpoint := endpoint
+		endpoint = &testCase.endpointFlag
+		cleanupFuncs = append(cleanupFuncs, func() error {
+			endpoint = oldEndpoint
+			return nil
+		})
+	}
+
+	if testCase.configJsonEnvContents != "" {
+		configFile := writeTempConfigFile(testCase.configJsonEnvContents, testCase.testState)
+		configFilename := configFile.Name()
+		cleanup := pushSetenv(ConfigEnvVar, configFilename)
+		cleanupFuncs = append(cleanupFuncs, cleanup)
+		cleanupFuncs = append(cleanupFuncs, func() error {
+			if e := os.Remove(configFilename); e != nil {
+				return e
+			}
+			return nil
+		})
+	}
+
+	if testCase.configJsonFlagContents != "" {
+		configFile := writeTempConfigFile(testCase.configJsonFlagContents, testCase.testState)
+		configFilename := configFile.Name()
+		oldConfigPath := configPath
+		configPath = &configFilename
+		cleanupFuncs = append(cleanupFuncs, func() error {
+			// cheat and piggy back on this cleanup
+			configPath = oldConfigPath
+
+			if e := os.Remove(configFilename); e != nil {
+				return e
+			}
+			return nil
+		})
+	}
+
+	return cleanupFuncs
+}
+
+// serialize the provided string into a new temp file named `src-config-something.json`
+// so the user can clearly identify any stragglers
+// You are responsible for deleting the file when you are done with it.
+func writeTempConfigFile(contents string, t *testing.T) os.File {
+	t.Helper()
+	tmpFile, tmpErr := ioutil.TempFile("", "src-config-*.json")
+	if tmpErr != nil {
+		t.Fatal(tmpErr)
+	}
+	tmpFile.WriteString(contents)
+	tmpFile.Close()
+	return *tmpFile
+}
+
+func pushSetenv(envName, envValue string) func() error {
+	existingEnvValue := os.Getenv(envName)
+	os.Setenv(envName, envValue)
+	return func() error {
+		return os.Setenv(envName, existingEnvValue)
+	}
+}
+
+func assertEquals(actual, wanted string, t *testing.T) {
+	t.Helper()
+	if actual != wanted {
+		t.Logf("Wanted \"%s\" but got \"%s\"", wanted, actual)
+	}
+}

--- a/cmd/src/main_test.go
+++ b/cmd/src/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"io/ioutil"
+	"log"
 	"os"
 	"testing"
 )
@@ -310,14 +311,21 @@ func writeTempConfigFile(contents string, t *testing.T) os.File {
 	if tmpErr != nil {
 		t.Fatal(tmpErr)
 	}
-	tmpFile.WriteString(contents)
-	tmpFile.Close()
+	filename := tmpFile.Name()
+	if _, err := tmpFile.WriteString(contents); err != nil {
+		log.Fatalf(`unable to write contents to "%s": %v`, filename, err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		log.Fatalf(`unable to close "%s": %v`, filename, err)
+	}
 	return *tmpFile
 }
 
 func pushSetenv(envName, envValue string) func() error {
 	existingEnvValue := os.Getenv(envName)
-	os.Setenv(envName, envValue)
+	if err := os.Setenv(envName, envValue); err != nil {
+		log.Fatal(err)
+	}
 	return func() error {
 		return os.Setenv(envName, existingEnvValue)
 	}

--- a/cmd/src/main_test.go
+++ b/cmd/src/main_test.go
@@ -281,10 +281,7 @@ func (testCase *FlagTestCaseInput) setUp() []func() error {
 		cleanup := pushSetenv(ConfigEnvVar, configFilename)
 		cleanupFuncs = append(cleanupFuncs, cleanup)
 		cleanupFuncs = append(cleanupFuncs, func() error {
-			if e := os.Remove(configFilename); e != nil {
-				return e
-			}
-			return nil
+			return os.Remove(configFilename)
 		})
 	}
 
@@ -297,10 +294,7 @@ func (testCase *FlagTestCaseInput) setUp() []func() error {
 			// cheat and piggy back on this cleanup
 			configPath = oldConfigPath
 
-			if e := os.Remove(configFilename); e != nil {
-				return e
-			}
-			return nil
+			return os.Remove(configFilename)
 		})
 	}
 

--- a/cmd/src/main_test.go
+++ b/cmd/src/main_test.go
@@ -334,6 +334,6 @@ func pushSetenv(envName, envValue string) func() error {
 func assertEquals(actual, wanted string, t *testing.T) {
 	t.Helper()
 	if actual != wanted {
-		t.Logf("Wanted \"%s\" but got \"%s\"", wanted, actual)
+		t.Fatalf(`Wanted "%s" but got "%s"`, wanted, actual)
 	}
 }


### PR DESCRIPTION
Including, naturally, the config location itself. This takes the opportunity to pull some magic strings up into constants to make their usage more obvious

This commit stops shy of wrapping the *132* character long help text line, because maybe that's the golang way, but it could arguably be improved, also

```
--- PASS: TestReadConfig (0.01s)
    --- PASS: TestReadConfig/pure_defaults (0.00s)
    --- PASS: TestReadConfig/accessToken_in_the_environment (0.00s)
    --- PASS: TestReadConfig/accessToken_in_the_-config_flag (0.00s)
    --- PASS: TestReadConfig/accessToken_in_a_file_identified_by_the_SRC_CONFIG_env (0.00s)
    --- PASS: TestReadConfig/accessToken_in_the_env,_superseding_-config_file (0.00s)
    --- PASS: TestReadConfig/accessToken_in_the_env,_superseding_SRC_CONFIG_file (0.00s)
    --- PASS: TestReadConfig/accessToken_in_the_env,_superseding_-config,_with_SRC_CONFIG_set (0.00s)
    --- PASS: TestReadConfig/accessToken_in_-config,_with_SRC_CONFIG_set (0.00s)
    --- PASS: TestReadConfig/endpoint_in_SRC_ENDPOINT (0.00s)
    --- PASS: TestReadConfig/endpoint_in_SRC_ENDPOINT,_superseding_-config (0.00s)
    --- PASS: TestReadConfig/endpoint_in_SRC_ENDPOINT,_and_-config,_-endpoint_wins (0.00s)
    --- PASS: TestReadConfig/endpoint_in_-config,_but_-endpoint_wins (0.00s)
    --- PASS: TestReadConfig/ensure_env-vars_do_not_leak (0.00s)
```

cc: @sqs as mentioned in the other thread
cc: @nicksnyder per our discussion over email (I am expecting there is more coming, but this certainly is something to discuss)
