### PR TITLE
Fix "off by two" error when checking for args

### DIFF
--- a/cmd/src/campaigns_add_changesets.go
+++ b/cmd/src/campaigns_add_changesets.go
@@ -54,11 +54,11 @@ Notes:
 			return &usageError{errors.New("-repo-name must be specified")}
 		}
 
-		if len(args) <= 4 {
+		if len(args) <= 2 {
 			return &usageError{errors.New("no external changeset IDs specified")}
 		}
 
-		externalIDs := args[4:]
+		externalIDs := args[2:]
 
 		repoID, err := getRepoID(apiFlags, *repoNameFlag)
 		if err != nil {


### PR DESCRIPTION
I don't know how I previously came up with 4, but as it turns out if you
run this

    src campaigns add-changesets -campaign='Q2FtcGFpZ246MQ==' -repo-name=github.com/sourcegraph/sourcegraph 33 44 55 66

The IDs `33` and `44` are ignored.

This fixes the issue.