### PR TITLE
Add BaseRef field to CampaignPlanPatch and use commitID in BaseRevision

### DIFF
--- a/cmd/src/actions_exec_backend_runner.go
+++ b/cmd/src/actions_exec_backend_runner.go
@@ -68,6 +68,7 @@ func (x *actionExecutor) do(ctx context.Context, repo ActionRepo) (err error) {
 		status.Patch = CampaignPlanPatch{
 			Repository:   repo.ID,
 			BaseRevision: repo.Rev,
+			BaseRef:      repo.BaseRef,
 			Patch:        string(patch),
 		}
 	}

--- a/cmd/src/campaign_plans_create_from_patches.go
+++ b/cmd/src/campaign_plans_create_from_patches.go
@@ -97,6 +97,33 @@ func createCampaignPlanFromPatches(
 	var result struct {
 		CreateCampaignPlanFromPatches CampaignPlan
 	}
+
+	version, err := getSourcegraphVersion()
+	if err != nil {
+		return err
+	}
+	supportsBaseRef, err := sourcegraphVersionCheck(version, ">= 3.14-0", "2020-03-11")
+	if err != nil {
+		return err
+	}
+
+	// If we're on Sourcegraph >=3.14 the GraphQL API is "fixed" and accepts
+	// patches with `BaseRevision` and `BaseRef` fields. <3.14 expects a ref
+	// (e.g. "refs/heads/master") in `BaseRevision`, so we need to copy the
+	// value over.
+	if !supportsBaseRef {
+		patchesWithoutBaseRef := make([]CampaignPlanPatch, len(patches))
+		for i, p := range patches {
+			patchesWithoutBaseRef[i] = CampaignPlanPatch{
+				Repository:   p.Repository,
+				BaseRevision: p.BaseRef,
+				BaseRef:      "IGNORE-THIS",
+				Patch:        p.Patch,
+			}
+		}
+		patches = patchesWithoutBaseRef
+	}
+
 	return (&apiRequest{
 		query:  query,
 		vars:   map[string]interface{}{"patches": patches},

--- a/cmd/src/campaign_plans_create_from_patches.go
+++ b/cmd/src/campaign_plans_create_from_patches.go
@@ -102,7 +102,7 @@ func createCampaignPlanFromPatches(
 	if err != nil {
 		return err
 	}
-	supportsBaseRef, err := sourcegraphVersionCheck(version, ">= 3.14-0", "2020-03-11")
+	supportsBaseRef, err := sourcegraphVersionCheck(version, ">= 3.14.0", "2020-03-11")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This implements the src CLI tasks of https://github.com/sourcegraph/sourcegraph/issues/8846

With this change src CLI uses the commit ID (instead of refspec) as the
`CampaignPlanPatch.BaseRevision` when creating a `CampaignPlan`.

It also adds the additional `baseRef` field to `CampaignPlanPatch` and
sends that to the GraphQL.

Since Sourcegraph <3.14 expects the `baseRevision` of a
`CampaignPlanPatch` to contain a ref (e.g. "refs/heads/master") we check
the Sourcegraph version and fall back to that behaviour so that
customers can use a newer src CLI version with their <3.14
instance.

With the addition of these fields to ActionRepo and CampaignPlanPatch
the cache of src CLI is now also busted when the revision of the default
branch of a repo changes.