### PR TITLE
fix graphql extensions query

### DIFF
--- a/cmd/src/extensions.go
+++ b/cmd/src/extensions.go
@@ -59,7 +59,6 @@ fragment RegistryExtensionFields on RegistryExtension {
     isLocal
     manifest {
         raw
-        title
         description
         bundleURL
     }

--- a/cmd/src/extensions_list.go
+++ b/cmd/src/extensions_list.go
@@ -32,7 +32,7 @@ Examples:
 	var (
 		firstFlag  = flagSet.Int("first", 1000, "Returns the first n extensions from the list. (use -1 for unlimited)")
 		queryFlag  = flagSet.String("query", "", `Returns extensions whose extension IDs match the query. (e.g. "myextension")`)
-		formatFlag = flagSet.String("f", "{{.ExtensionID}}", `Format for the output, using the syntax of Go package text/template. (e.g. "{{.ExtensionID}}: {{.Manifest.Title}} ({{.RemoteURL}})" or "{{.|json}}")`)
+		formatFlag = flagSet.String("f", "{{.ExtensionID}}", `Format for the output, using the syntax of Go package text/template. (e.g. "{{.ExtensionID}}: {{.Manifest.Description}} ({{.RemoteURL}})" or "{{.|json}}")`)
 		apiFlags   = newAPIFlags(flagSet)
 	)
 


### PR DESCRIPTION
The extension manifest used to contain a "title" field, but that was phased out a while ago in favor of just having a name. The `src extensions list` command and other subcommands still tried to fetch the manifest title, which resulted in the following error:

```
GraphQL errors:
[
  {
    "locations": [
      {
        "column": 9,
        "line": 29
      }
    ],
    "message": "Cannot query field \"title\" on type \"ExtensionManifest\"."
  }
]
```

This fixes the GraphQL query to not use the (nonexistent) title field anymore.