### PR TITLE
Handle new Sourcegraph 0.0.0+dev version

### DIFF
--- a/cmd/src/campaigns_create.go
+++ b/cmd/src/campaigns_create.go
@@ -301,7 +301,7 @@ func getSourcegraphVersion() (string, error) {
 }
 
 func sourcegraphVersionCheck(version, constraint, minDate string) (bool, error) {
-	if version == "dev" {
+	if version == "dev" || version == "0.0.0+dev" {
 		return true, nil
 	}
 

--- a/cmd/src/campaigns_create_test.go
+++ b/cmd/src/campaigns_create_test.go
@@ -38,6 +38,12 @@ func TestSourcegraphVersionCheck(t *testing.T) {
 			expected:       true,
 		},
 		{
+			currentVersion: "0.0.0+dev",
+			constraint:     ">= 3.13",
+			minDate:        "2020-01-19",
+			expected:       true,
+		},
+		{
 			currentVersion: "54959_2020-01-29_9258595",
 			minDate:        "2020-01-19",
 			constraint:     ">= 999.13",


### PR DESCRIPTION
Seems like shortly after we introduced the version check here our format changed: https://github.com/sourcegraph/sourcegraph/pull/8157