### PR TITLE
Log action errors

### DIFF
--- a/cmd/src/actions_exec_logger.go
+++ b/cmd/src/actions_exec_logger.go
@@ -159,9 +159,9 @@ func (a *actionLogger) RepoFinished(repoName string, patchProduced bool, actionE
 
 	if actionErr != nil {
 		if a.keepLogs {
-			a.write(repoName, boldRed, "Action failed. Logfile: %s\n", f.Name())
+			a.write(repoName, boldRed, "Action failed: %q (Logfile: %s)\n", actionErr, f.Name())
 		} else {
-			a.write(repoName, boldRed, "Action failed.\n")
+			a.write(repoName, boldRed, "Action failed: %q\n", actionErr)
 		}
 	} else if patchProduced {
 		a.write(repoName, boldGreen, "Finished. Patch produced.\n")

--- a/cmd/src/actions_terminal_ui.go
+++ b/cmd/src/actions_terminal_ui.go
@@ -73,7 +73,7 @@ func newTerminalUI(keepLogs bool) func(reposMap map[ActionRepo]ActionRepoStatus)
 			case status.Cached || !status.FinishedAt.IsZero():
 				if status.Err != nil {
 					statusColor = color.RedString
-					statusText = "error: see " + status.LogFile
+					statusText = fmt.Sprintf("error: %q (see %s)", status.Err, status.LogFile)
 					logFileText = "" // don't show twice
 				} else {
 					statusColor = color.GreenString


### PR DESCRIPTION
Previously we only directed the user to the logfile, but there are some
errors that are independent of the action's step: failing to fetch the
ZIP archive, failing to extract ZIP archive, etc.

(This addresses point 2 in https://gist.github.com/unknwon/b7c80d23e6b2a624e50e4073454959e0)

Those are not in the logfiles and as it turns out we never logged them.

This change fixes that.

#### Before
<img width="1278" alt="log_error_before" src="https://user-images.githubusercontent.com/1185253/77901876-a18d6500-7280-11ea-8c40-47c350516348.png">



#### After

<img width="1280" alt="log_error_after" src="https://user-images.githubusercontent.com/1185253/77901887-a6521900-7280-11ea-80b2-a0a2d3e1dfc7.png">
