### PR TITLE
Fix new git based diff generation file paths

### DIFF
--- a/cmd/src/actions_exec_backend_runner.go
+++ b/cmd/src/actions_exec_backend_runner.go
@@ -239,7 +239,10 @@ func runAction(ctx context.Context, prefix, repoID, repoName, rev string, steps 
 		return nil, errors.Wrap(err, "git add failed")
 	}
 
-	// --no-prefix omits the a/ and b/ folder prefixes, otherwise the diff would be interpreted as renaming the file
+	// As of Sourcegraph 3.14 we only support unified diff format.
+	// That means we need to strip away the `a/` and `/b` prefixes with `--no-prefix`.
+	// See: https://github.com/sourcegraph/sourcegraph/blob/82d5e7e1562fef6be5c0b17f18631040fd330835/enterprise/internal/campaigns/service.go#L324-L329
+	// 
 	diffOut, err := runGitCmd("diff", "--cached", "--no-prefix")
 	if err != nil {
 		return nil, errors.Wrap(err, "git diff failed")

--- a/cmd/src/actions_exec_backend_runner.go
+++ b/cmd/src/actions_exec_backend_runner.go
@@ -239,7 +239,8 @@ func runAction(ctx context.Context, prefix, repoID, repoName, rev string, steps 
 		return nil, errors.Wrap(err, "git add failed")
 	}
 
-	diffOut, err := runGitCmd("diff", "--cached")
+	// --no-prefix omits the a/ and b/ folder prefixes, otherwise the diff would be interpreted as renaming the file
+	diffOut, err := runGitCmd("diff", "--cached", "--no-prefix")
 	if err != nil {
 		return nil, errors.Wrap(err, "git diff failed")
 	}


### PR DESCRIPTION
Before, `/a` -> `/b` was the prefix for all files, so new files have the `/b` prefix and existing ones are moved.
This flag omits them.