### PR TITLE
Add `campaigns add-changesets` subcommand

### DIFF
--- a/cmd/src/campaigns.go
+++ b/cmd/src/campaigns.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+)
+
+var campaignsCommands commander
+
+func init() {
+	usage := `'src campaigns' is a tool that manages campaigns on a Sourcegraph instance.
+
+EXPERIMENTAL: Campaigns are experimental functionality on Sourcegraph and in the 'src' tool.
+
+Usage:
+
+	src campaigns command [command options]
+
+The commands are:
+
+	add-changesets    add changesets of a given repository to a campaign
+
+Use "src campaigns [command] -h" for more information about a command.
+`
+
+	flagSet := flag.NewFlagSet("campaigns", flag.ExitOnError)
+	handler := func(args []string) error {
+		campaignsCommands.run(flagSet, "src campaigns", usage, args)
+		return nil
+	}
+
+	// Register the command.
+	commands = append(commands, &command{
+		flagSet: flagSet,
+		handler: handler,
+		usageFunc: func() {
+			fmt.Println(usage)
+		},
+	})
+}

--- a/cmd/src/campaigns_add_changesets.go
+++ b/cmd/src/campaigns_add_changesets.go
@@ -12,17 +12,17 @@ Add changesets for a given repository to a campaign.
 
 Usage:
 
-	src campaigns add-changesets -campaign-id <id> -repo-name <name> [external changeset IDs...]
+	src campaigns add-changesets -campaign <id> -repo-name <name> [external changeset IDs...]
 
 Examples:
 
-  Add GitHub pull requests #5662 and #5366 for repository "github.com/sourcegraph/sourcegraph" to the Sourcegraph campaign with GraphQL ID "Q2FtcGFpZ246MQ=="
+  Add GitHub pull requests #5662 and #5366 for repository "github.com/sourcegraph/sourcegraph" to the Sourcegraph campaign with GraphQL ID "Q2FtcGFpZ246MQ==":
 
-    	$ src campaigns add-changesets -campaign-id=Q2FtcGFpZ246MQ== -repo-name=github.com/sourcegraph/sourcegraph 5662 5366
+    	$ src campaigns add-changesets -campaign=Q2FtcGFpZ246MQ== -repo-name=github.com/sourcegraph/sourcegraph 5662 5366
 
   Then we can add pull requests from another repository, "github.com/sourcegraph/src-cli" to the same campaign:
 
-    	$ src campaigns add-changesets -campaign-id=Q2FtcGFpZ246MQ== -repo-name=github.com/sourcegraph/src-cli 33 41
+    	$ src campaigns add-changesets -campaign=Q2FtcGFpZ246MQ== -repo-name=github.com/sourcegraph/src-cli 33 41
 
 Notes:
 
@@ -38,7 +38,7 @@ Notes:
 		fmt.Println(usage)
 	}
 	var (
-		campaignIDFlag = flagSet.String("campaign-id", "", "ID of campaign to which to add changesets. (required)")
+		campaignIDFlag = flagSet.String("campaign", "", "ID of campaign to which to add changesets. (required)")
 		repoNameFlag   = flagSet.String("repo-name", "", "Name of repository to which the changesets belong. (required)")
 		apiFlags       = newAPIFlags(flagSet)
 	)
