### PR TITLE
Hard exit when user hits Ctrl-C a second time

### DIFF
--- a/cmd/src/actions_exec.go
+++ b/cmd/src/actions_exec.go
@@ -197,6 +197,8 @@ Format of the action JSON files:
 				cancel()
 			case <-ctx.Done():
 			}
+			<-c // If user hits Ctrl-C second time, we do a hard exit
+			os.Exit(2)
 		}()
 
 		logger := newActionLogger(*verbose, *keepLogsFlag)


### PR DESCRIPTION
Right now we don't propagate the context to everything (most notably:
API requests). That means the program gets stuck when it's running a
portion of the code that doesn't use the context and the user hits
Ctrl-C.

To avoid that we listen for a second Ctrl-C and then exit with the
interrupt code 2.