### PR TITLE
Add `campaigns list` subcommand

### DIFF
--- a/cmd/src/campaigns.go
+++ b/cmd/src/campaigns.go
@@ -18,6 +18,7 @@ Usage:
 
 The commands are:
 
+	list              lists campaigns
 	add-changesets    add changesets of a given repository to a campaign
 
 Use "src campaigns [command] -h" for more information about a command.

--- a/cmd/src/campaigns_list.go
+++ b/cmd/src/campaigns_list.go
@@ -31,7 +31,7 @@ Examples:
 		fmt.Println(usage)
 	}
 	var (
-		firstFlag  = flagSet.Int("first", 1000, "Returns the first n repositories from the list. (use -1 for unlimited)")
+		firstFlag  = flagSet.Int("first", 1000, "Returns the first n campaigns.")
 		formatFlag = flagSet.String("f", "{{.ID}}: {{.Name}}", `Format for the output, using the syntax of Go package text/template. (e.g. "{{.ID}}: {{.Name}}") or "{{.|json}}")`)
 		apiFlags   = newAPIFlags(flagSet)
 	)

--- a/cmd/src/campaigns_list.go
+++ b/cmd/src/campaigns_list.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"time"
+)
+
+func init() {
+	usage := `
+Examples:
+
+  List campaigns (default limit is 1000):
+
+    	$ src campaigns list
+
+  List only the first 5 campaigns:
+
+    	$ src campaigns list -first=5
+
+  List campaigns and only print their IDs (default is to print ID and Name):
+
+    	$ src campaigns list -first=5 -f '{{.ID}}'
+
+`
+
+	flagSet := flag.NewFlagSet("list", flag.ExitOnError)
+	usageFunc := func() {
+		fmt.Fprintf(flag.CommandLine.Output(), "Usage of 'src repos %s':\n", flagSet.Name())
+		flagSet.PrintDefaults()
+		fmt.Println(usage)
+	}
+	var (
+		firstFlag  = flagSet.Int("first", 1000, "Returns the first n repositories from the list. (use -1 for unlimited)")
+		formatFlag = flagSet.String("f", "{{.ID}}: {{.Name}}", `Format for the output, using the syntax of Go package text/template. (e.g. "{{.ID}}: {{.Name}}") or "{{.|json}}")`)
+		apiFlags   = newAPIFlags(flagSet)
+	)
+
+	handler := func(args []string) error {
+		flagSet.Parse(args)
+
+		tmpl, err := parseTemplate(*formatFlag)
+		if err != nil {
+			return err
+		}
+
+		query := `query Campaigns($first: Int) {
+  campaigns(first: $first) {
+    nodes {
+      id
+      name
+      description
+      createdAt
+      updatedAt
+
+      changesets {
+        nodes {
+          id
+          state
+          reviewState
+          repository {
+            id
+            name
+          }
+          externalURL {
+            url
+            serviceType
+          }
+          createdAt
+          updatedAt
+        }
+        totalCount
+      }
+    }
+  }
+}
+`
+
+		var result struct {
+			Campaigns struct {
+				Nodes []struct {
+					ID          string
+					Name        string
+					Description string
+					CreatedAt   time.Time
+					UpdatedAt   time.Time
+					Changesets  struct {
+						Nodes []struct {
+							ID          string
+							State       string
+							ReviewState string
+							Repository  struct {
+								ID   string
+								Name string
+							}
+							ExternalURL struct {
+								URL         string
+								ServiceType string
+							}
+							CreatedAt time.Time
+							UpdatedAt time.Time
+						}
+						TotalCount int
+					}
+				}
+			}
+		}
+
+		return (&apiRequest{
+			query:  query,
+			vars:   map[string]interface{}{"first": nullInt(*firstFlag)},
+			result: &result,
+			done: func() error {
+				for _, c := range result.Campaigns.Nodes {
+					if err := execTemplate(tmpl, c); err != nil {
+						return err
+					}
+				}
+				return nil
+			},
+			flags: apiFlags,
+		}).do()
+	}
+
+	// Register the command.
+	campaignsCommands = append(campaignsCommands, &command{
+		flagSet:   flagSet,
+		handler:   handler,
+		usageFunc: usageFunc,
+	})
+}


### PR DESCRIPTION
This allows the users to list campaigns and get the campaign IDs they
need to use the `campaigns add-changesets` command.

The default rendering template is `{{.ID}}: {{.Name}}` but users can
specify more fields or get a JSON dump of all of them with the described
`{{.|json}}` pipe:

    $ src campaigns list -first 1
    Q2FtcGFpZ246NA==: testing the src cli

    $ src campaigns list -first 1 -f '{{. |json}}' | jq .
    {
      "ID": "Q2FtcGFpZ246NA==",
      "Name": "testing the src cli",
      "Description": "This campaign is here to test the `src` cli tool.",
      "CreatedAt": "2019-09-20T05:49:54Z",
      "UpdatedAt": "2019-09-20T13:07:55Z",
      "Changesets": {
        "Nodes": [
          {
            "ID": "Q2hhbmdlc2V0OjM1",
            "State": "CLOSED",
            "ReviewState": "APPROVED",
            "Repository": {
              "ID": "UmVwb3NpdG9yeTo0Mg==",
              "Name": "github.com/sourcegraph/sourcegraph"
            },
            "ExternalURL": {
              "URL": "https://github.com/sourcegraph/sourcegraph/pull/5003",
              "ServiceType": "github"
            },
            "CreatedAt": "2019-09-20T06:30:20Z",
            "UpdatedAt": "2019-09-20T13:32:04Z"
          },
          {
            "ID": "Q2hhbmdlc2V0OjM5",
            "State": "MERGED",
            "ReviewState": "APPROVED",
            "Repository": {
              "ID": "UmVwb3NpdG9yeTo0Mg==",
              "Name": "github.com/sourcegraph/sourcegraph"
            },
            "ExternalURL": {
              "URL": "https://github.com/sourcegraph/sourcegraph/pull/5005",
              "ServiceType": "github"
            },
            "CreatedAt": "2019-09-20T06:32:14Z",
            "UpdatedAt": "2019-09-20T13:32:04Z"
          }
        ],
        "TotalCount": 2
      }
    }