### PR TITLE
Skip repositories being cloned in action exec instead of returning error

### DIFF
--- a/cmd/src/cmd.go
+++ b/cmd/src/cmd.go
@@ -124,6 +124,13 @@ type exitCodeError struct {
 	exitCode int
 }
 
+func (e *exitCodeError) Error() string {
+	if e.error != nil {
+		return fmt.Sprintf("%s (exit code: %d)", e.error, e.exitCode)
+	}
+	return fmt.Sprintf("exit code: %d", e.exitCode)
+}
+
 const (
 	graphqlErrorsExitCode = 2
 )


### PR DESCRIPTION
This fixes https://github.com/sourcegraph/sourcegraph/issues/9149

When a repository is being cloned while we execute the `scopeQuery` of
an action, the GraphQL query returns something like this:

    {
      "errors": [
        {
          "message": "repository does not exist: github.com/sourcegraphtest/alwayscloningtest",
          "path": [ "search", "results", "results", 2, "defaultBranch" ]
        }
      ],
      "data": {
        "search": {
          "results": {
            "results": [
              {
                "__typename": "Repository",
                "id": "UmVwb3NpdG9yeTox",
                "name": "github.com/sourcegraph/automation-testing",
                "defaultBranch": { "name": "refs/heads/master", "target": { "oid": "3a0d12026c1349c4aefb712145433cc26c330a06" }
                }
              },
              {
                "__typename": "Repository",
                "id": "UmVwb3NpdG9yeTozOTU=",
                "name": "github.com/sourcegraphtest/AlwaysCloningTest",
                "defaultBranch": null
              }
            ]
          }
        }
      }
    }

There is an error for `AlwaysCloningTest` but `AlwaysCloningTest` is
also being returned in the data, except that its `defaultBranch` is
`null`.

So instead of returning an error when one of the repositories is being
cloned and doesn't have a default branch, we simply check for the
existence of the `defaultBranch` attribute and if it's not there, we
skip the repository.