### PR TITLE
Update ctxhttp module path.

### DIFF
--- a/cmd/src/actions_exec_backend_runner.go
+++ b/cmd/src/actions_exec_backend_runner.go
@@ -17,8 +17,8 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"github.com/shurcooL/go/ctxhttp"
 	"github.com/sourcegraph/go-diff/diff"
+	"golang.org/x/net/context/ctxhttp"
 )
 
 type ActionRepoStatus struct {

--- a/go.mod
+++ b/go.mod
@@ -13,11 +13,10 @@ require (
 	github.com/neelance/parallel v0.0.0-20160708114440-4de9ce63d14c
 	github.com/olekukonko/tablewriter v0.0.4 // indirect
 	github.com/pkg/errors v0.8.1
-	github.com/shurcooL/go v0.0.0-20180423040247-9e1955d9fb6e
 	github.com/sourcegraph/go-diff v0.5.1
 	github.com/sourcegraph/jsonx v0.0.0-20190114210550-ba8cb36a8614
 	github.com/ssor/bom v0.0.0-20170718123548-6386211fdfcf // indirect
-	golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553 // indirect
+	golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553
 	golang.org/x/sys v0.0.0-20200107162124-548cf772de50 // indirect
 	jaytaylor.com/html2text v0.0.0-20190408195923-01ec452cbe43
 )


### PR DESCRIPTION
The github.com/shurcooL/go/ctxhttp package no longer exists, and has been moved (and updated) to golang.org/x/net/context/ctxhttp. Update the import path and go module config. No functional changes are intended. Fixes a build break apparently introduced by #80.