### PR TITLE
Check for status code 202 on LSIF upload

### DIFF
--- a/cmd/src/lsif_upload.go
+++ b/cmd/src/lsif_upload.go
@@ -135,7 +135,7 @@ Examples:
 		// Our request may have failed before the reaching GraphQL endpoint, so
 		// confirm the status code. You can test this easily with e.g. an invalid
 		// endpoint like -endpoint=https://google.com
-		if resp.StatusCode != http.StatusOK {
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 			body, err := ioutil.ReadAll(resp.Body)
 			if err != nil {
 				return err


### PR DESCRIPTION
PR https://github.com/sourcegraph/sourcegraph/pull/6227 changed the
status code from `201` to `202`.

That broke the check here and resulted in an `error: 202 Accepted` being
printed.

And the exit code is checked in
https://github.com/sourcegraph/lsif-upload-action, which runs on every
PR in sourcegrah/sourcegraph