### PR TITLE
Only check for -branch for Sourcegraph >= 3.13, dev or custom build

### DIFF
--- a/cmd/src/campaigns_create.go
+++ b/cmd/src/campaigns_create.go
@@ -92,7 +92,7 @@ Examples:
 			if err != nil {
 				return err
 			}
-			needsBranch, err := sourcegraphVersionCheck(version, ">= 3.13")
+			needsBranch, err := sourcegraphVersionCheck(version, ">= 3.13", "2020-02-13")
 			if err != nil {
 				return err
 			}
@@ -300,7 +300,7 @@ func getSourcegraphVersion() (string, error) {
 	return sourcegraphVersion.Site.ProductVersion, nil
 }
 
-func sourcegraphVersionCheck(version, constraint string) (bool, error) {
+func sourcegraphVersionCheck(version, constraint, minDate string) (bool, error) {
 	if version == "dev" {
 		return true, nil
 	}
@@ -308,8 +308,7 @@ func sourcegraphVersionCheck(version, constraint string) (bool, error) {
 	buildDate := regexp.MustCompile(`^\d+_(\d{4}-\d{2}-\d{2})_[a-z0-9]{7}$`)
 	matches := buildDate.FindStringSubmatch(version)
 	if len(matches) > 1 {
-		// For now we treat non-release builds as matching the criteria
-		return true, nil
+		return matches[1] >= minDate, nil
 	}
 
 	c, err := semver.NewConstraint(constraint)

--- a/cmd/src/campaigns_create.go
+++ b/cmd/src/campaigns_create.go
@@ -8,8 +8,10 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"regexp"
 	"strings"
 
+	"github.com/Masterminds/semver"
 	"github.com/pkg/errors"
 )
 
@@ -47,7 +49,7 @@ Examples:
 		namespaceFlag   = flagSet.String("namespace", "", "ID of the namespace under which to create the campaign. The namespace can be the GraphQL ID of a Sourcegraph user or organisation. If not specified, the ID of the authenticated user is queried and used. (Required)")
 		planIDFlag      = flagSet.String("plan", "", "ID of campaign plan the campaign should turn into changesets. If no plan is specified, a campaign is created to which changesets can be added manually.")
 		draftFlag       = flagSet.Bool("draft", false, "Create the campaign as a draft (which won't create pull requests on code hosts)")
-		branchFlag      = flagSet.String("branch", "", "Name of the branch that will be created in each repository on the code host. Required when 'plan' is specified.")
+		branchFlag      = flagSet.String("branch", "", "Name of the branch that will be created in each repository on the code host. Required for Sourcegraph >= 3.13 when 'plan' is specified.")
 
 		changesetsFlag = flagSet.Int("changesets", 1000, "Returns the first n changesets per campaign.")
 
@@ -84,8 +86,20 @@ Examples:
 			return &usageError{errors.New("campaign description cannot be blank")}
 		}
 
-		if *planIDFlag != "" && *branchFlag == "" {
-			return &usageError{errors.New("branch cannot be blank for campaigns with a plan")}
+		if *planIDFlag != "" {
+			// We only need to check for -branch if the Sourcegraph version is >= 3.13
+			version, err := getSourcegraphVersion()
+			if err != nil {
+				return err
+			}
+			needsBranch, err := sourcegraphVersionCheck(version, ">= 3.13")
+			if err != nil {
+				return err
+			}
+
+			if needsBranch && *branchFlag == "" {
+				return &usageError{errors.New("branch cannot be blank for campaigns with a plan")}
+			}
 		}
 
 		var namespace string
@@ -259,4 +273,53 @@ func openInEditor(file string) error {
 	}
 
 	return cmd.Run()
+}
+
+const sourcegraphVersionQuery = `query SourcegraphVersion {
+  site {
+    productVersion
+  }
+}
+`
+
+func getSourcegraphVersion() (string, error) {
+	var sourcegraphVersion struct {
+		Site struct {
+			ProductVersion string
+		}
+	}
+
+	err := (&apiRequest{
+		query:  sourcegraphVersionQuery,
+		result: &sourcegraphVersion,
+	}).do()
+	if err != nil {
+		return "", err
+	}
+
+	return sourcegraphVersion.Site.ProductVersion, nil
+}
+
+func sourcegraphVersionCheck(version, constraint string) (bool, error) {
+	if version == "dev" {
+		return true, nil
+	}
+
+	buildDate := regexp.MustCompile(`^\d+_(\d{4}-\d{2}-\d{2})_[a-z0-9]{7}$`)
+	matches := buildDate.FindStringSubmatch(version)
+	if len(matches) > 1 {
+		// For now we treat non-release builds as matching the criteria
+		return true, nil
+	}
+
+	c, err := semver.NewConstraint(constraint)
+	if err != nil {
+		return false, nil
+	}
+
+	v, err := semver.NewVersion(version)
+	if err != nil {
+		return false, err
+	}
+	return c.Check(v), nil
 }

--- a/cmd/src/campaigns_create_test.go
+++ b/cmd/src/campaigns_create_test.go
@@ -1,0 +1,25 @@
+package main
+
+import "testing"
+
+func TestSourcegraphVersionCheck(t *testing.T) {
+	for _, tc := range []struct {
+		currentVersion, constraint string
+		expected                   bool
+	}{
+		{currentVersion: "3.12.6", constraint: ">= 3.12.6", expected: true},
+		{currentVersion: "3.12.6", constraint: ">= 3.13", expected: false},
+		{currentVersion: "3.13.0", constraint: ">= 3.13", expected: true},
+		{currentVersion: "dev", constraint: ">= 3.13", expected: true},
+		{currentVersion: "54959_2020-01-29_9258595", constraint: ">= 999.13", expected: true},
+	} {
+		actual, err := sourcegraphVersionCheck(tc.currentVersion, tc.constraint)
+		if err != nil {
+			t.Errorf("err: %s", err)
+		}
+
+		if actual != tc.expected {
+			t.Errorf("wrong result. want=%t, got=%t (version=%q, constraint=%q)", tc.expected, actual, tc.currentVersion, tc.constraint)
+		}
+	}
+}

--- a/cmd/src/campaigns_create_test.go
+++ b/cmd/src/campaigns_create_test.go
@@ -4,16 +4,53 @@ import "testing"
 
 func TestSourcegraphVersionCheck(t *testing.T) {
 	for _, tc := range []struct {
-		currentVersion, constraint string
-		expected                   bool
+		currentVersion, constraint, minDate string
+		expected                            bool
 	}{
-		{currentVersion: "3.12.6", constraint: ">= 3.12.6", expected: true},
-		{currentVersion: "3.12.6", constraint: ">= 3.13", expected: false},
-		{currentVersion: "3.13.0", constraint: ">= 3.13", expected: true},
-		{currentVersion: "dev", constraint: ">= 3.13", expected: true},
-		{currentVersion: "54959_2020-01-29_9258595", constraint: ">= 999.13", expected: true},
+		{
+			currentVersion: "3.12.6",
+			constraint:     ">= 3.12.6",
+			minDate:        "2020-01-19",
+			expected:       true,
+		},
+		{
+			currentVersion: "3.12.6",
+			constraint:     ">= 3.13",
+			minDate:        "2020-01-19",
+			expected:       false,
+		},
+		{
+			currentVersion: "3.13.0",
+			constraint:     ">= 3.13",
+			minDate:        "2020-01-19",
+			expected:       true,
+		},
+		{
+			currentVersion: "dev",
+			constraint:     ">= 3.13",
+			minDate:        "2020-01-19",
+			expected:       true,
+		},
+		{
+			currentVersion: "54959_2020-01-29_9258595",
+			minDate:        "2020-01-19",
+			constraint:     ">= 999.13",
+			expected:       true,
+		},
+		{
+			currentVersion: "54959_2020-01-29_9258595",
+			minDate:        "2020-01-30",
+			constraint:     ">= 999.13",
+			expected:       false,
+		},
+		{
+			currentVersion: "54959_2020-01-29_9258595",
+			minDate:        "2020-01-29",
+			constraint:     ">= 0.0",
+			expected:       true,
+		},
 	} {
-		actual, err := sourcegraphVersionCheck(tc.currentVersion, tc.constraint)
+		actual, err := sourcegraphVersionCheck(tc.currentVersion, tc.constraint, tc.minDate)
 		if err != nil {
 			t.Errorf("err: %s", err)
 		}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/sourcegraph/src-cli
 go 1.13
 
 require (
+	github.com/Masterminds/semver v1.5.0
 	github.com/dustin/go-humanize v1.0.0
 	github.com/fatih/color v1.9.0
 	github.com/gogo/protobuf v1.3.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
+github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/fatih/color v1.9.0 h1:8xPHl4/q1VyqGIPif1F+1V3Y3lSmrq01EabUW3CoW5s=


### PR DESCRIPTION
This changes the behavior of `campaign create` to only check for the
`-branch` flag if the Sourcegraph instance's version is either

- >= 3.13
- dev
- a custom build date

I'm aware that the "custom build date" check is flaky, but what we want
at the moment is simply to say: only check for this flag if your
Sourcegraph version is newer than `3.12.x`.