### PR TITLE
a8n: add branch flag for creating campaigns

### DIFF
--- a/cmd/src/campaigns_create.go
+++ b/cmd/src/campaigns_create.go
@@ -19,10 +19,11 @@ Create a campaign with the given attributes. If -name or -desc are not specified
 
 Examples:
 
-  Create a campaign with the given name, description and campaign plan:
+  Create a campaign with the given name, branch, description and campaign plan:
 
 		$ src campaigns create -name="Format Go code" \
 		   -desc="This campaign runs gofmt over all Go repositories" \
+		   -branch=run-go-fmt \
 		   -plan=Q2FtcGFpZ25QbGFuOjM=
 
   Create a manual campaign with the given name and description and adds two GitHub pull requests to it:
@@ -41,12 +42,12 @@ Examples:
 		fmt.Println(usage)
 	}
 	var (
-		nameFlag        = flagSet.String("name", "", "Name of the campaign. ")
+		nameFlag        = flagSet.String("name", "", "Name of the campaign.")
 		descriptionFlag = flagSet.String("desc", "", "Description for the campaign in Markdown.")
 		namespaceFlag   = flagSet.String("namespace", "", "ID of the namespace under which to create the campaign. The namespace can be the GraphQL ID of a Sourcegraph user or organisation. If not specified, the ID of the authenticated user is queried and used. (Required)")
 		planIDFlag      = flagSet.String("plan", "", "ID of campaign plan the campaign should turn into changesets. If no plan is specified, a campaign is created to which changesets can be added manually.")
 		draftFlag       = flagSet.Bool("draft", false, "Create the campaign as a draft (which won't create pull requests on code hosts)")
-		branchFlag      = flagSet.String("branch", "", "")
+		branchFlag      = flagSet.String("branch", "", "Name of the branch that will be created in each repository on the code host. Required when 'plan' is specified.")
 
 		changesetsFlag = flagSet.Int("changesets", 1000, "Returns the first n changesets per campaign.")
 

--- a/cmd/src/campaigns_create.go
+++ b/cmd/src/campaigns_create.go
@@ -46,6 +46,7 @@ Examples:
 		namespaceFlag   = flagSet.String("namespace", "", "ID of the namespace under which to create the campaign. The namespace can be the GraphQL ID of a Sourcegraph user or organisation. If not specified, the ID of the authenticated user is queried and used. (Required)")
 		planIDFlag      = flagSet.String("plan", "", "ID of campaign plan the campaign should turn into changesets. If no plan is specified, a campaign is created to which changesets can be added manually.")
 		draftFlag       = flagSet.Bool("draft", false, "Create the campaign as a draft (which won't create pull requests on code hosts)")
+		branchFlag      = flagSet.String("branch", "", "")
 
 		changesetsFlag = flagSet.Int("changesets", 1000, "Returns the first n changesets per campaign.")
 
@@ -82,6 +83,10 @@ Examples:
 			return &usageError{errors.New("campaign description cannot be blank")}
 		}
 
+		if *branchFlag == "" {
+			return &usageError{errors.New("branch cannot be blank")}
+		}
+
 		var namespace string
 		if *namespaceFlag != "" {
 			namespace = *namespaceFlag
@@ -116,6 +121,7 @@ Examples:
 			"namespace":   namespace,
 			"plan":        nullString(*planIDFlag),
 			"draft":       *draftFlag,
+			"branch":      *branchFlag,
 		}
 
 		var result struct {

--- a/cmd/src/campaigns_create.go
+++ b/cmd/src/campaigns_create.go
@@ -83,8 +83,8 @@ Examples:
 			return &usageError{errors.New("campaign description cannot be blank")}
 		}
 
-		if *branchFlag == "" {
-			return &usageError{errors.New("branch cannot be blank")}
+		if *planIDFlag != "" && *branchFlag == "" {
+			return &usageError{errors.New("branch cannot be blank for campaigns with a plan")}
 		}
 
 		var namespace string

--- a/cmd/src/format.go
+++ b/cmd/src/format.go
@@ -101,7 +101,7 @@ func parseTemplate(text string) (*template.Template, error) {
 			fmt.Fprintln(&buf, color.HiGreenString("✔  Campaign plan saved."), "To preview and run the campaign (and create branches and changesets):")
 			fmt.Fprintln(&buf)
 			fmt.Fprintln(&buf, " ", color.HiCyanString("▶ Web:"), campaignPlan.PreviewURL, color.HiBlackString("or"))
-			cliCommand := fmt.Sprintf("src campaigns create -plan=%s", campaignPlan.ID)
+			cliCommand := fmt.Sprintf("src campaigns create -plan=%s -branch=DESIRED-BRANCH-NAME", campaignPlan.ID)
 			fmt.Fprintln(&buf, " ", color.HiCyanString("▶ CLI:"), cliCommand)
 			return buf.String()
 		},


### PR DESCRIPTION
This PR adds a flag to specify a branch name when creating campaigns.