### PR TITLE
Bump default action timeout from 2min to 15min

### DIFF
--- a/cmd/src/actions_exec.go
+++ b/cmd/src/actions_exec.go
@@ -52,7 +52,7 @@ func userCacheDir() (string, error) {
 	return filepath.Join(userCacheDir, "sourcegraph-src"), nil
 }
 
-const defaultTimeout = 2 * time.Minute
+const defaultTimeout = 15 * time.Minute
 
 func init() {
 	usage := `
@@ -139,7 +139,7 @@ Format of the action JSON files:
 		clearCacheFlag = flagSet.Bool("clear-cache", false, "Remove possibly cached results for an action before executing it.")
 
 		keepLogsFlag = flagSet.Bool("keep-logs", false, "Do not remove execution log files when done.")
-		timeoutFlag  = flagSet.Duration("timeout", defaultTimeout, "The maximum duration a single action run can take (excluding the building of Docker images).")
+		timeoutFlag  = flagSet.Duration("timeout", defaultTimeout, "The maximum duration a single action run can take.")
 
 		createPatchSetFlag      = flagSet.Bool("create-patchset", false, "Create a patch set from the produced set of patches. When the execution of the action fails in a single repository a prompt will ask to confirm or reject the patch set creation.")
 		forceCreatePatchSetFlag = flagSet.Bool("force-create-patchset", false, "Force creation of patch set from the produced set of patches, without asking for confirmation even when the execution of the action failed for a subset of repositories.")

--- a/cmd/src/actions_exec.go
+++ b/cmd/src/actions_exec.go
@@ -52,7 +52,7 @@ func userCacheDir() (string, error) {
 	return filepath.Join(userCacheDir, "sourcegraph-src"), nil
 }
 
-const defaultTimeout = 15 * time.Minute
+const defaultTimeout = 60 * time.Minute
 
 func init() {
 	usage := `


### PR DESCRIPTION
This fixes #159.

I think we could (should?) go even higher, since most of the actions I ran take their time, especially on macOS.