### PR TITLE
Log scopeQuery as it will be sent to Sourcegraph

### DIFF
--- a/cmd/src/actions_exec.go
+++ b/cmd/src/actions_exec.go
@@ -314,7 +314,7 @@ Format of the action JSON files:
 		})
 
 		if *verbose {
-			log.Printf("# Querying %s for repositories matching %q...", cfg.Endpoint, action.ScopeQuery)
+			log.Printf("# Querying %s for repositories matching '%s'...", cfg.Endpoint, action.ScopeQuery)
 		}
 
 		// Query repos over which to run action

--- a/cmd/src/actions_scope_query.go
+++ b/cmd/src/actions_scope_query.go
@@ -58,6 +58,10 @@ Examples:
 
 		ctx := context.Background()
 
+		if *verbose {
+			log.Printf("# scopeQuery in action definition: %s\n", action.ScopeQuery)
+		}
+
 		repos, err := actionRepos(ctx, *verbose, action.ScopeQuery)
 		if err != nil {
 			return err


### PR DESCRIPTION
This should help with the problem encountered in #125 by making it easier to debug the scopeQuery.

The change here adds another logline to `src actions scope-query` when the `-v` flag is given and changes the existing log in `src actions exec` to show the scope query as it will be sent over the wire.

#### Example

`unescaped.action.json`:
```json
{
  "scopeQuery": "repo:github\.com\/sourcegraph\/sourcegraph$|basic-code-intel$ repohasfile:yarn.lock file:^package.json$ rxjs"
}
```
```
$ src -v action scope-query -f unescaped.action.json                                                                                                                -130-
# scopeQuery in action definition: repo:githubcom/sourcegraph/sourcegraph$|basic-code-intel$ repohasfile:yarn.lock file:^package.json$ rxjs
# 1 repositories match.
github.com/sourcegraph/sourcegraph-basic-code-intel
```

`escaped.action.json`:
```json
{
  "scopeQuery": "repo:github\\.com\\/sourcegraph\\/sourcegraph$|basic-code-intel$ repohasfile:yarn.lock file:^package.json$ rxjs"
}
```
```
$ src -v action scope-query -f escaped.action.json
# scopeQuery in action definition: repo:github\.com\/sourcegraph\/sourcegraph$|basic-code-intel$ repohasfile:yarn.lock file:^package.json$ rxjs
# 2 repositories match.
github.com/sourcegraph/sourcegraph-basic-code-intel
github.com/sourcegraph/sourcegraph
```