### PR TITLE
Fix race-condition when uploading releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,4 +24,4 @@ deploy:
   skip_cleanup: true
   on:
     tags: true
-    condition: "$TRAVIS_OS_NAME = linux"
+    condition: "$TRAVIS_OS_NAME = linux && $TRAVIS_TAG != latest"


### PR DESCRIPTION
I've realized that the cause for the sporadic "artifact already exists"
error messages when releasing is that Travis runs releases on both the
`latest` and the version-specific tag.

This only runs releases when on the version-specific commit.