### PR TITLE
LSIF: strip slash prefix

### DIFF
--- a/cmd/src/lsif_upload.go
+++ b/cmd/src/lsif_upload.go
@@ -265,7 +265,7 @@ func parseRemoteURL(urlString string) (string, error) {
 		if len(parts) != 2 {
 			return "", fmt.Errorf("unrecognized remote URL: %s", urlString)
 		}
-		return strings.TrimPrefix(parts[0], "git@") + "/" + strings.TrimSuffix(parts[1], ".git"), nil
+		return strings.TrimPrefix(parts[0], "git@") + "/" + strings.TrimPrefix(strings.TrimSuffix(parts[1], ".git"), "/"), nil
 	}
 
 	remoteURL, err := url.Parse(urlString)


### PR DESCRIPTION
Sometimes there's a leading slash in git URIs:

```
git remote -vv
origin	git@github.com:/sourcegraph/lsif-java (fetch)
origin	git@github.com:/sourcegraph/lsif-java (push)
```