### PR TITLE
Log cache hits when running 'src action exec'

### DIFF
--- a/cmd/src/actions_exec_backend_runner.go
+++ b/cmd/src/actions_exec_backend_runner.go
@@ -41,10 +41,9 @@ func (x *actionExecutor) do(ctx context.Context, repo ActionRepo) (err error) {
 	if result, ok, err := x.opt.cache.get(ctx, cacheKey); err != nil {
 		return errors.Wrapf(err, "checking cache for %s", repo.Name)
 	} else if ok {
-		x.updateRepoStatus(repo, ActionRepoStatus{
-			Cached: true,
-			Patch:  result,
-		})
+		status := ActionRepoStatus{Cached: true, Patch: result}
+		x.updateRepoStatus(repo, status)
+		x.logger.RepoCacheHit(repo, status.Patch != CampaignPlanPatch{})
 		return nil
 	}
 

--- a/cmd/src/actions_exec_logger.go
+++ b/cmd/src/actions_exec_logger.go
@@ -17,6 +17,7 @@ import (
 var (
 	boldRed   = color.New(color.Bold, color.FgRed)
 	boldGreen = color.New(color.Bold, color.FgGreen)
+	green     = color.New(color.FgGreen)
 	yellow    = color.New(color.FgYellow)
 	grey      = color.New(color.FgHiBlack)
 )
@@ -55,6 +56,17 @@ func (a *actionLogger) Warnf(format string, args ...interface{}) {
 func (a *actionLogger) Infof(format string, args ...interface{}) {
 	if a.verbose {
 		fmt.Fprintf(os.Stderr, format, args...)
+	}
+}
+
+func (a *actionLogger) RepoCacheHit(repo ActionRepo, patchProduced bool) {
+	if a.verbose {
+		if patchProduced {
+			fmt.Fprintf(os.Stderr, "%s -> Cached result with patch found.\n", boldGreen.Sprint(repo.Name))
+			return
+		}
+
+		fmt.Fprintf(os.Stderr, "%s -> Cached result without patch found.\n", green.Sprint(repo.Name))
 	}
 }
 


### PR DESCRIPTION
I forgot to add this when introducing the new logger. This now logs when a result for a repository was found in the cache and depending on whether the result has a patch it's either bold or not bold.

<img width="897" alt="Screen Shot 2020-02-27 at 14 54 57" src="https://user-images.githubusercontent.com/1185253/75451645-309d1980-5971-11ea-9c0b-e99f7ecd4c2d.png">