### PR TITLE
Add verify-emails to allow mutating in mass

### DIFF
--- a/cmd/src/users.go
+++ b/cmd/src/users.go
@@ -16,11 +16,12 @@ Usage:
 
 The commands are:
 
-	list       lists users
-	get        gets a user
-	create     creates a user account
-	delete     deletes a user account
-	tag        add/remove a tag on a user
+	list          lists users
+	get           gets a user
+	create        creates a user account
+	delete        deletes a user account
+	tag           add/remove a tag on a user
+	verify-emails verify user emails in bulk
 
 Use "src users [command] -h" for more information about a command.
 `

--- a/cmd/src/users.go
+++ b/cmd/src/users.go
@@ -21,7 +21,7 @@ The commands are:
 	create        creates a user account
 	delete        deletes a user account
 	tag           add/remove a tag on a user
-	verify-emails verify user emails in bulk
+	emails        actions related to user emails
 
 Use "src users [command] -h" for more information about a command.
 `

--- a/cmd/src/users_emails.go
+++ b/cmd/src/users_emails.go
@@ -59,7 +59,9 @@ please file an issue at https://github.com/sourcegraph/sourcegraph/issues/new/ch
 	}
 
 	handler := func(args []string) error {
-		flagSet.Parse(args)
+		if err := flagSet.Parse(args); err != nil {
+			return err
+		}
 
 		var verifyList []VerifyEmailJson
 		if err := json.Unmarshal([]byte(*verifyJsonFlag), &verifyList); err != nil {

--- a/cmd/src/users_emails.go
+++ b/cmd/src/users_emails.go
@@ -9,8 +9,6 @@ import (
 	"text/template"
 )
 
-const SubCommand = "verify-emails"
-
 // input = `[]VerifyEmailJson`
 // be careful if you change the vars format, since the vars need to match below
 const setEmailVerifiedTemplate = `
@@ -38,11 +36,11 @@ Examples:
 
   Verify one or more user account(s):
 
-    	$ src users ` + SubCommand + ` -verify-json='[{"ID": "ID1", "Email": "email1"},...]'
+    	$ src users emails verify-json='[{"ID": "ID1", "Email": "email1"},...]'
 
 `
 
-	flagSet := flag.NewFlagSet(SubCommand, flag.ExitOnError)
+	flagSet := flag.NewFlagSet("emails", flag.ExitOnError)
 	usageFunc := func() {
 		fmt.Fprintf(flag.CommandLine.Output(), "Usage of 'src users %s':\n", flagSet.Name())
 		flagSet.PrintDefaults()

--- a/cmd/src/users_verify.go
+++ b/cmd/src/users_verify.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"strings"
+)
+
+const SubCommand = "verify-emails"
+
+type VerifyEmailJson struct {
+	ID    string `json:"ID"`
+	Email string `json:"Email"`
+}
+
+func init() {
+	usage := `
+Examples:
+
+  Verify one or more user account(s):
+
+    	$ src users ` + SubCommand + ` -verify-json='[{"ID": "ID1", "Email": "email1"},...]'
+
+`
+
+	flagSet := flag.NewFlagSet(SubCommand, flag.ExitOnError)
+	usageFunc := func() {
+		fmt.Fprintf(flag.CommandLine.Output(), "Usage of 'src users %s':\n", flagSet.Name())
+		flagSet.PrintDefaults()
+		fmt.Println(usage)
+	}
+	var (
+		verifyJsonFlag = flagSet.String("verify-json", "",
+			`The JSON array of id-email descriptors of those user/emails that should be marked as verified. (required)`)
+		apiFlags = newAPIFlags(flagSet)
+	)
+
+	handler := func(args []string) error {
+		flagSet.Parse(args)
+
+		dec := json.NewDecoder(bytes.NewBufferString(*verifyJsonFlag))
+
+		var verifyList []VerifyEmailJson
+		if err := dec.Decode(&verifyList); err != nil {
+			return err
+		}
+
+		vars := map[string]interface{}{}
+
+		// translate the provided index of `verifyList` into variables for its `id` and `email` payload
+		indexToKeys := func(idx int) (string, string) {
+			return fmt.Sprintf("id%09d", idx), fmt.Sprintf("email%09d", idx)
+		}
+
+		for idx, verifyObj := range verifyList {
+			idKey, emailKey := indexToKeys(idx)
+			vars[idKey] = verifyObj.ID
+			vars[emailKey] = verifyObj.Email
+		}
+
+		query := `mutation VerifyUserEmails(`
+		for k := range vars {
+			varType := "String!"
+			if strings.HasPrefix(k, "id") {
+				varType = "ID!"
+			}
+			query += fmt.Sprintf("$%s: %s,", k, varType)
+		}
+		query += ") {"
+		for idx := range verifyList {
+			idKey, emailKey := indexToKeys(idx)
+			query += fmt.Sprintf(`verify%09d: setUserEmailVerified(user: $%s, email: $%s, verified: true) {
+alwaysNil
+}`, idx, idKey, emailKey)
+		}
+		query += "}"
+
+		var result struct {
+			VerifyUserEmails struct{}
+		}
+		return (&apiRequest{
+			query:  query,
+			vars:   vars,
+			result: &result,
+			done: func() error {
+				fmt.Printf("Verified %d emails.\n", len(verifyList))
+				return nil
+			},
+			flags: apiFlags,
+		}).do()
+	}
+
+	// Register the command.
+	usersCommands = append(usersCommands, &command{
+		flagSet:   flagSet,
+		handler:   handler,
+		usageFunc: usageFunc,
+	})
+}

--- a/cmd/src/users_verify.go
+++ b/cmd/src/users_verify.go
@@ -39,10 +39,8 @@ Examples:
 	handler := func(args []string) error {
 		flagSet.Parse(args)
 
-		dec := json.NewDecoder(strings.NewReader(*verifyJsonFlag))
-
 		var verifyList []VerifyEmailJson
-		if err := dec.Decode(&verifyList); err != nil {
+		if err := json.Unmarshal([]byte(*verifyJsonFlag), &verifyList); err != nil {
 			return err
 		}
 

--- a/cmd/src/users_verify.go
+++ b/cmd/src/users_verify.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bytes"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -40,7 +39,7 @@ Examples:
 	handler := func(args []string) error {
 		flagSet.Parse(args)
 
-		dec := json.NewDecoder(bytes.NewBufferString(*verifyJsonFlag))
+		dec := json.NewDecoder(strings.NewReader(*verifyJsonFlag))
 
 		var verifyList []VerifyEmailJson
 		if err := dec.Decode(&verifyList); err != nil {


### PR DESCRIPTION
There seemed to be precedent for using subshells to generate flag values, which was **especially** relevant for this since we need a list of tuples, so a JSON structure seemed like a reasonable choice.

fixes: #17

cc: @nicksnyder (this is the last one I had on my "I think I can do that" list, and hopefully we're getting to a pretty representative sample; it's my first time writing GraphQL, so be gentle :grin: )