### PR TITLE
Add support for programmatically excluding repos via external service config

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,13 +58,13 @@ Consult `src -h` and `src api -h` for usage information.
 Some Sourcegraph instances will be configured to require authentication. You can do so via the environment:
 
 ```sh
-SRC_ACCESS_TOKEN="secret" src ...
+SRC_ENDPOINT=https://sourcegraph.example.com SRC_ACCESS_TOKEN="secret" src ...
 ```
 
 Or via the configuration file (`~/src-config.json`):
 
 ```sh
-	{"accessToken": "secret"}
+	{"accessToken": "secret", "endpoint": "https://sourcegraph.example.com"}
 ```
 
 See `src -h` for more information on specifying access tokens.

--- a/cmd/src/extsvc.go
+++ b/cmd/src/extsvc.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+)
+
+var extsvcCommands commander
+
+func init() {
+	usage := `'src extsvc' is a tool that manages external services on a Sourcegraph instance.
+
+Usage:
+
+	src extsvc command [command options]
+
+The commands are:
+
+	list      lists the external services on the Sourcegraph instance
+
+Use "src extsvc [command] -h" for more information about a command.
+`
+
+	flagSet := flag.NewFlagSet("extsvc", flag.ExitOnError)
+	handler := func(args []string) error {
+		extsvcCommands.run(flagSet, "src extsvc", usage, args)
+		return nil
+	}
+
+	// Register the command.
+	commands = append(commands, &command{
+		flagSet: flagSet,
+		aliases: []string{"extsvc", "external-service"},
+		handler: handler,
+		usageFunc: func() {
+			fmt.Println(usage)
+		},
+	})
+}

--- a/cmd/src/extsvc.go
+++ b/cmd/src/extsvc.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 )
@@ -36,4 +37,32 @@ Use "src extsvc [command] -h" for more information about a command.
 			fmt.Println(usage)
 		},
 	})
+}
+
+func lookupExternalServiceByName(name string) (id string, err error) {
+	var result struct {
+		ExternalServices struct {
+			Nodes []struct {
+				DisplayName string
+				ID          string
+			}
+		}
+	}
+	err = (&apiRequest{
+		query: externalServicesListQuery,
+		vars: map[string]interface{}{
+			"first": 99999,
+		},
+		result: &result,
+	}).do()
+	for _, svc := range result.ExternalServices.Nodes {
+		if svc.DisplayName == name {
+			id = svc.ID
+			break
+		}
+	}
+	if id == "" {
+		return "", errors.New("no such external service")
+	}
+	return
 }

--- a/cmd/src/extsvc_edit.go
+++ b/cmd/src/extsvc_edit.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	isatty "github.com/mattn/go-isatty"
+)
+
+func init() {
+	usage := `
+Examples:
+
+  Edit an external service configuration on the Sourcegraph instance:
+
+    	$ cat new-config.json | src extsvc edit -id 'RXh0ZXJuYWxTZXJ2aWNlOjQ='
+    	$ src extsvc edit -name 'My GitHub connection' new-config.json
+
+  Edit an external service name on the Sourcegraph instance:
+
+    	$ src extsvc edit -name 'My GitHub connection' -rename 'New name'
+
+`
+
+	flagSet := flag.NewFlagSet("edit", flag.ExitOnError)
+	usageFunc := func() {
+		fmt.Fprintf(flag.CommandLine.Output(), "Usage of 'src extsvc %s':\n", flagSet.Name())
+		flagSet.PrintDefaults()
+		fmt.Println(usage)
+	}
+	var (
+		nameFlag   = flagSet.String("name", "", "exact name of the external service to edit")
+		idFlag     = flagSet.String("id", "", "ID of the external service to edit")
+		renameFlag = flagSet.String("rename", "", "when specified, renames the external service")
+		apiFlags   = newAPIFlags(flagSet)
+	)
+
+	handler := func(args []string) (err error) {
+		flagSet.Parse(args)
+
+		// Determine ID of external service we will edit.
+		if *nameFlag == "" && *idFlag == "" {
+			return &usageError{errors.New("one of -name or -id flag must be specified")}
+		}
+		id := *idFlag
+		if id == "" {
+			id, err = lookupExternalServiceByName(*nameFlag)
+			if err != nil {
+				return err
+			}
+		}
+
+		// Determine if we are updating the JSON configuration or not.
+		var updateJSON []byte
+		if len(flagSet.Args()) == 1 {
+			updateJSON, err = ioutil.ReadFile(flagSet.Arg(0))
+			if err != nil {
+				return err
+			}
+		}
+		if !isatty.IsTerminal(os.Stdin.Fd()) {
+			// stdin is a pipe not a terminal
+			updateJSON, err = ioutil.ReadAll(os.Stdin)
+			if err != nil {
+				return err
+			}
+		}
+
+		updateExternalServiceInput := map[string]interface{}{
+			"id": id,
+		}
+		if *renameFlag != "" {
+			updateExternalServiceInput["displayName"] = *renameFlag
+		}
+		if len(updateJSON) > 0 {
+			updateExternalServiceInput["config"] = string(updateJSON)
+		}
+		if len(updateExternalServiceInput) == 1 {
+			return nil // nothing to update
+		}
+
+		queryVars := map[string]interface{}{
+			"input": updateExternalServiceInput,
+		}
+		var result struct{} // TODO: future: allow formatting resulting external service
+		return (&apiRequest{
+			query:  externalServicesUpdateMutation,
+			vars:   queryVars,
+			result: &result,
+			done: func() error {
+				fmt.Println("External service updated:", id)
+				return nil
+			},
+			flags: apiFlags,
+		}).do()
+	}
+
+	// Register the command.
+	extsvcCommands = append(extsvcCommands, &command{
+		flagSet:   flagSet,
+		handler:   handler,
+		usageFunc: usageFunc,
+	})
+}
+
+const externalServicesUpdateMutation = `
+mutation ($input: UpdateExternalServiceInput!) {
+	updateExternalService(input: $input) {
+		id
+	}
+}
+`

