### PR TITLE
add file highlighting for structural search

### DIFF
--- a/cmd/src/search.go
+++ b/cmd/src/search.go
@@ -424,11 +424,11 @@ type highlight struct {
 // relative to the whole file, and can add lines of context around the
 // highlighted range. It makes no assumptions about the preview field in
 // LineMatches (the preview field is not used).
-func applyHighlightsForFile(fileContent *string, highlights []highlight) string {
+func applyHighlightsForFile(fileContent string, highlights []highlight) string {
 	var result []rune
 	start := ansiColors["search-match"]
 	end := ansiColors["nc"]
-	lines := strings.Split(*fileContent, "\n")
+	lines := strings.Split(fileContent, "\n")
 	for _, highlight := range highlights {
 		line := lines[highlight.line]
 		for characterIndex, character := range []rune(line + "\n") {
@@ -503,8 +503,7 @@ var searchTemplateFuncs = map[string]interface{}{
 		var highlights []highlight
 		if strings.Contains(q, "patterntype:structural") {
 			highlights = convertMatchToHighlights(m, false)
-			c := content.(string)
-			return applyHighlightsForFile(&c, highlights)
+			return applyHighlightsForFile(content.(string), highlights)
 		} else {
 			preview := m["preview"].(string)
 			highlights = convertMatchToHighlights(m, true)

--- a/cmd/src/search.go
+++ b/cmd/src/search.go
@@ -107,6 +107,7 @@ Other tips:
 					name
 					path
 					url
+					content
 					commit {
 						oid
 					}
@@ -419,6 +420,31 @@ type highlight struct {
 	length    int // the 1-indexed length of the highlight, in characters.
 }
 
+// applyHighlightsForFile expects highlight information that is
+// relative to the whole file, and can add lines of context around the
+// highlighted range. It makes no assumptions about the preview field in
+// LineMatches (the preview field is not used).
+func applyHighlightsForFile(fileContent *string, highlights []highlight) string {
+	var result []rune
+	start := ansiColors["search-match"]
+	end := ansiColors["nc"]
+	lines := strings.Split(*fileContent, "\n")
+	for _, highlight := range highlights {
+		line := lines[highlight.line]
+		for characterIndex, character := range []rune(line + "\n") {
+			if characterIndex == highlight.character {
+				result = append(result, []rune(start)...)
+			} else if characterIndex == highlight.character+highlight.length {
+				result = append(result, []rune(end)...)
+			}
+			result = append(result, character)
+		}
+	}
+	return string(result)
+}
+
+// applyHighlights expects highlight information that applies relative to lines in
+// the input string, where the input string corresponds to the preview field in LineMatches.
 func applyHighlights(input string, highlights []highlight, start, end string) string {
 	var result []rune
 	lines := strings.Split(input, "\n")
@@ -440,6 +466,27 @@ func applyHighlights(input string, highlights []highlight, start, end string) st
 	return string(result)
 }
 
+// convertMatchToHighlights converts a FileMatch m to a highlight data type.
+// When isPreview is true, it is assumed that the result to highlight is only on
+// one line, and the offets are relative to this line. When isPreview is false,
+// the lineNumber from the FileMatch data is used, which is relative to the file
+// content.
+func convertMatchToHighlights(m map[string]interface{}, isPreview bool) (highlights []highlight) {
+	var line int
+	for _, offsetAndLength := range m["offsetAndLengths"].([]interface{}) {
+		ol := offsetAndLength.([]interface{})
+		offset := int(ol[0].(float64))
+		length := int(ol[1].(float64))
+		if isPreview {
+			line = 1
+		} else {
+			line = int(m["lineNumber"].(float64))
+		}
+		highlights = append(highlights, highlight{line: line, character: offset, length: length})
+	}
+	return highlights
+}
+
 var searchTemplateFuncs = map[string]interface{}{
 	"searchSequentialLineNumber": func(lineMatches []interface{}, index int) bool {
 		prevIndex := index - 1
@@ -450,17 +497,19 @@ var searchTemplateFuncs = map[string]interface{}{
 		lineNumber := lineMatches[index].(map[string]interface{})["lineNumber"]
 		return prevLineNumber.(float64) == lineNumber.(float64)-1
 	},
-	"searchHighlightMatch": func(match interface{}) string {
+	"searchHighlightMatch": func(content, query, match interface{}) string {
 		m := match.(map[string]interface{})
-		preview := m["preview"].(string)
+		q := query.(string)
 		var highlights []highlight
-		for _, offsetAndLength := range m["offsetAndLengths"].([]interface{}) {
-			ol := offsetAndLength.([]interface{})
-			offset := int(ol[0].(float64))
-			length := int(ol[1].(float64))
-			highlights = append(highlights, highlight{line: 1, character: offset, length: length})
+		if strings.Contains(q, "patterntype:structural") {
+			highlights = convertMatchToHighlights(m, false)
+			c := content.(string)
+			return applyHighlightsForFile(&c, highlights)
+		} else {
+			preview := m["preview"].(string)
+			highlights = convertMatchToHighlights(m, true)
+			return applyHighlights(preview, highlights, ansiColors["search-match"], ansiColors["nc"])
 		}
-		return applyHighlights(preview, highlights, ansiColors["search-match"], ansiColors["nc"])
 	},
 	"searchHighlightPreview": func(preview interface{}) string {
 		return searchHighlightPreview(preview, "", "")
@@ -549,12 +598,13 @@ const searchResultsTemplate = `{{- /* ignore this line for template formatting s
 
 			{{- /* Line matches */ -}}
 			{{- $lineMatches := .lineMatches -}}
+			{{- $content := .file.content -}}
 			{{- range $index, $match := $lineMatches -}}
 				{{- if not (searchSequentialLineNumber $lineMatches $index) -}}
 					{{- color "search-border"}}{{"  ------------------------------------------------------------------------------\n"}}{{color "nc"}}
 				{{- end -}}
 				{{- "  "}}{{color "search-line-numbers"}}{{pad (addFloat $match.lineNumber 1) 6 " "}}{{color "nc" -}}
-				{{- color "search-border"}}{{" |  "}}{{color "nc"}}{{searchHighlightMatch $match}}
+				{{- color "search-border"}}{{" |  "}}{{color "nc"}}{{searchHighlightMatch $content $.Query $match}}
 			{{- end -}}
 		{{- end -}}
 

--- a/cmd/src/testdata/search_formatting/highlight-structural-search.test.json
+++ b/cmd/src/testdata/search_formatting/highlight-structural-search.test.json
@@ -1,0 +1,210 @@
+{
+    "Cloning": [],
+    "ElapsedMilliseconds": 18,
+    "LimitHit": false,
+    "Missing": [],
+    "Query": "patterntype:structural 'WriteObject(:[args]) error {:[body]}' lang:go count:1000 file:pkg/io/config_store.go",
+    "ResultCount": 20,
+    "Results": [
+        {
+            "__typename": "FileMatch",
+            "file": {
+"content": "package io\n\nimport (\n\t\"fmt\"\n\t\"io/ioutil\"\n\n\t\"github.com/ghodss/yaml\"\n\t\"github.com/jenkins-x/jx/pkg/util\"\n\t\"github.com/jenkins-x/jx/pkg/vault\"\n\t\"github.com/pkg/errors\"\n)\n\n// ConfigStore provides an interface for storing configs\ntype ConfigStore interface {\n\t// Write saves some secret data to the store\n\tWrite(name string, bytes []byte) error\n\n\t// Read reads some secret data from the store\n\tRead(name string) ([]byte, error)\n\n\t// WriteObject writes a named object to the store\n\tWriteObject(name string, object interface{}) error\n\n\t// ReadObject reads an object from the store\n\tReadObject(name string, object interface{}) error\n}\n\ntype fileStore struct {\n}\n\n// NewFileStore creates a ConfigStore that stores its data to the filesystem\nfunc NewFileStore() ConfigStore {\n\treturn &fileStore{}\n}\n\n// Write writes a secret to the filesystem\nfunc (f *fileStore) Write(fileName string, bytes []byte) error {\n\treturn ioutil.WriteFile(fileName, bytes, util.DefaultWritePermissions)\n}\n\n// WriteObject writes a secret to the filesystem in YAML format\nfunc (f *fileStore) WriteObject(fileName string, object interface{}) error {\n\ty, err := yaml.Marshal(object)\n\tif err != nil {\n\t\treturn errors.Wrapf(err, \"unable to marshal object to yaml: %v\", object)\n\t}\n\treturn f.Write(fileName, y)\n}\n\n// Read reads a secret form the filesystem\nfunc (f *fileStore) Read(fileName string) ([]byte, error) {\n\treturn ioutil.ReadFile(fileName)\n}\n\n// ReadObject reads an object from the filesystem as yaml\nfunc (f *fileStore) ReadObject(fileName string, object interface{}) error {\n\tdata, err := f.Read(fileName)\n\tif err != nil {\n\t\treturn errors.Wrapf(err, \"unable to read %s\", fileName)\n\t}\n\treturn yaml.Unmarshal(data, object)\n}\n\ntype vaultStore struct {\n\tclient vault.Client\n\tpath   string\n}\n\n// NewVaultStore creates a new store which stores its data in Vault\nfunc NewVaultStore(client vault.Client, path string) ConfigStore {\n\treturn &vaultStore{\n\t\tclient: client,\n\t\tpath:   path,\n\t}\n}\n\n// Write store a secret in vault as an array of bytes\nfunc (v *vaultStore) Write(name string, bytes []byte) error {\n\tdata := map[string]interface{}{\n\t\t\"data\": bytes,\n\t}\n\t_, err := v.client.Write(v.secretPath(name), data)\n\tif err != nil {\n\t\treturn errors.Wrapf(err, \"unable to write data for secret '%s' to vault\", name)\n\t}\n\treturn nil\n}\n\n// Read reads a secret from vault which was stored as an array of bytes\nfunc (v *vaultStore) Read(name string) ([]byte, error) {\n\tsecret, err := v.client.Read(v.secretPath(name))\n\tif err != nil {\n\t\treturn nil, errors.Wrapf(err, \"unable to read '%s' secret from vault\", name)\n\t}\n\tdata, ok := secret[\"data\"]\n\tif !ok {\n\t\treturn nil, fmt.Errorf(\"data not found for secret '%s'\", name)\n\t}\n\n\tbytes, ok := data.([]byte)\n\tif !ok {\n\t\treturn nil, fmt.Errorf(\"unable to convert the secret content '%s' to bytes\", name)\n\t}\n\n\treturn bytes, nil\n}\n\n// WriteObject writes a generic named object to vault\nfunc (v *vaultStore) WriteObject(name string, object interface{}) error {\n\ty, err := yaml.Marshal(object)\n\tif err != nil {\n\t\treturn errors.Wrapf(err, \"unable to marshal object to yaml: %v\", object)\n\t}\n\t_, err = v.client.WriteYaml(v.secretPath(name), string(y))\n\tif err != nil {\n\t\treturn errors.Wrapf(err, \"writing the %q secret in YAMl format to vault\", name)\n\t}\n\treturn nil\n}\n\n// ReadObject reads a generic named object from vault\nfunc (v *vaultStore) ReadObject(name string, object interface{}) error {\n\tdata, err := v.client.ReadYaml(v.secretPath(name))\n\tif err != nil {\n\t\treturn errors.Wrapf(err, \"reading the %q secret in YAMl fromat from vault\", name)\n\t}\n\treturn yaml.Unmarshal([]byte(data), object)\n}\n\nfunc (v *vaultStore) secretPath(name string) string {\n\treturn v.path + name\n}\n",
+                "commit": {
+                    "oid": "6a3bc0d2f7e8a65ec0862f86e605cb0a85d3f3a7"
+                },
+                "path": "pkg/io/config_store.go",
+                "url": "/github.com/jenkins-x/jx/-/blob/pkg/io/config_store.go"
+            },
+            "limitHit": false,
+            "lineMatches": [
+                {
+                    "lineNumber": 41,
+                    "offsetAndLengths": [
+                        [
+                            20,
+                            56
+                        ]
+                    ],
+                    "preview": "WriteObject(fileName string, object interface{}) error {"
+                },
+                {
+                    "lineNumber": 42,
+                    "offsetAndLengths": [
+                        [
+                            0,
+                            31
+                        ]
+                    ],
+                    "preview": "\ty, err := yaml.Marshal(object)"
+                },
+                {
+                    "lineNumber": 43,
+                    "offsetAndLengths": [
+                        [
+                            0,
+                            16
+                        ]
+                    ],
+                    "preview": "\tif err != nil {"
+                },
+                {
+                    "lineNumber": 44,
+                    "offsetAndLengths": [
+                        [
+                            0,
+                            74
+                        ]
+                    ],
+                    "preview": "\t\treturn errors.Wrapf(err, \"unable to marshal object to yaml: %v\", object)"
+                },
+                {
+                    "lineNumber": 45,
+                    "offsetAndLengths": [
+                        [
+                            0,
+                            2
+                        ]
+                    ],
+                    "preview": "\t}"
+                },
+                {
+                    "lineNumber": 46,
+                    "offsetAndLengths": [
+                        [
+                            0,
+                            28
+                        ]
+                    ],
+                    "preview": "\treturn f.Write(fileName, y)"
+                },
+                {
+                    "lineNumber": 47,
+                    "offsetAndLengths": [
+                        [
+                            0,
+                            1
+                        ]
+                    ],
+                    "preview": "}"
+                },
+                {
+                    "lineNumber": 108,
+                    "offsetAndLengths": [
+                        [
+                            21,
+                            52
+                        ]
+                    ],
+                    "preview": "WriteObject(name string, object interface{}) error {"
+                },
+                {
+                    "lineNumber": 109,
+                    "offsetAndLengths": [
+                        [
+                            0,
+                            31
+                        ]
+                    ],
+                    "preview": "\ty, err := yaml.Marshal(object)"
+                },
+                {
+                    "lineNumber": 110,
+                    "offsetAndLengths": [
+                        [
+                            0,
+                            16
+                        ]
+                    ],
+                    "preview": "\tif err != nil {"
+                },
+                {
+                    "lineNumber": 111,
+                    "offsetAndLengths": [
+                        [
+                            0,
+                            74
+                        ]
+                    ],
+                    "preview": "\t\treturn errors.Wrapf(err, \"unable to marshal object to yaml: %v\", object)"
+                },
+                {
+                    "lineNumber": 112,
+                    "offsetAndLengths": [
+                        [
+                            0,
+                            2
+                        ]
+                    ],
+                    "preview": "\t}"
+                },
+                {
+                    "lineNumber": 113,
+                    "offsetAndLengths": [
+                        [
+                            0,
+                            59
+                        ]
+                    ],
+                    "preview": "\t_, err = v.client.WriteYaml(v.secretPath(name), string(y))"
+                },
+                {
+                    "lineNumber": 114,
+                    "offsetAndLengths": [
+                        [
+                            0,
+                            16
+                        ]
+                    ],
+                    "preview": "\tif err != nil {"
+                },
+                {
+                    "lineNumber": 115,
+                    "offsetAndLengths": [
+                        [
+                            0,
+                            81
+                        ]
+                    ],
+                    "preview": "\t\treturn errors.Wrapf(err, \"writing the %q secret in YAMl format to vault\", name)"
+                },
+                {
+                    "lineNumber": 116,
+                    "offsetAndLengths": [
+                        [
+                            0,
+                            2
+                        ]
+                    ],
+                    "preview": "\t}"
+                },
+                {
+                    "lineNumber": 117,
+                    "offsetAndLengths": [
+                        [
+                            0,
+                            11
+                        ]
+                    ],
+                    "preview": "\treturn nil"
+                },
+                {
+                    "lineNumber": 118,
+                    "offsetAndLengths": [
+                        [
+                            0,
+                            1
+                        ]
+                    ],
+                    "preview": "}"
+                }
+            ],
+            "repository": {
+                "name": "github.com/jenkins-x/jx",
+                "url": "/github.com/jenkins-x/jx"
+            }
+        }
+    ],
+    "SourcegraphEndpoint": "https://sourcegraph.com",
+    "Timedout": []
+}

--- a/cmd/src/testdata/search_formatting/highlight-structural-search.want.txt
+++ b/cmd/src/testdata/search_formatting/highlight-structural-search.want.txt
@@ -1,0 +1,24 @@
+[38;5;57m✱[0m [38;5;2m20 results[0m for [38;5;68m"patterntype:structural 'WriteObject(:[args]) error {:[body]}' lang:go count:1000 file:pkg/io/config_store.go"[0m in [38;5;2m18ms[0m
+[38;5;239m--------------------------------------------------------------------------------
+[0m[38;5;239m([0m[38;5;237mhttps://sourcegraph.com/github.com/jenkins-x/jx/-/blob/pkg/io/config_store.go[0m[38;5;239m)
+[0m[0m[38;5;23mgithub.com/jenkins-x/jx[0m › [38;5;69m<no value>[0m[38;5;2m (18 matches)[0m
+[38;5;239m--------------------------------------------------------------------------------
+[0m  [38;5;69m    42[0m[38;5;239m |  [0mfunc (f *fileStore) [38;5;0m[48;5;11mWriteObject(fileName string, object interface{}) error {[0m
+  [38;5;69m    43[0m[38;5;239m |  [0m[38;5;0m[48;5;11m	y, err := yaml.Marshal(object)[0m
+  [38;5;69m    44[0m[38;5;239m |  [0m[38;5;0m[48;5;11m	if err != nil {[0m
+  [38;5;69m    45[0m[38;5;239m |  [0m[38;5;0m[48;5;11m		return errors.Wrapf(err, "unable to marshal object to yaml: %v", object)[0m
+  [38;5;69m    46[0m[38;5;239m |  [0m[38;5;0m[48;5;11m	}[0m
+  [38;5;69m    47[0m[38;5;239m |  [0m[38;5;0m[48;5;11m	return f.Write(fileName, y)[0m
+  [38;5;69m    48[0m[38;5;239m |  [0m[38;5;0m[48;5;11m}[0m
+[38;5;239m  ------------------------------------------------------------------------------
+[0m  [38;5;69m   109[0m[38;5;239m |  [0mfunc (v *vaultStore) [38;5;0m[48;5;11mWriteObject(name string, object interface{}) error {[0m
+  [38;5;69m   110[0m[38;5;239m |  [0m[38;5;0m[48;5;11m	y, err := yaml.Marshal(object)[0m
+  [38;5;69m   111[0m[38;5;239m |  [0m[38;5;0m[48;5;11m	if err != nil {[0m
+  [38;5;69m   112[0m[38;5;239m |  [0m[38;5;0m[48;5;11m		return errors.Wrapf(err, "unable to marshal object to yaml: %v", object)[0m
+  [38;5;69m   113[0m[38;5;239m |  [0m[38;5;0m[48;5;11m	}[0m
+  [38;5;69m   114[0m[38;5;239m |  [0m[38;5;0m[48;5;11m	_, err = v.client.WriteYaml(v.secretPath(name), string(y))[0m
+  [38;5;69m   115[0m[38;5;239m |  [0m[38;5;0m[48;5;11m	if err != nil {[0m
+  [38;5;69m   116[0m[38;5;239m |  [0m[38;5;0m[48;5;11m		return errors.Wrapf(err, "writing the %q secret in YAMl format to vault", name)[0m
+  [38;5;69m   117[0m[38;5;239m |  [0m[38;5;0m[48;5;11m	}[0m
+  [38;5;69m   118[0m[38;5;239m |  [0m[38;5;0m[48;5;11m	return nil[0m
+  [38;5;69m   119[0m[38;5;239m |  [0m[38;5;0m[48;5;11m}[0m


### PR DESCRIPTION
I have cleaned up the logic compared to #67. Notable things:

It is hard to work with a highlighting procedure that assumes all highlights happen on one line, with the `highlight{line: 1, character: offset, length: length}` and assumption that this is relative to the `preview` string. I tried hard to make the function `applyHighlights` work for a use case where the `FileMatch` data can be used as ranges to highlight things given the file content, but eventually stopped wasting time on this and split it out to `applyHighlightsForFile`. 

To convince you that it is not a totally insane thing to want access to the file contents as opposed to making `Preview` be some kind of source of truth, I worked on trying to get some context lines to show around matches in #71 but it didn't pan out because it needs to take into account the line numbering/padding that gets written to terminal. I realize that the idea of context lines is useful generally and it's too bad we don't support this more directly in the API (I believe), but in lieu of that, it is nice that we have the _possibility_ of sidestepping this in `src-cli` to highlight around context lines, but it would need more effort and #71 might help guide that.

The last thing that is annoying is the reported "number of matches" which is a lie for structural search/multiline matches, due to the line-based assumption that FileMatch contains complete matches. Not specific to this change or `src-cli`, but relevant to the whole highlighting business and lack of ranges.

This PR still needs tests, but can be reviewed as is.

More inline comments.