### PR TITLE
Update .travis.yml to use Go 1.13.x instead of 1.10.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 sudo: false
 go:
-  - 1.10.x
+  - 1.13.x
 go_import_path: github.com/sourcegraph/src-cli
 install:
   - go get -d -t ./...


### PR DESCRIPTION
I don't see a reason why we can't use the newest version, especially since we already use `go.mod` and `go.sum` files.