### PR TITLE
Add support for specifying a sudo token user

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,13 +63,25 @@ SRC_ACCESS_TOKEN="secret" src ...
 
 Or via the configuration file (`~/src-config.json`):
 
-```sh
+```json
 	{"accessToken": "secret"}
 ```
 
 See `src -h` for more information on specifying access tokens.
 
 To acquire the access token, visit your Sourcegraph instance (or https://sourcegraph.com), click your profile picture, and select **access tokens** in the left hand menu.
+
+### Sudo Tokens
+
+If an access token has the `site-admin:sudo` scope, then one may perform an action as a user other than the one who created the access token. To enable this functionality, add the additional `"runAs": ""` property to your `src-config.json`.
+
+```json
+	{"accessToken": "secret", "runAs": "other-username"}
+```
+
+This extra field is optional, even with `sudo` tokens; without that field the `sudo` token will behave just like a traditional access token.
+
+_N.B._ be careful not to leave that field in place when using a _non_ `sudo` scoped token, as that will cause authentication failures.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ It currently provides the ability to:
   - You can easily convert a `src api` command into a curl command with `src api -get-curl`.
 - **Manage repositories, users, and organizations** using the `src repos`, `src users`, and `src orgs` commands.
 
-If there is something you'd like to see Sourcegraph be able to do from the CLI, let us know! :)
+If there is something you'd like to see Sourcegraph be able to do from the CLI, [let us know!](https://github.com/sourcegraph/sourcegraph/issues/new/choose) :)
 
 ## Installation
 
@@ -32,7 +32,7 @@ chmod +x /usr/local/bin/src
 
 ### Windows:
 
-Note: Windows support is still rough around the edges, but is available. If you encounter issues, please let us know by filing an issue :)
+Note: Windows support is still rough around the edges, but is available. If you encounter issues, please let us know by [filing an issue](https://github.com/sourcegraph/sourcegraph/issues/new/choose) :)
 
 Run in PowerShell as administrator:
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Consult `src -h` and `src api -h` for usage information.
 
 Some Sourcegraph instances will be configured to require authentication. You can do so via the environment:
 
-```sh
+```bash
 SRC_ACCESS_TOKEN="secret" src ...
 ```
 
@@ -87,7 +87,7 @@ _N.B._ be careful not to leave that field in place when using a _non_ `sudo` sco
 
 If you want to develop the CLI, you can install it with `go get`:
 
