### PR TITLE
Make diff flag check work for GNU diffutils 3.3

### DIFF
--- a/cmd/src/actions_exec_backend_runner.go
+++ b/cmd/src/actions_exec_backend_runner.go
@@ -13,6 +13,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -280,7 +281,10 @@ func diffSupportsFlag(ctx context.Context, flag string) (bool, error) {
 	if err != nil && cmd.ProcessState.ExitCode() != 2 {
 		return false, errors.Wrapf(err, "Checking whether diff supports %q failed", flag)
 	}
-	return !strings.Contains(string(out), "unrecognized option `"+flag), nil
+
+	pattern := fmt.Sprintf("unrecognized\\soption\\s[`']%s", flag)
+	matched, err := regexp.MatchString(pattern, string(out))
+	return !matched, err
 }
 
 // We use an explicit prefix for our temp directories, because otherwise Go


### PR DESCRIPTION
It seems that some point after GNU diffutils 2.8.1 the output changed from using a backtick to a single quote.

That's why the check fails even if the diff version supports it.