### PR TITLE
Add -clear-cache flag to src action exec

### DIFF
--- a/cmd/src/actions_cache.go
+++ b/cmd/src/actions_cache.go
@@ -20,6 +20,7 @@ type actionExecutionCacheKey struct {
 type actionExecutionCache interface {
 	get(ctx context.Context, key actionExecutionCacheKey) (result PatchInput, ok bool, err error)
 	set(ctx context.Context, key actionExecutionCacheKey, result PatchInput) error
+	clear(ctx context.Context, key actionExecutionCacheKey) error
 }
 
 type actionExecutionDiskCache struct {
@@ -82,6 +83,15 @@ func (c actionExecutionDiskCache) set(ctx context.Context, key actionExecutionCa
 	return ioutil.WriteFile(path, data, 0600)
 }
 
+func (c actionExecutionDiskCache) clear(ctx context.Context, key actionExecutionCacheKey) error {
+	path, err := c.cacheFilePath(key)
+	if err != nil {
+		return err
+	}
+
+	return os.Remove(path)
+}
+
 // actionExecutionNoOpCache is an implementation of actionExecutionCache that does not store or
 // retrieve cache entries.
 type actionExecutionNoOpCache struct{}
@@ -91,5 +101,9 @@ func (actionExecutionNoOpCache) get(ctx context.Context, key actionExecutionCach
 }
 
 func (actionExecutionNoOpCache) set(ctx context.Context, key actionExecutionCacheKey, result PatchInput) error {
+	return nil
+}
+
+func (actionExecutionNoOpCache) clear(ctx context.Context, key actionExecutionCacheKey) error {
 	return nil
 }

--- a/cmd/src/actions_exec.go
+++ b/cmd/src/actions_exec.go
@@ -164,9 +164,6 @@ Format of the action JSON files:
 			return errors.New("cache is not a valid path")
 		}
 
-		if *clearCacheFlag {
-		}
-
 		var (
 			actionFile []byte
 			err        error

--- a/cmd/src/actions_exec.go
+++ b/cmd/src/actions_exec.go
@@ -134,9 +134,12 @@ Format of the action JSON files:
 	var (
 		fileFlag        = flagSet.String("f", "-", "The action file. If not given or '-' standard input is used. (Required)")
 		parallelismFlag = flagSet.Int("j", runtime.GOMAXPROCS(0), "The number of parallel jobs.")
-		cacheDirFlag    = flagSet.String("cache", displayUserCacheDir, "Directory for caching results.")
-		keepLogsFlag    = flagSet.Bool("keep-logs", false, "Do not remove execution log files when done.")
-		timeoutFlag     = flagSet.Duration("timeout", defaultTimeout, "The maximum duration a single action run can take (excluding the building of Docker images).")
+
+		cacheDirFlag   = flagSet.String("cache", displayUserCacheDir, "Directory for caching results.")
+		clearCacheFlag = flagSet.Bool("clear-cache", false, "Remove possibly cached results for an action before executing it.")
+
+		keepLogsFlag = flagSet.Bool("keep-logs", false, "Do not remove execution log files when done.")
+		timeoutFlag  = flagSet.Duration("timeout", defaultTimeout, "The maximum duration a single action run can take (excluding the building of Docker images).")
 
 		createPatchSetFlag      = flagSet.Bool("create-patchset", false, "Create a patch set from the produced set of patches. When the execution of the action fails in a single repository a prompt will ask to confirm or reject the patch set creation.")
 		forceCreatePatchSetFlag = flagSet.Bool("force-create-patchset", false, "Force creation of patch set from the produced set of patches, without asking for confirmation even when the execution of the action failed for a subset of repositories.")
@@ -159,6 +162,9 @@ Format of the action JSON files:
 			// This can only happen if `userCacheDir()` fails or the user
 			// specifies a blank string.
 			return errors.New("cache is not a valid path")
+		}
+
+		if *clearCacheFlag {
 		}
 
 		var (
@@ -196,9 +202,10 @@ Format of the action JSON files:
 		}
 
 		opts := actionExecutorOptions{
-			timeout:  *timeoutFlag,
-			keepLogs: *keepLogsFlag,
-			cache:    actionExecutionDiskCache{dir: *cacheDirFlag},
+			timeout:    *timeoutFlag,
+			keepLogs:   *keepLogsFlag,
+			clearCache: *clearCacheFlag,
+			cache:      actionExecutionDiskCache{dir: *cacheDirFlag},
 		}
 		if !*verbose {
 			opts.onUpdate = newTerminalUI(*keepLogsFlag)

--- a/cmd/src/actions_exec_backend.go
+++ b/cmd/src/actions_exec_backend.go
@@ -12,7 +12,9 @@ type actionExecutorOptions struct {
 	keepLogs bool
 	timeout  time.Duration
 
-	cache    actionExecutionCache
+	clearCache bool
+	cache      actionExecutionCache
+
 	onUpdate func(map[ActionRepo]ActionRepoStatus)
 }
 


### PR DESCRIPTION
This fixes https://github.com/sourcegraph/src-cli/issues/165 and works like this:

<img width="1243" alt="Screen Shot 2020-03-30 at 16 25 38" src="https://user-images.githubusercontent.com/1185253/77923807-3c973680-72a3-11ea-8c01-99969b4ddd69.png">
