### PR TITLE
Add 'src actions scope-query' command

### DIFF
--- a/cmd/src/actions.go
+++ b/cmd/src/actions.go
@@ -19,6 +19,7 @@ Usage:
 The commands are:
 
 	exec              executes an action to produce patches
+	scope-query       list the repositories matched by "scopeQuery" in action
 
 Use "src actions [command] -h" for more information about a command.
 `

--- a/cmd/src/actions_exec.go
+++ b/cmd/src/actions_exec.go
@@ -93,7 +93,7 @@ Format of the action JSON files:
 
 	An action JSON needs to specify:
 
-	- "scopeQuery" - a Sourcegraph search query to generate a list of repositories over which to run the action
+	- "scopeQuery" - a Sourcegraph search query to generate a list of repositories over which to run the action. Use 'src actions scope-query' to see which repositories are matched by the query
 	- "steps" - a list of action steps to execute in each repository
 
 	A single "step" can either be a command that's executed on the machine on which 'src actions exec' is executed.
@@ -318,7 +318,7 @@ Format of the action JSON files:
 			return err
 		}
 		if *verbose {
-			log.Printf("# %d repositories match.", len(repos))
+			log.Printf("# %d repositories match. Use 'src actions scope-query' for help with scoping.", len(repos))
 		}
 		for _, repo := range repos {
 			executor.enqueueRepo(repo)

--- a/cmd/src/actions_scope_query.go
+++ b/cmd/src/actions_scope_query.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+
+	"github.com/pkg/errors"
+)
+
+func init() {
+	usage := `
+List the repositories that are matched by the "scopeQuery" in an action definition. This command is meant to help with creating action definitions to be used with 'src actions exec'.
+
+Examples:
+
+  List the names of the repositories that are returned by the "scopeQuery" in ~/action.json:
+
+		$ src actions scope-query -f ~/run-gofmt-in-dockerfile.json
+
+`
+
+	flagSet := flag.NewFlagSet("scope-query", flag.ExitOnError)
+	usageFunc := func() {
+		fmt.Fprintf(flag.CommandLine.Output(), "Usage of 'src actions %s':\n", flagSet.Name())
+		flagSet.PrintDefaults()
+		fmt.Println(usage)
+	}
+
+	var (
+		fileFlag = flagSet.String("f", "-", "The action file. If not given or '-' standard input is used. (Required)")
+	)
+
+	handler := func(args []string) error {
+		flagSet.Parse(args)
+
+		var (
+			actionFile []byte
+			err        error
+		)
+
+		if *fileFlag == "-" {
+			actionFile, err = ioutil.ReadAll(os.Stdin)
+		} else {
+			actionFile, err = ioutil.ReadFile(*fileFlag)
+		}
+		if err != nil {
+			return err
+		}
+
+		var action Action
+		if err := jsonxUnmarshal(string(actionFile), &action); err != nil {
+			return errors.Wrap(err, "invalid JSON action file")
+		}
+
+		ctx := context.Background()
+
+		repos, err := actionRepos(ctx, *verbose, action.ScopeQuery)
+		if err != nil {
+			return err
+		}
+		if *verbose {
+			log.Printf("# %d repositories match.", len(repos))
+		}
+		for _, repo := range repos {
+			fmt.Println(repo.Name)
+		}
+
+		return nil
+	}
+
+	// Register the command.
+	actionsCommands = append(actionsCommands, &command{
+		flagSet:   flagSet,
+		handler:   handler,
+		usageFunc: usageFunc,
+	})
+}


### PR DESCRIPTION
This command is meant to help with creating action definitions. It returns the repositories that are matched by the "scopeQuery" in an action definition.

Example:

    $ src actions scope-query -f ~/run-gofmt-in-dockerfile.json
    github.com/sd9/ava
    github.com/sd9/go-diff
    github.com/sourcegraph/automation-testing

It's based on @sqs' suggestion here: https://github.com/sourcegraph/sourcegraph/issues/7850#issuecomment-577678760