--- a/cmd/src/extsvc_list.go
+++ b/cmd/src/extsvc_list.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+)
+
+func init() {
+	usage := `
+Examples:
+
+  List external service configurations on the Sourcegraph instance:
+
+    	$ src extsvc list
+
+  List external service configurations and choose output format:
+
+    	$ src extsvc list -f '{{.ID}}'
+
+`
+
+	flagSet := flag.NewFlagSet("list", flag.ExitOnError)
+	usageFunc := func() {
+		fmt.Fprintf(flag.CommandLine.Output(), "Usage of 'src extsvc %s':\n", flagSet.Name())
+		flagSet.PrintDefaults()
+		fmt.Println(usage)
+	}
+	var (
+		firstFlag  = flagSet.Int("first", -1, "Return only the first n external services. (use -1 for unlimited)")
+		formatFlag = flagSet.String("f", "", `Format for the output, using the syntax of Go package text/template. (e.g. "{{.|json}}")`)
+		apiFlags   = newAPIFlags(flagSet)
+	)
+
+	handler := func(args []string) error {
+		flagSet.Parse(args)
+
+		first := *firstFlag
+		if first == -1 {
+			first = 9999999 // GraphQL API doesn't support negative for unlimited query
+		}
+
+		var formatStr string
+		if *formatFlag != "" {
+			formatStr = *formatFlag
+		} else {
+			// Set default here instead of in flagSet.String because it is very long and makes the usage message ugly.
+			formatStr = `{{range .Nodes}}ID: {{.id}} | {{padRight .kind 15 " "}} | {{.displayName}}{{"\n"}}{{end}}`
+		}
+		tmpl, err := parseTemplate(formatStr)
+		if err != nil {
+			return err
+		}
+
+		queryVars := map[string]interface{}{
+			"first": first,
+		}
+		var result externalServicesListResult
+		return (&apiRequest{
+			query:  externalServicesListQuery,
+			vars:   queryVars,
+			result: &result,
+			done: func() error {
+				return execTemplate(tmpl, result.ExternalServices)
+			},
+			flags: apiFlags,
+		}).do()
+	}
+
+	// Register the command.
+	extsvcCommands = append(extsvcCommands, &command{
+		flagSet:   flagSet,
+		handler:   handler,
+		usageFunc: usageFunc,
+	})
+}
+
+const externalServicesListQuery = `
+	query ($first: Int!) {
+		externalServices(first: $first) {
+			nodes {
+				id
+				kind
+				displayName
+				config
+				createdAt
+				updatedAt
+			}
+			totalCount
+			pageInfo {
+				hasNextPage
+			}
+		}
+	}
+`
+
+// Typing here is primarily for ordering of results as we format them (maps are unordered).
+type externalServicesListResult struct {
+	ExternalServices struct {
+		Nodes      []map[string]interface{}
+		TotalCount int
+		PageInfo   struct {
+			HasNextPage bool
+		}
+	}
+}

--- a/cmd/src/main.go
+++ b/cmd/src/main.go
@@ -31,6 +31,7 @@ The commands are:
 	users,user      manages users
 	orgs,org        manages organizations
 	config          manages global, org, and user settings
+	extsvc          manages external services
 	extensions,ext  manages extensions (experimental)
 
 Use "src [command] -h" for more information about a command.

--- a/cmd/src/main.go
+++ b/cmd/src/main.go
@@ -92,6 +92,11 @@ func readConfig() (*config, error) {
 		cfg.Endpoint = strings.TrimSuffix(*endpoint, "/")
 	}
 	if cfg.Endpoint == "" {
+		if endpoint := os.Getenv("SRC_ENDPOINT"); endpoint != "" {
+			cfg.Endpoint = endpoint
+		}
+	}
+	if cfg.Endpoint == "" {
 		cfg.Endpoint = "https://sourcegraph.com"
 	}
 	return &cfg, nil

