### PR TITLE
highlight structural search results

### DIFF
--- a/cmd/src/search.go
+++ b/cmd/src/search.go
@@ -541,7 +541,7 @@ const searchResultsTemplate = `{{- /* ignore this line for template formatting s
 			{{- color "search-repository"}}{{.repository.name}}{{color "nc" -}}
 			{{- " › " -}}
 			{{- color "search-filename"}}{{.file.name}}{{color "nc" -}}
-                        {{- /* Rijnard hack deletes number of matches b/c it relies on lines and is wrong for multiline */ -}}
+                        {{- color "success"}}{{" ("}}{{len .lineMatches}}{{" matches)"}}{{color "nc" -}}
 			{{- "\n" -}}
 			{{- color "search-border"}}{{"--------------------------------------------------------------------------------\n"}}{{color "nc"}}
 

--- a/cmd/src/search.go
+++ b/cmd/src/search.go
@@ -541,7 +541,7 @@ const searchResultsTemplate = `{{- /* ignore this line for template formatting s
 			{{- color "search-repository"}}{{.repository.name}}{{color "nc" -}}
 			{{- " › " -}}
 			{{- color "search-filename"}}{{.file.name}}{{color "nc" -}}
-                        {{- color "success"}}{{" ("}}{{len .lineMatches}}{{" matches)"}}{{color "nc" -}}
+			{{- color "success"}}{{" ("}}{{len .lineMatches}}{{" matches)"}}{{color "nc" -}}
 			{{- "\n" -}}
 			{{- color "search-border"}}{{"--------------------------------------------------------------------------------\n"}}{{color "nc"}}
 


### PR DESCRIPTION
Problem: search highlight function highlights relative to preview instead of the line that the FileMatch highlight ranges correspond to in file. Need access to file and line.