### PR TITLE
Use V2 search when searching for action scopeQuery

### DIFF
--- a/cmd/src/actions_exec.go
+++ b/cmd/src/actions_exec.go
@@ -426,7 +426,7 @@ type ActionRepo struct {
 func actionRepos(ctx context.Context, verbose bool, scopeQuery string) ([]ActionRepo, error) {
 	query := `
 query ActionRepos($query: String!) {
-	search(query: $query, version: V1) {
+	search(query: $query, version: V2) {
 		results {
 			results {
 				__typename


### PR DESCRIPTION
I'm not sure whether this was a deliberate decision by @sqs but it bit me when experimenting with a query in my local instance and then not getting it work in `src actions scope-query`.