### PR TITLE
Fix action create schema url

### DIFF
--- a/cmd/src/actions_create.go
+++ b/cmd/src/actions_create.go
@@ -8,7 +8,7 @@ import (
 )
 
 const actionDefinitionTemplate = `{
-  "$schema": "https://github.com/sourcegraph/src-cli/tree/master/schema/actions.schema.json",
+  "$schema": "https://raw.githubusercontent.com/sourcegraph/src-cli/master/schema/actions.schema.json",
   "scopeQuery": "",
   "steps": [
   ]


### PR DESCRIPTION
The other URL was wrong because it pointed to the HTML rendered page on GitHub, which doesn't work.