@@ -47,7 +47,7 @@ Notes:
 		flagSet.Parse(args)
 
 		if *campaignIDFlag == "" {
-			return &usageError{errors.New("-campaign-id must be specified")}
+			return &usageError{errors.New("-campaign must be specified")}
 		}
 
 		if *repoNameFlag == "" {

--- a/cmd/src/campaigns_add_changesets.go
+++ b/cmd/src/campaigns_add_changesets.go
@@ -1,0 +1,196 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+)
+
+func init() {
+	usage := `
+Add changesets for a given repository to a campaign.
+
+Usage:
+
+	src campaigns add-changesets -campaign-id <id> -repo-name <name> [external changeset IDs...]
+
+Examples:
+
+  Add GitHub pull requests #5662 and #5366 for repository "github.com/sourcegraph/sourcegraph" to the Sourcegraph campaign with GraphQL ID "Q2FtcGFpZ246MQ=="
+
+    	$ src campaigns add-changesets -campaign-id=Q2FtcGFpZ246MQ== -repo-name=github.com/sourcegraph/sourcegraph 5662 5366
+
+  Then we can add pull requests from another repository, "github.com/sourcegraph/src-cli" to the same campaign:
+
+    	$ src campaigns add-changesets -campaign-id=Q2FtcGFpZ246MQ== -repo-name=github.com/sourcegraph/src-cli 33 41
+
+Notes:
+
+  You can NOT add changesets to a campaign if the repository is not mirrored on the Sourcegraph instance.
+
+  The repository names are the names you get when you run "src repos list".
+`
+
+	flagSet := flag.NewFlagSet("add-changesets", flag.ExitOnError)
+	usageFunc := func() {
+		fmt.Fprintf(flag.CommandLine.Output(), "Usage of 'src campaigns %s':\n", flagSet.Name())
+		flagSet.PrintDefaults()
+		fmt.Println(usage)
+	}
+	var (
+		campaignIDFlag = flagSet.String("campaign-id", "", "ID of campaign to which to add changesets. (required)")
+		repoNameFlag   = flagSet.String("repo-name", "", "Name of repository to which the changesets belong. (required)")
+		apiFlags       = newAPIFlags(flagSet)
+	)
+
+	handler := func(args []string) error {
+		flagSet.Parse(args)
+
+		if *campaignIDFlag == "" {
+			return &usageError{errors.New("-campaign-id must be specified")}
+		}
+
+		if *repoNameFlag == "" {
+			return &usageError{errors.New("-repo-name must be specified")}
+		}
+
+		if len(args) <= 4 {
+			return &usageError{errors.New("no external changeset IDs specified")}
+		}
+
+		externalIDs := args[4:]
+
+		repoID, err := getRepoID(apiFlags, *repoNameFlag)
+		if err != nil {
+			return err
+		}
+
+		changesetIDs, err := createChangesets(apiFlags, repoID, externalIDs)
+		if err != nil {
+			return err
+		}
+
+		err = addChangesets(apiFlags, *campaignIDFlag, changesetIDs)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	// Register the command.
+	campaignsCommands = append(campaignsCommands, &command{
+		flagSet:   flagSet,
+		handler:   handler,
+		usageFunc: usageFunc,
+	})
+
+	// Catch the mistake of omitting the "extensions" subcommand.
+	commands = append(commands, didYouMeanOtherCommand("add-changesets", []string{"campaigns add-changesets"}))
+}
+
+const getRepoIDQuery = `query Repository($name: String) { repository(name: $name) { id } }`
+
+func getRepoID(f *apiFlags, name string) (string, error) {
+	var result struct{ Repository struct{ ID string } }
+
+	req := &apiRequest{
+		query:  getRepoIDQuery,
+		vars:   map[string]interface{}{"name": name},
+		result: &result,
+		flags:  f,
+	}
+
+	err := req.do()
+	if err != nil {
+		return "", err
+	}
+
+	return result.Repository.ID, err
+}
+
+const createChangesetsQuery = `
+mutation CreateChangesets($input: [CreateChangesetInput!]!) {
+  createChangesets(input: $input) {
+    id
+  }
+}`
+
+func createChangesets(f *apiFlags, repoID string, externalIDs []string) ([]string, error) {
+	var result struct {
+		CreateChangesets []struct {
+			ID string `json:"id"`
+		} `json:"createChangesets"`
+	}
+
+	pairs := make([]map[string]interface{}, len(externalIDs))
+	for i, id := range externalIDs {
+		pairs[i] = map[string]interface{}{
+			"repository": repoID,
+			"externalID": id,
+		}
+	}
+
+	var changesetIDs []string
+
+	req := &apiRequest{
+		query:  createChangesetsQuery,
+		vars:   map[string]interface{}{"input": pairs},
+		result: &result,
+		flags:  f,
+	}
+
+	err := req.do()
+	if err != nil {
+		return changesetIDs, err
+	}
+
+	for _, c := range result.CreateChangesets {
+		changesetIDs = append(changesetIDs, c.ID)
+	}
+
+	fmt.Printf("Created %d changesets.\n", len(changesetIDs))
+
+	return changesetIDs, err
+}
+
+const addChangesetsQuery = `
+mutation AddChangesetsToCampaign($campaign: ID!, $changesets: [ID!]!) {
+  addChangesetsToCampaign(campaign: $campaign, changesets: $changesets) {
+	id
+	changesets {
+      totalCount
+    }
+  }
+}
+`
+
+func addChangesets(f *apiFlags, campaignID string, changesetIDs []string) error {
+	var result struct {
+		AddChangesetsToCampaign struct {
+			ID         string `json:"id"`
+			Changesets struct {
+				TotalCount int `json:"totalCount"`
+			} `json:"changesets"`
+		} `json:"addChangesetsToCampaign"`
+	}
+
+	req := &apiRequest{
+		query: addChangesetsQuery,
+		vars: map[string]interface{}{
+			"campaign":   campaignID,
+			"changesets": changesetIDs,
+		},
+		result: &result,
+		flags:  f,
+	}
+
+	err := req.do()
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Added changeset to campaign. Changesets now in campaign: %d\n", result.AddChangesetsToCampaign.Changesets.TotalCount)
+
+	return err
+}

--- a/cmd/src/campaigns_add_changesets.go
+++ b/cmd/src/campaigns_add_changesets.go
@@ -157,8 +157,8 @@ func createChangesets(f *apiFlags, repoID string, externalIDs []string) ([]strin
 const addChangesetsQuery = `
 mutation AddChangesetsToCampaign($campaign: ID!, $changesets: [ID!]!) {
   addChangesetsToCampaign(campaign: $campaign, changesets: $changesets) {
-	id
-	changesets {
+    id
+    changesets {
       totalCount
     }
   }


### PR DESCRIPTION
This adds the changesets with the given external IDs to the given
campaign.

### Example:

    $ src campaigns add-changesets -campaign-id Q2FtcGFpZ246NA== -repo-name github.com/sourcegraph/sourcegraph 5016 5017 5018
    Created 3 changesets.
    Added changeset to campaign. Changesets now in campaign: 10


### Current downsides

(These are mostly due to how our API works with batches and could be fixed on the API side, collecting these just here for documentation/transparency)

* When one of the changeset already exists, the command fails with:

```
[
  {
    "message": "pq: duplicate key value violates unique constraint \"changesets_repo_external_id_unique\"",
    "path": [
      "createChangesets"
    ]
  }
]
```

* When one of the external IDs specified is invalid (non existant, for example), it creates the rest silently but returns an error message for the single invalid one:

```
[
  {
    "message": "error in GraphQL response: Could not resolve to a PullRequest with the number of 5013.",
    "path": [
      "createChangesets"
    ]
  }
]
```