-```
+```bash
 go get -u github.com/sourcegraph/src-cli/cmd/src
 ```
 

--- a/cmd/src/api.go
+++ b/cmd/src/api.go
@@ -138,7 +138,6 @@ func authenticationHeader(cfg *config) (string, string) {
 	} else {
 		headerValue = "token " + cfg.AccessToken
 	}
-
 	return "Authorization", headerValue
 }
 

--- a/cmd/src/api.go
+++ b/cmd/src/api.go
@@ -156,8 +156,7 @@ func curlCmd(cfg *config, query string, vars map[string]interface{}) (string, er
 
 	s := fmt.Sprintf("curl \\\n")
 	if cfg.AccessToken != "" {
-		var headerName, headerValue string
-		headerName, headerValue = authenticationHeader(cfg)
+		headerName, headerValue := authenticationHeader(cfg)
 		if headerName == "" {
 			return "", fmt.Errorf(authHeaderMissingAccessTokenError)
 		}
@@ -227,8 +226,7 @@ func (a *apiRequest) do() error {
 		return err
 	}
 	if cfg.AccessToken != "" {
-		var headerName, headerValue string
-		headerName, headerValue = authenticationHeader(cfg)
+		headerName, headerValue := authenticationHeader(cfg)
 		if headerName == "" {
 			return fmt.Errorf(authHeaderMissingAccessTokenError)
 		}

--- a/cmd/src/api.go
+++ b/cmd/src/api.go
@@ -56,7 +56,9 @@ Examples:
 	)
 
 	handler := func(args []string) error {
-		flagSet.Parse(args)
+		if err := flagSet.Parse(args); err != nil {
+			return err
+		}
 
 		// Build the GraphQL request.
 		query := *queryFlag

--- a/cmd/src/api.go
+++ b/cmd/src/api.go
@@ -15,10 +15,6 @@ import (
 	"github.com/mattn/go-isatty"
 )
 
-const (
-	authHeaderMissingAccessTokenError = `unable to translate config into authentication header, please file an issue https://github.com/sourcegraph/sourcegraph/issues/new/choose`
-)
-
 func init() {
 	usage := `
 Exit codes:
@@ -158,7 +154,7 @@ func curlCmd(cfg *config, query string, vars map[string]interface{}) (string, er
 	if cfg.AccessToken != "" {
 		headerName, headerValue := authenticationHeader(cfg)
 		if headerName == "" {
-			return "", fmt.Errorf(authHeaderMissingAccessTokenError)
+			panic("failed to create authentication header from configuration")
 		}
 		authHeader := fmt.Sprintf("%s: %s", headerName, headerValue)
 		s += fmt.Sprintf("   %s \\\n", shellquote.Join("-H", authHeader))
@@ -228,7 +224,7 @@ func (a *apiRequest) do() error {
 	if cfg.AccessToken != "" {
 		headerName, headerValue := authenticationHeader(cfg)
 		if headerName == "" {
-			return fmt.Errorf(authHeaderMissingAccessTokenError)
+			panic("failed to create authentication header from configuration")
 		}
 		req.Header.Set(headerName, headerValue)
 	}

--- a/cmd/src/api.go
+++ b/cmd/src/api.go
@@ -125,20 +125,20 @@ func gqlURL(endpoint string) string {
 	return endpoint + "/.api/graphql"
 }
 
-// authenticationHeader returns the header name and header value required to authenticate a request,
-// or `"", ""` if one calls this function when the config has no AccessToken information
-func authenticationHeader(cfg *config) (string, string) {
+// authorizationHeaderValue returns the header value required to authenticate a request,
+// or `""` if one calls this function when the config has no AccessToken information
+func authorizationHeaderValue(cfg *config) string {
 	if cfg.AccessToken == "" {
-		return "", ""
+		return ""
 	}
 
-	var headerValue string
+	var result string
 	if cfg.RunAs != "" {
-		headerValue = fmt.Sprintf(`token-sudo user="%s",token="%s"`, cfg.RunAs, cfg.AccessToken)
+		result = fmt.Sprintf(`token-sudo user="%s",token="%s"`, cfg.RunAs, cfg.AccessToken)
 	} else {
-		headerValue = "token " + cfg.AccessToken
+		result = "token " + cfg.AccessToken
 	}
-	return "Authorization", headerValue
+	return result
 }
 
 // curlCmd returns the curl command to perform the given GraphQL query. Bash-only.
@@ -153,8 +153,9 @@ func curlCmd(cfg *config, query string, vars map[string]interface{}) (string, er
 
 	s := fmt.Sprintf("curl \\\n")
 	if cfg.AccessToken != "" {
-		headerName, headerValue := authenticationHeader(cfg)
-		if headerName == "" {
+		headerName := "Authorization"
+		headerValue := authorizationHeaderValue(cfg)
+		if headerValue == "" {
 			panic("failed to create authentication header from configuration")
 		}
 		authHeader := fmt.Sprintf("%s: %s", headerName, headerValue)
@@ -223,8 +224,9 @@ func (a *apiRequest) do() error {
 		return err
 	}
 	if cfg.AccessToken != "" {
-		headerName, headerValue := authenticationHeader(cfg)
-		if headerName == "" {
+		headerName := "Authorization"
+		headerValue := authorizationHeaderValue(cfg)
+		if headerValue == "" {
 			panic("failed to create authentication header from configuration")
 		}
 		req.Header.Set(headerName, headerValue)

--- a/cmd/src/api.go
+++ b/cmd/src/api.go
@@ -132,7 +132,7 @@ func authenticationHeader(cfg *config) (string, string) {
 
 	var headerValue string
 	if cfg.RunAs != "" {
-		headerValue = fmt.Sprintf("token-sudo user=\"%s\",token=\"%s\"", cfg.RunAs, cfg.AccessToken)
+		headerValue = fmt.Sprintf(`token-sudo user="%s",token="%s"`, cfg.RunAs, cfg.AccessToken)
 	} else {
 		headerValue = "token " + cfg.AccessToken
 	}

--- a/cmd/src/api.go
+++ b/cmd/src/api.go
@@ -15,6 +15,10 @@ import (
 	"github.com/mattn/go-isatty"
 )
 
+const (
+	authHeaderMissingAccessTokenError = `unable to translate config into authentication header, please file an issue https://github.com/sourcegraph/sourcegraph/issues/new/choose`
+)
+
 func init() {
 	usage := `
 Exit codes:
@@ -155,7 +159,7 @@ func curlCmd(cfg *config, query string, vars map[string]interface{}) (string, er
 		var headerName, headerValue string
 		headerName, headerValue = authenticationHeader(cfg)
 		if headerName == "" {
-			return "", fmt.Errorf("unable to translate config into authentication header, please file an issue")
+			return "", fmt.Errorf(authHeaderMissingAccessTokenError)
 		}
 		authHeader := fmt.Sprintf("%s: %s", headerName, headerValue)
 		s += fmt.Sprintf("   %s \\\n", shellquote.Join("-H", authHeader))
@@ -226,7 +230,7 @@ func (a *apiRequest) do() error {
 		var headerName, headerValue string
 		headerName, headerValue = authenticationHeader(cfg)
 		if headerName == "" {
-			return fmt.Errorf("unable to translate config into authentication header, please file an issue")
+			return fmt.Errorf(authHeaderMissingAccessTokenError)
 		}
 		req.Header.Set(headerName, headerValue)
 	}

--- a/cmd/src/main.go
+++ b/cmd/src/main.go
@@ -20,7 +20,7 @@ Usage:
 
 The options are:
 
-	-config=$HOME/src-config.json    specifies a file containing {"accessToken": "<secret>", "endpoint": "https://sourcegraph.com", "runAs": "another-user"}
+	-config=$HOME/src-config.json    specifies a file containing {"accessToken": "<secret>", "endpoint": "https://sourcegraph.com"}
 	-endpoint=                       specifies the endpoint to use e.g. "https://sourcegraph.com" (overrides -config, if any)
 
 The commands are:

--- a/cmd/src/main.go
+++ b/cmd/src/main.go
@@ -20,7 +20,7 @@ Usage:
 
 The options are:
 
-	-config=$HOME/src-config.json    specifies a file containing {"accessToken": "<secret>", "endpoint": "https://sourcegraph.com"}
+	-config=$HOME/src-config.json    specifies a file containing {"accessToken": "<secret>", "endpoint": "https://sourcegraph.com", "runAs": "another-user"}
 	-endpoint=                       specifies the endpoint to use e.g. "https://sourcegraph.com" (overrides -config, if any)
 
 The commands are:
@@ -59,6 +59,9 @@ var cfg *config
 type config struct {
 	Endpoint    string `json:"endpoint"`
 	AccessToken string `json:"accessToken"`
+	// implies that the `AccessToken` is a "sudo" token
+	// and this value is the username as whom the request will run
+	RunAs string `json:"runAs"`
 }
 
 // readConfig reads the config file from the given path.


### PR DESCRIPTION
Adds another top-level field to the `src-config.json` entitled "runAs" that serves as both the username as whom the request will run, and therefore also marks the access token as a sudo token. Currently, if `"runAs"` is provided but the token is not actually a sudo token, it will end pretty much as poorly as one might expect

I didn't add any additional sanity checking because the original code didn't have any, but I am cognizant that it appears the cli is currently using the deserialized `string` as is, surfacing header injection attacks if the config payload is untrusted.

fixes: #3

cc: @nicksnyder (less code than #22 but this one is an actual feature, and (heh) was requested, so that might help you more)