--- a/cmd/src/repos_list.go
+++ b/cmd/src/repos_list.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"strings"
 )
 
 func init() {
@@ -41,16 +42,17 @@ Examples:
 		firstFlag = flagSet.Int("first", 1000, "Returns the first n repositories from the list. (use -1 for unlimited)")
 		queryFlag = flagSet.String("query", "", `Returns repositories whose names match the query. (e.g. "myorg/")`)
 		// TODO: add support for "names" field.
-		enabledFlag         = flagSet.Bool("enabled", true, "Include enabled repositories.")
-		disabledFlag        = flagSet.Bool("disabled", false, "Include disabled repositories.")
-		clonedFlag          = flagSet.Bool("cloned", true, "Include cloned repositories.")
-		cloneInProgressFlag = flagSet.Bool("clone-in-progress", true, "Include repositories that are currently being cloned.")
-		notClonedFlag       = flagSet.Bool("not-cloned", true, "Include repositories that are not yet cloned and for which cloning is not in progress.")
-		indexedFlag         = flagSet.Bool("indexed", true, "Include repositories that have a text search index.")
-		notIndexedFlag      = flagSet.Bool("not-indexed", true, "Include repositories that do not have a text search index.")
-		orderByFlag         = flagSet.String("order-by", "name", `How to order the results; possible choices are: "name", "created-at"`)
-		descendingFlag      = flagSet.Bool("descending", false, "Whether or not results should be in descending order.")
-		apiFlags            = newAPIFlags(flagSet)
+		enabledFlag          = flagSet.Bool("enabled", true, "Include enabled repositories.")
+		disabledFlag         = flagSet.Bool("disabled", false, "Include disabled repositories.")
+		clonedFlag           = flagSet.Bool("cloned", true, "Include cloned repositories.")
+		cloneInProgressFlag  = flagSet.Bool("clone-in-progress", true, "Include repositories that are currently being cloned.")
+		notClonedFlag        = flagSet.Bool("not-cloned", true, "Include repositories that are not yet cloned and for which cloning is not in progress.")
+		indexedFlag          = flagSet.Bool("indexed", true, "Include repositories that have a text search index.")
+		notIndexedFlag       = flagSet.Bool("not-indexed", true, "Include repositories that do not have a text search index.")
+		orderByFlag          = flagSet.String("order-by", "name", `How to order the results; possible choices are: "name", "created-at"`)
+		descendingFlag       = flagSet.Bool("descending", false, "Whether or not results should be in descending order.")
+		namesWithoutHostFlag = flagSet.Bool("names-without-host", false, "Whether or not repository names should be printed without the code host (new form)")
+		apiFlags             = newAPIFlags(flagSet)
 	)
 
 	handler := func(args []string) error {
@@ -123,6 +125,11 @@ Examples:
 			result: &result,
 			done: func() error {
 				for _, repo := range result.Repositories.Nodes {
+					if *namesWithoutHostFlag {
+						firstSlash := strings.Index(repo.Name, "/")
+						fmt.Println(repo.Name[firstSlash+len("/"):])
+						continue
+					}
 					fmt.Println(repo.Name)
 				}
 				return nil

--- a/cmd/src/testdata/search_formatting/basic-diff.want.txt
+++ b/cmd/src/testdata/search_formatting/basic-diff.want.txt
@@ -24,7 +24,7 @@
 
 [38;5;239m--------------------------------------------------------------------------------
 [0m[38;5;239m([0m[38;5;237mhttps://sourcegraph.com/github.com/golang/oauth2/-/commit/088f8e1d436e8d636f13cd83a345b3d6ff2f04ae[0m[38;5;239m)
-[0m[0m[38;5;23mgithub.com/golang/oauth2[0m › [38;5;2mGuillaume J. Charmes[0m [38;5;68m"oauth2: Add support for custom params in Exchange"[0m [38;5;23m(N months ago)[0m
+[0m[0m[38;5;23mgithub.com/golang/oauth2[0m › [38;5;2mGuillaume J. Charmes[0m [38;5;68m"oauth2: Add support for custom params in Exchange"[0m [38;5;23m(1 year ago)[0m
 [38;5;239m--------------------------------------------------------------------------------
 [0m  diff --git oauth2.go oauth2.go
   index 10299d2..16775d0 100644


### PR DESCRIPTION
This PR adds support for querying repositories by name (e.g. `/secretrepos/`) and passing that list of repositories into a command that adds them to the `exclude` list in the external service configuration.

For example, it is possible to write this script now to add all repositories with `/secretrepos/` in their name to the exclusion list of all external services:

```
# Determine which repositories we will exclude.
repos_to_exclude=$(src -config=./src-config.json repos list -first="-1" -names-without-host -query="/secretrepos/")

# Determine which external service configurations we need to update.
extsvcs=$(src -config=./src-config.json extsvc list -f '{{range .Nodes}}{{.id}} {{end}}')

# edit the configuration to exclude the repositories
echo "$extsvcs" | xargs -n1 -I {} src -config=./src-config.json extsvc edit -id '{}' -exclude-repos "$repos_to_exclude"
```

Previously we maintained backwards compatibility for `setRepositoryEnablement` in the GraphQL API which was used for this purpose, but because it resulted in updating the config once per repository it became VERY slow (unusable slow). This approach is much faster as you can add thousands at once instead of individually.

For https://app.hubspot.com/contacts/2762526/company/407948923 