### PR TITLE
remove elapsedMillisecond hack now that backend is fixed

### DIFF
--- a/cmd/src/search.go
+++ b/cmd/src/search.go
@@ -205,13 +205,6 @@ Other tips:
 					searchResults:       result.Search.Results,
 				}
 
-				// HACK: temporary workaround for a bug where ElapsedMilliseconds is nonsensical
-				// when results == 0; Remove this when the bug is fixed and enough time has passed
-				// (internal tracking issue: https://github.com/sourcegraph/sourcegraph/issues/12625)
-				if len(improved.Results) == 0 {
-					improved.ElapsedMilliseconds = 0
-				}
-
 				if *jsonFlag {
 					// Print the formatted JSON.
 					f, err := marshalIndent(improved)


### PR DESCRIPTION
See https://github.com/sourcegraph/sourcegraph/pull/551 for details. Bad value for elapsedMilliseconds should not be coming back from the server on new versions.

Not sure how releases work so I'll leave that part up to you guys.