### PR TITLE
Use $EDITOR to define campaign name/desc if not given

### DIFF
--- a/cmd/src/campaigns_create.go
+++ b/cmd/src/campaigns_create.go
@@ -236,6 +236,10 @@ func extractContent(file string) (string, error) {
 
 func openInEditor(file string) error {
 	editor := os.ExpandEnv("$EDITOR")
+	if editor == "" {
+		return errors.New("$EDITOR is not set")
+	}
+
 	cmd := exec.Command(editor)
 
 	r := regexp.MustCompile(`\b(?:[gm]?vim)(?:\.exe)?$`)

--- a/cmd/src/campaigns_create.go
+++ b/cmd/src/campaigns_create.go
@@ -16,6 +16,8 @@ import (
 
 func init() {
 	usage := `
+Create a campaign with the given attributes. If -name or -desc are not specified $EDITOR will open a temporary Markdown file to edit both.
+
 Examples:
 
   Create a campaign with the given name, description and campaign plan:
@@ -40,8 +42,8 @@ Examples:
 		fmt.Println(usage)
 	}
 	var (
-		nameFlag        = flagSet.String("name", "", "Name of the campaign. (required)")
-		descriptionFlag = flagSet.String("desc", "", "Description for the campaign in Markdown. (required)")
+		nameFlag        = flagSet.String("name", "", "Name of the campaign. ")
+		descriptionFlag = flagSet.String("desc", "", "Description for the campaign in Markdown.")
 		namespaceFlag   = flagSet.String("namespace", "", "ID of the namespace under which to create the campaign. The namespace can be the GraphQL ID of a Sourcegraph user or organisation. If not specified, the ID of the authenticated user is queried and used. (Required)")
 		planIDFlag      = flagSet.String("plan", "", "ID of campaign plan the campaign should turn into changesets. If no plan is specified, a campaign is created to which changesets can be added manually.")
 		draftFlag       = flagSet.Bool("draft", false, "Create the campaign as a draft (which won't create pull requests on code hosts)")

--- a/cmd/src/campaigns_create.go
+++ b/cmd/src/campaigns_create.go
@@ -1,8 +1,15 @@
 package main
 
 import (
+	"bufio"
+	"bytes"
 	"flag"
 	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
 
 	"github.com/pkg/errors"
 )
@@ -34,7 +41,7 @@ Examples:
 	}
 	var (
 		nameFlag        = flagSet.String("name", "", "Name of the campaign. (required)")
-		descriptionFlag = flagSet.String("desc", "", "Description for the campaign. (required)")
+		descriptionFlag = flagSet.String("desc", "", "Description for the campaign in Markdown. (required)")
 		namespaceFlag   = flagSet.String("namespace", "", "ID of the namespace under which to create the campaign. The namespace can be the GraphQL ID of a Sourcegraph user or organisation. If not specified, the ID of the authenticated user is queried and used. (Required)")
 		planIDFlag      = flagSet.String("plan", "", "ID of campaign plan the campaign should turn into changesets. If no plan is specified, a campaign is created to which changesets can be added manually.")
 		draftFlag       = flagSet.Bool("draft", false, "Create the campaign as a draft (which won't create pull requests on code hosts)")
@@ -48,12 +55,30 @@ Examples:
 	handler := func(args []string) error {
 		flagSet.Parse(args)
 
-		if *nameFlag == "" {
-			return &usageError{errors.New("-name must be specified")}
+		var name, description string
+
+		if *nameFlag == "" || *descriptionFlag == "" {
+			editor := &CampaignEditor{
+				Name:        *nameFlag,
+				Description: *descriptionFlag,
+			}
+
+			var err error
+			name, description, err = editor.EditAndExtract()
+			if err != nil {
+				return err
+			}
+		} else {
+			name = *nameFlag
+			description = *descriptionFlag
 		}
 
-		if *descriptionFlag == "" {
-			return &usageError{errors.New("-desc must be specified")}
+		if name == "" {
+			return &usageError{errors.New("campaign name cannot be blank")}
+		}
+
+		if description == "" {
+			return &usageError{errors.New("campaign description cannot be blank")}
 		}
 
 		var namespace string
@@ -85,8 +110,8 @@ Examples:
 		}
 
 		input := map[string]interface{}{
-			"name":        *nameFlag,
-			"description": *descriptionFlag,
+			"name":        name,
+			"description": description,
 			"namespace":   namespace,
 			"plan":        nullString(*planIDFlag),
 			"draft":       *draftFlag,
@@ -126,3 +151,109 @@ const createcampaignMutation = `mutation CreateCampaign($input: CreateCampaignIn
   }
 }
 `
+
+const (
+	sep         = "------- EVERYTHING BELOW THIS LINE WILL BE IGNORE -------"
+	commentChar = "#"
+	notice      = `You are creating a new campaign.
+Write a name and description for this campaign in this file.
+The first line of text is the name and the rest is the description.`
+)
+
+type CampaignEditor struct {
+	Name        string
+	Description string
+}
+
+func (e *CampaignEditor) EditAndExtract() (string, string, error) {
+	f, err := ioutil.TempFile("", "new-campaign")
+	if err != nil {
+		return "", "", err
+	}
+	defer os.Remove(f.Name())
+
+	err = e.writeTemplate(f)
+	if err != nil {
+		return "", "", err
+	}
+
+	err = openInEditor(f.Name())
+	if err != nil {
+		return "", "", errors.Wrap(err, "Failed to open text editor to edit campaign")
+	}
+
+	content, err := extractContent(f.Name())
+	if err != nil {
+		return "", "", err
+	}
+
+	var name, description string
+
+	parts := strings.SplitN(content, "\n\n", 2)
+	if len(parts) >= 1 {
+		name = strings.TrimSpace(strings.Replace(parts[0], "\n", " ", -1))
+	}
+	if len(parts) >= 2 {
+		description = strings.TrimSpace(parts[1])
+	}
+
+	return name, description, nil
+}
+
+func (e *CampaignEditor) writeTemplate(f *os.File) error {
+	template := e.Name + "\n\n" + e.Description
+	template += "\n\n" + commentChar + " " + sep
+	template += "\n\n" + notice
+
+	_, err := f.WriteString(template)
+	return err
+}
+
+func extractContent(file string) (string, error) {
+	fileContent, err := ioutil.ReadFile(file)
+	if err != nil {
+		return "", err
+	}
+
+	trimmed := bytes.TrimSpace(fileContent)
+
+	separator := commentChar + " " + sep
+	scanner := bufio.NewScanner(bytes.NewReader(trimmed))
+
+	content := []string{}
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == separator {
+			break
+		}
+		content = append(content, line)
+	}
+	if err = scanner.Err(); err != nil {
+		return "", err
+	}
+
+	return strings.Join(content, "\n"), nil
+}
+
+func openInEditor(file string) error {
+	editor := os.ExpandEnv("$EDITOR")
+	cmd := exec.Command(editor)
+
+	r := regexp.MustCompile(`\b(?:[gm]?vim)(?:\.exe)?$`)
+	if r.MatchString(cmd.Path) {
+		cmd.Args = append(cmd.Args, "--cmd", "set ft=markdown")
+	}
+
+	cmd.Args = append(cmd.Args, file)
+
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	tty, err := os.OpenFile("/dev/tty", os.O_RDONLY, 0660)
+	if err == nil {
+		cmd.Stdin = tty
+	}
+
+	return cmd.Run()
+}

--- a/cmd/src/campaigns_create.go
+++ b/cmd/src/campaigns_create.go
@@ -153,9 +153,8 @@ const createcampaignMutation = `mutation CreateCampaign($input: CreateCampaignIn
 `
 
 const (
-	sep         = "------- EVERYTHING BELOW THIS LINE WILL BE IGNORE -------"
-	commentChar = "#"
-	notice      = `You are creating a new campaign.
+	sep    = "------- EVERYTHING BELOW THIS LINE WILL BE IGNORE -------"
+	notice = `You are creating a new campaign.
 Write a name and description for this campaign in this file.
 The first line of text is the name and the rest is the description.`
 )
@@ -202,7 +201,7 @@ func (e *CampaignEditor) EditAndExtract() (string, string, error) {
 
 func (e *CampaignEditor) writeTemplate(f *os.File) error {
 	template := e.Name + "\n\n" + e.Description
-	template += "\n\n" + commentChar + " " + sep
+	template += "\n\n" + sep
 	template += "\n\n" + notice
 
 	_, err := f.WriteString(template)
@@ -217,14 +216,13 @@ func extractContent(file string) (string, error) {
 
 	trimmed := bytes.TrimSpace(fileContent)
 
-	separator := commentChar + " " + sep
 	scanner := bufio.NewScanner(bytes.NewReader(trimmed))
 
 	content := []string{}
 
 	for scanner.Scan() {
 		line := scanner.Text()
-		if line == separator {
+		if line == sep {
 			break
 		}
 		content = append(content, line)

--- a/cmd/src/campaigns_create.go
+++ b/cmd/src/campaigns_create.go
@@ -155,7 +155,7 @@ const createcampaignMutation = `mutation CreateCampaign($input: CreateCampaignIn
 `
 
 const (
-	sep    = "------- EVERYTHING BELOW THIS LINE WILL BE IGNORE -------"
+	sep    = "------- EVERYTHING BELOW THIS LINE WILL BE IGNORED -------"
 	notice = `You are creating a new campaign.
 Write a name and description for this campaign in this file.
 The first line of text is the name and the rest is the description.`
@@ -237,7 +237,7 @@ func extractContent(file string) (string, error) {
 }
 
 func openInEditor(file string) error {
-	editor := os.ExpandEnv("$EDITOR")
+	editor := os.Getenv("EDITOR")
 	if editor == "" {
 		return errors.New("$EDITOR is not set")
 	}

--- a/cmd/src/format.go
+++ b/cmd/src/format.go
@@ -101,7 +101,7 @@ func parseTemplate(text string) (*template.Template, error) {
 			fmt.Fprintln(&buf, color.HiGreenString("✔  Campaign plan saved."), "To preview and run the campaign (and create branches and changesets):")
 			fmt.Fprintln(&buf)
 			fmt.Fprintln(&buf, " ", color.HiCyanString("▶ Web:"), campaignPlan.PreviewURL, color.HiBlackString("or"))
-			cliCommand := fmt.Sprintf("src campaigns create -name='Campaign name' -desc='My first CLI-created campaign' -plan=%s", campaignPlan.ID)
+			cliCommand := fmt.Sprintf("src campaigns create -plan=%s", campaignPlan.ID)
 			fmt.Fprintln(&buf, " ", color.HiCyanString("▶ CLI:"), cliCommand)
 			return buf.String()
 		},


### PR DESCRIPTION
This opens a template markdown file in $EDITOR if either no `-name` or no `-desc` are given on the command line.

This is heavily inspired by the implementation of GitHub's `hub issue create`, except that it's probably 1/4 of the code.

I also took the little regex from it, to determine whether $EDITOR is a Vim and if so set the filetype to Markdown :)