### PR TITLE
Add -create-plan flag to 'src action exec'

### DIFF
--- a/cmd/src/actions_exec.go
+++ b/cmd/src/actions_exec.go
@@ -226,17 +226,25 @@ Format of the action JSON files:
 		err = executor.wait()
 
 		patches := executor.allPatches()
+		if len(patches) == 0 {
+			return err
+		}
+
+		logger.Infof("Action produced %d patches.\n", len(patches))
 
 		if !*createPlanFlag {
 			if err != nil {
 				return err
 			}
 
-			logger.Infof("Action produced %d patches.\n", len(patches))
 			return json.NewEncoder(os.Stdout).Encode(patches)
 		}
 
 		if err != nil {
+			if len(patches) == 0 {
+				return err
+			}
+
 			canInput := isatty.IsTerminal(os.Stdin.Fd()) || isatty.IsCygwinTerminal(os.Stdin.Fd())
 			if !canInput {
 				return err

--- a/cmd/src/actions_exec_backend.go
+++ b/cmd/src/actions_exec_backend.go
@@ -87,9 +87,9 @@ func (x *actionExecutor) allPatches() []CampaignPlanPatch {
 	patches := make([]CampaignPlanPatch, 0, len(x.repos))
 	x.reposMu.Lock()
 	defer x.reposMu.Unlock()
-	for _, repoStatus := range x.repos {
-		if patch := repoStatus.Patch; patch != (CampaignPlanPatch{}) {
-			patches = append(patches, repoStatus.Patch)
+	for _, status := range x.repos {
+		if patch := status.Patch; patch != (CampaignPlanPatch{}) && status.Err == nil {
+			patches = append(patches, status.Patch)
 		}
 	}
 	return patches

--- a/cmd/src/actions_exec_logger.go
+++ b/cmd/src/actions_exec_logger.go
@@ -11,13 +11,16 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/mattn/go-isatty"
+	"github.com/neelance/parallel"
 	"github.com/pkg/errors"
 )
 
 var (
+	boldBlack = color.New(color.Bold, color.FgBlack)
 	boldRed   = color.New(color.Bold, color.FgRed)
 	boldGreen = color.New(color.Bold, color.FgGreen)
 	green     = color.New(color.FgGreen)
+	hiGreen   = color.New(color.FgHiGreen)
 	yellow    = color.New(color.FgYellow)
 	grey      = color.New(color.FgHiBlack)
 )
@@ -47,15 +50,52 @@ func newActionLogger(verbose, keepLogs bool) *actionLogger {
 	}
 }
 
+func (a *actionLogger) Start() {
+	if a.verbose {
+		fmt.Fprintln(os.Stderr)
+	}
+}
+
 func (a *actionLogger) Warnf(format string, args ...interface{}) {
 	if a.verbose {
-		fmt.Fprintf(os.Stderr, color.YellowString("WARNING: ")+format, args...)
+		yellow.Fprintf(os.Stderr, "WARNING: "+format, args...)
+	}
+}
+
+func (a *actionLogger) ActionFailed(err error, patches []CampaignPlanPatch) {
+	if !a.verbose {
+		return
+	}
+	fmt.Fprintln(os.Stderr)
+	if perr, ok := err.(parallel.Errors); ok {
+		if len(patches) > 0 {
+			yellow.Fprintf(os.Stderr, "✗  Action produced %d patches but failed with %d errors.\n\n", len(patches), len(perr))
+		} else {
+			yellow.Fprintf(os.Stderr, "✗  Action failed with %d errors.\n", len(perr))
+		}
+	} else {
+		if len(patches) > 0 {
+			yellow.Fprintf(os.Stderr, "✗  Action produced %d patches but failed with error: %s\n\n", len(patches), err)
+		} else {
+			yellow.Fprintf(os.Stderr, "✗  Action failed with error: %s\n\n", err)
+		}
+	}
+}
+
+func (a *actionLogger) ActionSuccess(patches []CampaignPlanPatch, newLines bool) {
+	if a.verbose {
+		fmt.Fprintln(os.Stderr)
+		format := "✔  Action produced %d patches."
+		if newLines {
+			format = format + "\n\n"
+		}
+		hiGreen.Fprintf(os.Stderr, format, len(patches))
 	}
 }
 
 func (a *actionLogger) Infof(format string, args ...interface{}) {
 	if a.verbose {
-		fmt.Fprintf(os.Stderr, format, args...)
+		grey.Fprintf(os.Stderr, format, args...)
 	}
 }
 
@@ -85,10 +125,6 @@ func (a *actionLogger) AddRepo(repo ActionRepo) (string, error) {
 	a.logFiles[repo.Name] = logFile
 	a.logWriters[repo.Name] = logWriter
 
-	if a.verbose {
-		fmt.Fprintf(os.Stderr, "%s -> Enqueued. Logfile created at %s\n", grey.Sprint(repo.Name), logFile.Name())
-	}
-
 	return logFile.Name(), nil
 }
 
@@ -111,21 +147,28 @@ func (a *actionLogger) write(repoName string, c *color.Color, format string, arg
 }
 
 func (a *actionLogger) RepoFinished(repoName string, patchProduced bool, actionErr error) error {
+	a.mu.Lock()
+	f, ok := a.logFiles[repoName]
+	if !ok {
+		a.mu.Unlock()
+		return nil
+	}
+	a.mu.Unlock()
+
 	if actionErr != nil {
-		a.write(repoName, boldRed, "%s\n", actionErr)
+		if a.keepLogs {
+			a.write(repoName, boldRed, "Action failed. Logfile: %s\n", f.Name())
+		} else {
+			a.write(repoName, boldRed, "Action failed.\n")
+		}
 	} else if patchProduced {
-		a.write(repoName, boldGreen, "Finished. Patch generated.\n")
+		a.write(repoName, boldGreen, "Finished. Patch produced.\n")
 	} else {
-		a.write(repoName, grey, "Finished. No patch generated.\n")
+		a.write(repoName, grey, "Finished. No patch produced.\n")
 	}
 
 	a.mu.Lock()
 	defer a.mu.Unlock()
-
-	f, ok := a.logFiles[repoName]
-	if !ok {
-		return nil
-	}
 
 	delete(a.logFiles, repoName)
 	delete(a.logWriters, repoName)
@@ -144,15 +187,15 @@ func (a *actionLogger) RepoStarted(repoName, rev string, steps []*ActionStep) {
 }
 
 func (a *actionLogger) CommandStepStarted(repoName string, step int, args []string) {
-	a.write(repoName, yellow, "Step %d: command %v\n", step, args)
+	a.write(repoName, yellow, "[Step %d] command %v\n", step, args)
 }
 
 func (a *actionLogger) CommandStepErrored(repoName string, step int, err error) {
-	a.write(repoName, boldRed, "Step %d: error: %s.\n", step, err)
+	a.write(repoName, boldRed, "[Step %d] %s.\n", step, err)
 }
 
 func (a *actionLogger) CommandStepDone(repoName string, step int) {
-	a.write(repoName, yellow, "Step %d: done.\n", step)
+	a.write(repoName, yellow, "[Step %d] Done.\n", step)
 }
 
 func (a *actionLogger) DockerStepStarted(repoName string, step int, dockerfile, image string) {
@@ -160,13 +203,13 @@ func (a *actionLogger) DockerStepStarted(repoName string, step int, dockerfile, 
 	if dockerfile != "" {
 		fromDockerfile = " (built from inline Dockerfile)"
 	}
-	a.write(repoName, yellow, "Step %d: docker run %v%s\n", step, image, fromDockerfile)
+	a.write(repoName, yellow, "[Step %d] docker run %v%s\n", step, image, fromDockerfile)
 }
 
 func (a *actionLogger) DockerStepErrored(repoName string, step int, err error, elapsed time.Duration) {
-	a.write(repoName, boldRed, "Step %d: error: %s. (%s)\n", step, err, elapsed)
+	a.write(repoName, boldRed, "[Step %d] %s. (%s)\n", step, err, elapsed)
 }
 
 func (a *actionLogger) DockerStepDone(repoName string, step int, elapsed time.Duration) {
-	a.write(repoName, yellow, "Step %d: done. (%s)\n", step, elapsed)
+	a.write(repoName, yellow, "[Step %d] Done. (%s)\n", step, elapsed)
 }

--- a/cmd/src/actions_exec_logger.go
+++ b/cmd/src/actions_exec_logger.go
@@ -114,7 +114,9 @@ func (a *actionLogger) RepoFinished(repoName string, patchProduced bool, actionE
 	if actionErr != nil {
 		a.write(repoName, boldRed, "%s\n", actionErr)
 	} else if patchProduced {
-		a.write(repoName, boldGreen, "Patch generated.\n")
+		a.write(repoName, boldGreen, "Finished. Patch generated.\n")
+	} else {
+		a.write(repoName, grey, "Finished. No patch generated.\n")
 	}
 
 	a.mu.Lock()

--- a/cmd/src/actions_scope_query.go
+++ b/cmd/src/actions_scope_query.go
@@ -62,9 +62,12 @@ Examples:
 			log.Printf("# scopeQuery in action definition: %s\n", action.ScopeQuery)
 		}
 
-		repos, err := actionRepos(ctx, action.ScopeQuery)
+		repos, skipped, err := actionRepos(ctx, action.ScopeQuery)
 		if err != nil {
 			return err
+		}
+		for _, r := range skipped {
+			log.Printf("# Skipping repository %s because we couldn't determine default branch.\n", r)
 		}
 		if *verbose {
 			log.Printf("# %d repositories match.", len(repos))

--- a/cmd/src/format.go
+++ b/cmd/src/format.go
@@ -98,7 +98,7 @@ func parseTemplate(text string) (*template.Template, error) {
 		"friendlyCampaignPlanCreatedMessage": func(campaignPlan CampaignPlan) string {
 			var buf bytes.Buffer
 			fmt.Fprintln(&buf)
-			fmt.Fprintln(&buf, color.HiGreenString("✔  Campaign plan saved."), "\n\nTo preview and run the campaign (and create branches and changesets):")
+			fmt.Fprintln(&buf, color.HiGreenString("✔  Campaign plan saved."), "\n\nPreview and create this campaign on Sourcegraph using one of the following options:")
 			fmt.Fprintln(&buf)
 			fmt.Fprintln(&buf, " ", color.HiCyanString("▶ Web:"), campaignPlan.PreviewURL, color.HiBlackString("or"))
 			cliCommand := fmt.Sprintf("src campaigns create -plan=%s -branch=DESIRED-BRANCH-NAME", campaignPlan.ID)


### PR DESCRIPTION
When the -create-plan flag is given the `src action exec` command will
create a campaign plan from the produced patches, making it not
necessary to pipe the output to `src campaign plan create-from-patches`.

If the execution of the action failed in a subset of the repositories,
the user is prompted and asked whether they would create a campaign plan
from the successfully produced patches or not.