### PR TITLE
Rename "campaigns plan preview" to "campaigns plan create"

### DIFF
--- a/cmd/src/campaign_plans.go
+++ b/cmd/src/campaign_plans.go
@@ -19,7 +19,7 @@ Usage:
 The commands are:
 
 	create-from-patches  creates plan from patches to repository branches
-	preview              generates preview of plan from a specification
+	create               creates a plan from a specification and provides a preview of the changesets
 
 Use "src campaigns plans [command] -h" for more information about a command.
 `

--- a/cmd/src/campaign_plans_preview.go
+++ b/cmd/src/campaign_plans_preview.go
@@ -7,15 +7,17 @@ import (
 
 func init() {
 	usage := `
+Create a campaign plan from a specification. The created plan can then be viewed on the Sourcegraph instance and used to create a campaign and changesets.
+
 Examples:
 
-  Preview a comby campaign:
+  Create a comby campaign plan:
 
-    	$ src campaigns plans preview -type=comby -args='{"scopeQuery":"repo:sourcegraph/go-diff", "matchTemplate": "fmt.Errorf", "rewriteTemplate": "errors.Wrapf"}' -f '{{.|json}}'
+    	$ src campaigns plan create -type=comby -args='{"scopeQuery":"repo:sourcegraph/go-diff", "matchTemplate": "fmt.Errorf", "rewriteTemplate": "errors.Wrapf"}' -f '{{.|json}}'
 
 `
 
-	flagSet := flag.NewFlagSet("preview", flag.ExitOnError)
+	flagSet := flag.NewFlagSet("create", flag.ExitOnError)
 	usageFunc := func() {
 		fmt.Fprintf(flag.CommandLine.Output(), "Usage of 'src campaigns plans %s':\n", flagSet.Name())
 		flagSet.PrintDefaults()
@@ -77,6 +79,7 @@ Examples:
 	// Register the command.
 	campaignPlansCommands = append(campaignPlansCommands, &command{
 		flagSet:   flagSet,
+		aliases:   []string{"preview"},
 		handler:   handler,
 		usageFunc: usageFunc,
 	})


### PR DESCRIPTION
I think this makes a lot more sense from a users perspective, especially with the upcoming changes in https://github.com/sourcegraph/src-cli/pull/80.