### PR TITLE
Remove trailing slash from SRC_ENDPOINT

### DIFF
--- a/cmd/src/main.go
+++ b/cmd/src/main.go
@@ -95,7 +95,7 @@ func readConfig() (*config, error) {
 		cfg.AccessToken = envToken
 	}
 	if *endpoint != "" {
-		cfg.Endpoint = strings.TrimSuffix(*endpoint, "/")
+		cfg.Endpoint = *endpoint
 	}
 	if cfg.Endpoint == "" {
 		if endpoint := os.Getenv("SRC_ENDPOINT"); endpoint != "" {
@@ -105,5 +105,8 @@ func readConfig() (*config, error) {
 	if cfg.Endpoint == "" {
 		cfg.Endpoint = "https://sourcegraph.com"
 	}
+
+	cfg.Endpoint = strings.TrimSuffix(cfg.Endpoint, "/")
+
 	return &cfg, nil
 }


### PR DESCRIPTION
We already had this in place, just not for `SRC_ENDPOINT`. This should fix https://github.com/sourcegraph/src-cli/issues/111 even though I cannot reproduce it with my local setup. I assume it only happens when nginx is in front of sourcegraph.