### PR TITLE
Allow empty roots to be supplied explicitly to lsif upload command.

### DIFF
--- a/cmd/src/lsif_upload.go
+++ b/cmd/src/lsif_upload.go
@@ -91,7 +91,7 @@ Examples:
 		}
 		fmt.Println("File: " + *fileFlag)
 
-		if rootFlag == nil || *rootFlag == "" {
+		if rootFlag == nil {
 			checkError := func(err error) {
 				if err != nil {
 					fmt.Println(err)


### PR DESCRIPTION
See https://sourcegraph.slack.com/archives/CHXHX7XAS/p1581636650265900 for context.