### PR TITLE
Add a Setup section to the README and quick links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # Sourcegraph CLI [![Build Status](https://travis-ci.org/sourcegraph/src-cli.svg)](https://travis-ci.org/sourcegraph/src-cli) [![Build status](https://ci.appveyor.com/api/projects/status/fwa1bkd198hyim8a?svg=true)](https://ci.appveyor.com/project/sourcegraph/src-cli) [![Go Report Card](https://goreportcard.com/badge/sourcegraph/src-cli)](https://goreportcard.com/report/sourcegraph/src-cli)
 
+**Quick links**:
+
+* [Installation](#installation)
+* [Setup](#setup)
+  * [Authentication](#authentication)
+* [Usage](#usage)
+
 The Sourcegraph `src` CLI provides access to [Sourcegraph](https://sourcegraph.com) via a command-line interface.
 
 ![image](https://user-images.githubusercontent.com/3173176/43567326-3db5f31c-95e6-11e8-9e74-4c04079c01b0.png)
@@ -18,21 +25,21 @@ If there is something you'd like to see Sourcegraph be able to do from the CLI, 
 
 **NOTE:** To get the best version for _your_ Sourcegraph instance, simply replace `sourcegraph.com` in the commands below with your own Sourcegraph URL and the latest version compatible with your instance will be provided. If you are running a Sourcegraph version older than 3.12, run the commands below instead.
 
-### Mac OS
+#### Mac OS
 
 ```bash
 curl -L https://sourcegraph.com/.api/src-cli/src_darwin_amd64 -o /usr/local/bin/src
 chmod +x /usr/local/bin/src
 ```
 
-### Linux
+#### Linux
 
 ```bash
 curl -L https://sourcegraph.com/.api/src-cli/src_linux_amd64 -o /usr/local/bin/src
 chmod +x /usr/local/bin/src
 ```
 
-### Windows
+#### Windows
 
 **NOTE:** Windows support is still rough around the edges, but is available. If you encounter issues, please let us know by filing an issue :)
 
@@ -51,7 +58,7 @@ Or manually:
 - Place the file under e.g. `C:\Program Files\Sourcegraph\src.exe`
 - Add that directory to your system path to access it from any command prompt
 
-### Renaming `src` (optional)
+#### Renaming `src` (optional)
 
 If you have a naming conflict with the `src` command, such as a Bash alias, you can rename the static binary. For example, on Linux / Mac OS:
 
@@ -61,11 +68,15 @@ mv /usr/local/bin/src /usr/local/bin/sourcegraph-cli
 
 You can then invoke it via `sourcegraph-cli`.
 
-## Usage
+## Setup
 
-Consult `src -h` and `src api -h` for usage information.
+If you want to use `src` with your own Sourcegraph instance set the `SRC_ENDPOINT` environment variable:
 
-## Authentication
+```sh
+SRC_ENDPOINT=https://sourcegraph.example.com src search
+```
+
+### Authentication
 
 Some Sourcegraph instances will be configured to require authentication. You can do so via the environment:
 
@@ -82,6 +93,10 @@ Or via the configuration file (`~/src-config.json`):
 See `src -h` for more information on specifying access tokens.
 
 To acquire the access token, visit your Sourcegraph instance (or https://sourcegraph.com), click your username in the top right to open the user menu, select **Settings**, and then select **Access tokens** in the left hand menu.
+
+## Usage
+
+Consult `src -h` and `src api -h` for usage information.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,6 @@
 # Sourcegraph CLI [![Build Status](https://travis-ci.org/sourcegraph/src-cli.svg)](https://travis-ci.org/sourcegraph/src-cli) [![Build status](https://ci.appveyor.com/api/projects/status/fwa1bkd198hyim8a?svg=true)](https://ci.appveyor.com/project/sourcegraph/src-cli) [![Go Report Card](https://goreportcard.com/badge/sourcegraph/src-cli)](https://goreportcard.com/report/sourcegraph/src-cli)
 
-**Quick links**:
-
-* [Installation](#installation)
-* [Setup](#setup)
-  * [Authentication](#authentication)
-* [Usage](#usage)
+**Quick links**: [Installation](#installation), [Setup](#setup) ([Authentication](#authentication)), [Usage](#usage)
 
 The Sourcegraph `src` CLI provides access to [Sourcegraph](https://sourcegraph.com) via a command-line interface.
 


### PR DESCRIPTION
When guiding a Sourcegraph colleague through using `src` with Automation the first blocker was that their `src` was talking to `sourcegraph.com`.

I realized that in this README.md here there was barely any mention of `SRC_ENDPOINT`.

This PR tries to fix that by adding a separate `Setup` section and adding quick links at the top of the README to the three most important sections: Installation, Setup, Usage.