### PR TITLE
Bump version of sourcegraph instance useful for downloads in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ If there is something you'd like to see Sourcegraph be able to do from the CLI, 
 
 ## Installation
 
-**NOTE:** To get the best version for _your_ Sourcegraph instance, simply replace `sourcegraph.com` in the commands below with your own Sourcegraph URL and the latest version compatible with your instance will be provided. If you are running a Sourcegraph version older than 3.12, run the commands below instead.
+**NOTE:** To get the best version for _your_ Sourcegraph instance, simply replace `sourcegraph.com` in the commands below with your own Sourcegraph URL and the latest version compatible with your instance will be provided. If you are running a Sourcegraph version older than 3.13, run the commands below instead.
 
 #### Mac OS
 


### PR DESCRIPTION
There's a bug in 3.12 that doesn't allow curl to work properly on the download URL. This updates the readme to indicate that it's supported 3.13 and later to stop people from running into this issue.

Closes https://github.com/sourcegraph/src-cli/issues/103