### PR TITLE
Improve verbose output of src action exec

### DIFF
--- a/cmd/src/actions_exec_backend_runner.go
+++ b/cmd/src/actions_exec_backend_runner.go
@@ -82,7 +82,7 @@ func (x *actionExecutor) do(ctx context.Context, repo ActionRepo) (err error) {
 	}
 
 	x.updateRepoStatus(repo, status)
-	x.logger.RepoFinished(repo.Name, err)
+	x.logger.RepoFinished(repo.Name, len(patch) > 0, err)
 
 	// Add to cache if successful.
 	if err == nil {


### PR DESCRIPTION
This changes the `actionLogger` to show the different states of actions in repositories through colors:

<img width="1130" alt="Screen Shot 2020-02-25 at 14 48 05" src="https://user-images.githubusercontent.com/1185253/75253017-1121b780-57de-11ea-87aa-7c507e3c65ec.png">
