### PR TITLE
Use git diff in temp repository instead of diff over directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,6 @@ If you want to use `src` with your own Sourcegraph instance set the `SRC_ENDPOIN
 SRC_ENDPOINT=https://sourcegraph.example.com src search
 ```
 
-> NOTE: If you want to use the `src actions exec` functionality on macOS, we recommend installing the `zip` and `diffutils` packages from Homebrew (or any other package manager that has up-to-date versions) as the versions that come with macOS are quite old. This will solve issues related to being unable to unzip archives and diffing files.
-
 ### Authentication
 
 Some Sourcegraph instances will be configured to require authentication. You can do so via the environment:

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ For Sourcegraph 3.12 and older, run the following commands verbatim (against sou
 https://github.com/sourcegraph/src-cli/releases/download/{version}/{binary}
 ````
 
+> NOTE: If you want to use the 'src actions exec' functionality, make sure that git is installed and accessible by src.
+
 #### Mac OS
 
 ```bash

--- a/cmd/src/actions_exec.go
+++ b/cmd/src/actions_exec.go
@@ -21,15 +21,6 @@ import (
 	"github.com/sourcegraph/go-diff/diff"
 )
 
-// Older versions of GNU diff (< 3.3) do not support all the flags we want, but
-// since macOS Mojave and Catalina ship with GNU diff 2.8.1, we try to detect
-// missing flags and degrade behavior gracefully instead of failing. check for
-// the flags and degrade if they're not available.
-var (
-	diffSupportsNoDereference = false
-	diffSupportsColor         = false
-)
-
 type Action struct {
 	ScopeQuery string        `json:"scopeQuery,omitempty"`
 	Steps      []*ActionStep `json:"steps"`
@@ -178,22 +169,6 @@ Format of the action JSON files:
 		ctx := context.Background()
 
 		logger := newActionLogger(*verbose, *keepLogsFlag)
-
-		diffSupportsNoDereference, err = diffSupportsFlag(ctx, "--no-dereference")
-		if err != nil {
-			return err
-		}
-		if !diffSupportsNoDereference {
-			logger.Warnf("Local installation of 'diff' doesn't support '%s' flag. Consider upgrading to GNU diff >=3.7.\n", "--no-dereference")
-		}
-
-		diffSupportsColor, err = diffSupportsFlag(ctx, "--color")
-		if err != nil {
-			return err
-		}
-		if !diffSupportsColor {
-			logger.Warnf("Local installation of 'diff' doesn't support '%s' flag. Consider upgrading to GNU diff >=3.7.\n", "--color")
-		}
 
 		err = validateAction(ctx, action)
 		if err != nil {

--- a/cmd/src/actions_exec.go
+++ b/cmd/src/actions_exec.go
@@ -137,6 +137,10 @@ Format of the action JSON files:
 	handler := func(args []string) error {
 		flagSet.Parse(args)
 
+		if !isGitAvailable() {
+			return errors.New("Could not find git in $PATH. 'src actions exec' requires git to be available.")
+		}
+
 		if *cacheDirFlag == displayUserCacheDir {
 			*cacheDirFlag = cacheDir
 		}
@@ -463,4 +467,12 @@ func diffStatDiagram(stat diff.Stat) string {
 		deleted *= x
 	}
 	return color.GreenString(strings.Repeat("+", int(added))) + color.RedString(strings.Repeat("-", int(deleted)))
+}
+
+func isGitAvailable() bool {
+	cmd := exec.Command("git", "version")
+	if err := cmd.Run(); err != nil {
+		return false
+	}
+	return true
 }


### PR DESCRIPTION
This fixes #137.

Before this change `src actions exec` produced patches by doing the
following:

1. Download ZIP archive of repository
2. Unzip archive into directory A
3. Run action in directory A
4. Unzip archive into directory B
5. Run `diff A B`
6. Strip 'A' and 'B' prefixes from produced patches

The problem with this approach was that it didn't respect the .gitignore
file in a repository.

And since we run diff _outside_ the folder it's non-trivial to make it
respect the .gitignore, which contains pattern with the assumption that
the root directory is the repository.

This change here uses the following approach:

1. Download ZIP archive of repository
2. Unzip archive into directory A
3. Run `git init && git add --all --force & git commit -am "init"` in directory
4. Run action in directory A
5. Run `git add --all && git diff --cached` in directory A

That gives us a proper diff produced by git, respecting .gitignore.

There's a cost involved to making a commit with all the files (since the
git objects have to be written), but from manual testing I can say that
it's not noticably slower than unzipping the archive a second time, as
we previously did.

It also gets us rid of the dependency on `diff`, of which users have a
ton of different versions installed.