### PR TITLE
repos: Use REPOSITORY_NAME for order by

### DIFF
--- a/cmd/src/repos_list.go
+++ b/cmd/src/repos_list.go
@@ -93,7 +93,7 @@ Examples:
 		var orderBy string
 		switch *orderByFlag {
 		case "name":
-			orderBy = "REPO_URI"
+			orderBy = "REPOSITORY_NAME"
 		case "created-at":
 			orderBy = "REPO_CREATED_AT"
 		default:

--- a/cmd/src/search_test.go
+++ b/cmd/src/search_test.go
@@ -113,11 +113,11 @@ func TestSearchOutput(t *testing.T) {
 	}
 }
 
-var nMonthsAgoPattern = regexp.MustCompile(`\d+ months? ago`)
+var nTimeAgoPattern = regexp.MustCompile(`(\d+|N) (months?|years?|time) ago`)
 
 // normalizeTimeAgo makes tests not depend on the current time.
 func normalizeTimeAgo(s *string) {
-	*s = nMonthsAgoPattern.ReplaceAllString(*s, "N months ago")
+	*s = nTimeAgoPattern.ReplaceAllString(*s, "N time ago")
 }
 
 func TestBuildVersionHasNewSearchInterface(t *testing.T) {


### PR DESCRIPTION
REPO_URI has been deprecated for many months. This is the only known client of
the deprecated enum.

Part of https://github.com/sourcegraph/sourcegraph/issues/680