### PR TITLE
Rewrite LSIF upload command

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,4 @@
 version: "{build}"
-shallow_clone: true
 clone_folder: c:\gopath\src\github.com\sourcegraph\src-cli
 environment:
   GOPATH: c:\gopath

--- a/cmd/src/lsif_upload.go
+++ b/cmd/src/lsif_upload.go
@@ -124,7 +124,7 @@ Examples:
 		for _, v := range inferErrors {
 			return errors.New(strings.Join([]string{
 				fmt.Sprintf("error: %s", v.err),
-				fmt.Sprintf(`Unable to determine %s from environment. Either cd into a git repository or set -%s explicitly.`, v.argument, v.argument),
+				fmt.Sprintf("Unable to determine %s from environment. Either cd into a git repository or set -%s explicitly.", v.argument, v.argument),
 				argsString,
 			}, "\n\n"))
 		}

--- a/cmd/src/lsif_upload.go
+++ b/cmd/src/lsif_upload.go
@@ -123,7 +123,7 @@ Examples:
 
 		for _, v := range inferErrors {
 			return errors.New(strings.Join([]string{
-				fmt.Sprintf(`error: %s`, v.err),
+				fmt.Sprintf("error: %s", v.err),
 				fmt.Sprintf(`Unable to determine %s from environment. Either cd into a git repository or set -%s explicitly.`, v.argument, v.argument),
 				argsString,
 			}, "\n\n"))

--- a/cmd/src/lsif_upload.go
+++ b/cmd/src/lsif_upload.go
@@ -1,35 +1,17 @@
 package main
 
 import (
-	"bufio"
-	"compress/gzip"
-	"encoding/base64"
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io"
-	"io/ioutil"
-	"net/http"
-	"net/url"
 	"os"
-	"os/exec"
-	"path/filepath"
 	"strings"
 
-	"github.com/kballard/go-shellquote"
 	"github.com/mattn/go-isatty"
 	"github.com/pkg/browser"
+	"github.com/pkg/errors"
+	"github.com/sourcegraph/src-cli/internal/codeintel"
 )
-
-func isFlagSet(fs *flag.FlagSet, name string) bool {
-	var found bool
-	fs.Visit(func(f *flag.Flag) {
-		if f.Name == name {
-			found = true
-		}
-	})
-	return found
-}
 
 func init() {
 	usage := `
@@ -52,208 +34,170 @@ Examples:
     	$ src lsif upload -indexerName=lsif-elixir
 `
 
-	flagSet := flag.NewFlagSet("upload", flag.ExitOnError)
-	usageFunc := func() {
-		fmt.Fprintf(flag.CommandLine.Output(), "Usage of 'src lsif %s':\n", flagSet.Name())
-		flagSet.PrintDefaults()
-		fmt.Println(usage)
+	var flags struct {
+		repo             *string
+		commit           *string
+		file             *string
+		root             *string
+		indexer          *string
+		gitHubToken      *string
+		open             *bool
+		json             *bool
+		maxPayloadSizeMb *int
 	}
-	var (
-		repoFlag        = flagSet.String("repo", "", `The name of the repository (e.g. github.com/gorilla/mux). By default, derived from the origin remote.`)
-		commitFlag      = flagSet.String("commit", "", `The 40-character hash of the commit. Defaults to the currently checked-out commit.`)
-		fileFlag        = flagSet.String("file", "./dump.lsif", `The path to the LSIF dump file.`)
-		githubTokenFlag = flagSet.String("github-token", "", `A GitHub access token with 'public_repo' scope that Sourcegraph uses to verify you have access to the repository.`)
-		rootFlag        = flagSet.String("root", "", `The path in the repository that matches the LSIF projectRoot (e.g. cmd/project1). Defaults to the directory where the dump file is located.`)
-		indexerNameFlag = flagSet.String("indexerName", "", `The name of the indexer that generated the dump. This will override the 'toolInfo.name' field in the metadata vertex of the LSIF dump file. This must be supplied if the indexer does not set this field (in which case the upload will fail with an explicit message).`)
-		openFlag        = flagSet.Bool("open", false, `Open the LSIF upload page in your browser.`)
-		apiFlags        = newAPIFlags(flagSet)
-	)
 
-	handler := func(args []string) error {
+	flagSet := flag.NewFlagSet("upload", flag.ExitOnError)
+	flags.repo = flagSet.String("repo", "", `The name of the repository (e.g. github.com/gorilla/mux). By default, derived from the origin remote.`)
+	flags.commit = flagSet.String("commit", "", `The 40-character hash of the commit. Defaults to the currently checked-out commit.`)
+	flags.root = flagSet.String("root", "", `The path in the repository that matches the LSIF projectRoot (e.g. cmd/project1). Defaults to the directory where the dump file is located.`)
+	flags.file = flagSet.String("file", "./dump.lsif", `The path to the LSIF dump file.`)
+	flags.indexer = flagSet.String("indexer", "", `The name of the indexer that generated the dump. This will override the 'toolInfo.name' field in the metadata vertex of the LSIF dump file. This must be supplied if the indexer does not set this field (in which case the upload will fail with an explicit message).`)
+	flags.gitHubToken = flagSet.String("github-token", "", `A GitHub access token with 'public_repo' scope that Sourcegraph uses to verify you have access to the repository.`)
+	flags.open = flagSet.Bool("open", false, `Open the LSIF upload page in your browser.`)
+	flags.json = flagSet.Bool("json", false, `Output relevant state in JSON on success.`)
+	flags.maxPayloadSizeMb = flagSet.Int("max-payload-size", 100, `The maximum upload size (in megabytes). Indexes exceeding this limit will be uploaded over multiple HTTP requests.`)
+
+	parseAndValidateFlags := func(args []string) error {
 		flagSet.Parse(args)
 
-		if repoFlag == nil || *repoFlag == "" {
-			remoteURL, err := exec.Command("git", "remote", "get-url", "origin").Output()
-			if err != nil {
-				fmt.Printf("Failed to invoke git: %v\n", err)
-				fmt.Println("Unable to detect repository from environment.")
-				fmt.Println("Either cd into a git repository or set -repo explicitly.")
-				os.Exit(1)
-			}
-			*repoFlag, err = parseRemoteURL(strings.TrimSpace(string(remoteURL)))
-			if err != nil {
-				fmt.Println(err)
-				fmt.Println("Set -repo explicitly.")
-				os.Exit(1)
-			}
+		type inferError struct {
+			argument string
+			err      error
 		}
-		fmt.Println("Repository: " + *repoFlag)
+		var inferErrors []inferError
 
-		if commitFlag == nil || *commitFlag == "" {
-			commit, err := exec.Command("git", "rev-parse", "HEAD").Output()
-			if err != nil {
-				fmt.Printf("Failed to invoke git: %v\n", err)
-				fmt.Println("Unable to detect commit from environment.")
-				fmt.Println("Either cd into a git repository or set -commit explicitly.")
-				os.Exit(1)
-			}
-			*commitFlag = strings.TrimSpace(string(commit))
+		if _, err := os.Stat(*flags.file); os.IsNotExist(err) {
+			inferErrors = append(inferErrors, inferError{"file", err})
 		}
-		fmt.Println("Commit: " + *commitFlag)
 
-		if _, err := os.Stat(*fileFlag); os.IsNotExist(err) {
-			fmt.Println("File does not exist: " + *fileFlag)
-			fmt.Println("Either cd to the directory where it was generated or set -file explicitly.")
-			os.Exit(1)
+		if *flags.repo == "" {
+			if repo, err := codeintel.InferRepo(); err != nil {
+				inferErrors = append(inferErrors, inferError{"repo", err})
+			} else {
+				flags.repo = &repo
+			}
 		}
-		fmt.Println("File: " + *fileFlag)
+
+		if *flags.commit == "" {
+			if commit, err := codeintel.InferCommit(); err != nil {
+				inferErrors = append(inferErrors, inferError{"commit", err})
+			} else {
+				flags.commit = &commit
+			}
+		}
 
 		if !isFlagSet(flagSet, "root") {
-			checkError := func(err error) {
-				if err != nil {
-					fmt.Println(err)
-					fmt.Println("Unable to detect root of LSIF dump from environment.")
-					fmt.Println("Either cd into a git repository or set -root explicitly.")
-					os.Exit(1)
+			if root, err := codeintel.InferRoot(*flags.root); err != nil {
+				inferErrors = append(inferErrors, inferError{"root", err})
+			} else {
+				flags.root = &root
+			}
+		}
+		*flags.root = codeintel.SanitizeRoot(*flags.root)
+
+		if *flags.indexer == "" {
+			file, err := os.Open(*flags.file)
+			if err != nil {
+				inferErrors = append(inferErrors, inferError{"indexer", err})
+			}
+			defer file.Close()
+
+			if indexer, err := codeintel.ReadIndexerName(file); err != nil {
+				inferErrors = append(inferErrors, inferError{"indexer", err})
+			} else {
+				flags.indexer = &indexer
+			}
+		}
+
+		argsString := strings.Join([]string{
+			"Inferred arguments:",
+			fmt.Sprintf("  -repo=%s", *flags.repo),
+			fmt.Sprintf("  -commit=%s", *flags.commit),
+			fmt.Sprintf("  -root=%s", *flags.root),
+			fmt.Sprintf("  -file=%s", *flags.file),
+			fmt.Sprintf("  -indexer=%s", *flags.indexer),
+			"",
+		}, "\n")
+
+		for _, v := range inferErrors {
+			return errors.New(strings.Join([]string{
+				fmt.Sprintf(`error: %s`, v.err),
+				fmt.Sprintf(`Unable to determine %s from environment. Either cd into a git repository or set -%s explicitly.`, v.argument, v.argument),
+				argsString,
+			}, "\n\n"))
+		}
+
+		if strings.HasPrefix(*flags.root, "..") {
+			return errors.New("root must not be outside of repository")
+		}
+
+		if *flags.maxPayloadSizeMb <= 0 {
+			return errors.New("max-payload-size must be positive")
+		}
+
+		if !*flags.json {
+			fmt.Println(argsString)
+		}
+
+		return nil
+	}
+
+	handler := func(args []string) error {
+		if err := parseAndValidateFlags(args); err != nil {
+			return &usageError{err}
+		}
+
+		opts := codeintel.UploadIndexOpts{
+			Endpoint:            cfg.Endpoint,
+			AccessToken:         cfg.AccessToken,
+			Repo:                *flags.repo,
+			Commit:              *flags.commit,
+			Root:                *flags.root,
+			Indexer:             *flags.indexer,
+			GitHubToken:         *flags.gitHubToken,
+			File:                *flags.file,
+			MaxPayloadSizeBytes: *flags.maxPayloadSizeMb * 1000 * 1000,
+		}
+
+		uploadID, err := codeintel.UploadIndex(opts)
+		if err != nil {
+			if err == codeintel.ErrUnauthorized {
+				if *flags.gitHubToken == "" {
+					return fmt.Errorf("you must provide -github-token=TOKEN, where TOKEN is a GitHub personal access token with 'repo' or 'public_repo' scope")
+				}
+
+				if isatty.IsTerminal(os.Stdout.Fd()) {
+					fmt.Println("You may need to specify or update your GitHub access token to use this endpoint.")
+					fmt.Println("See https://github.com/sourcegraph/src-cli#authentication.")
 				}
 			}
 
-			topLevel, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
-			checkError(err)
-
-			absFile, err := filepath.Abs(*fileFlag)
-			checkError(err)
-
-			rel, err := filepath.Rel(strings.TrimSpace(string(topLevel)), absFile)
-			checkError(err)
-
-			relDir := filepath.Dir(rel)
-			rootFlag = &relDir
-		}
-
-		*rootFlag = filepath.Clean(*rootFlag)
-		if strings.HasPrefix(*rootFlag, "..") {
-			fmt.Println("-root is outside the repository: " + *rootFlag)
-			os.Exit(1)
-		}
-		if *rootFlag == "." || *rootFlag == "/" {
-			*rootFlag = ""
-		}
-		fmt.Println("Root: " + *rootFlag)
-
-		// First, build the URL which is used to both make the request
-		// and to emit a cURL command. This is a little different than
-		// the rest of the commands as it does not use a GraphQL endpoint,
-		// using the path and query string instead of the body.
-
-		qs := url.Values{}
-		qs.Add("repository", *repoFlag)
-		qs.Add("commit", *commitFlag)
-		if *githubTokenFlag != "" {
-			qs.Add("github_token", *githubTokenFlag)
-		}
-		if *rootFlag != "" {
-			qs.Add("root", *rootFlag)
-		}
-		if *indexerNameFlag != "" {
-			qs.Add("indexerName", *indexerNameFlag)
-		}
-
-		url, err := url.Parse(cfg.Endpoint + "/.api/lsif/upload")
-		if err != nil {
-			return err
-		}
-		url.RawQuery = qs.Encode()
-
-		// Emit a cURL command. This is also a bit different than the rest
-		// of the commands as it uploads a file rather than just sending a
-		// JSON-encoded body.
-		//
-		// Because we compress the body before sending it to the API below,
-		// we need to pipe the output of gzip into the cURL command.
-
-		if *apiFlags.getCurl {
-			curl := fmt.Sprintf("gzip -c %s | curl \\\n", shellquote.Join(*fileFlag))
-			curl += "   -X POST \\\n"
-			curl += fmt.Sprintf("   %s \\\n", shellquote.Join("-H", "Content-Type: application/x-ndjson+lsif"))
-			if cfg.AccessToken != "" {
-				curl += fmt.Sprintf("   %s \\\n", shellquote.Join("-H", "Authorization: token "+cfg.AccessToken))
-			}
-			curl += fmt.Sprintf("   %s \\\n", shellquote.Join(url.String()))
-			curl += fmt.Sprintf("   %s", shellquote.Join("--data-binary", "@-"))
-
-			fmt.Println(curl)
-			return nil
-		}
-
-		f, err := os.Open(*fileFlag)
-		if err != nil {
-			return err
-		}
-		defer f.Close()
-
-		// compress the file
-		pr, ch := gzipReader(f)
-
-		// Create the HTTP request.
-		req, err := http.NewRequest("POST", url.String(), pr)
-		if err != nil {
 			return err
 		}
 
-		req.Header.Set("Content-Type", "application/x-ndjson+lsif")
-		if cfg.AccessToken != "" {
-			req.Header.Set("Authorization", "token "+cfg.AccessToken)
-		}
+		uploadURL := fmt.Sprintf("%s/%s/-/settings/code-intelligence/lsif-uploads/%s", cfg.Endpoint, *flags.repo, uploadID)
 
-		// Perform the request.
-		resp, err := http.DefaultClient.Do(req)
-		if err != nil {
-			return err
-		}
-		defer resp.Body.Close()
-
-		// See if we had a reader error
-		if err := <-ch; err != nil {
-			return err
-		}
-
-		body, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			return err
-		}
-
-		// Our request may have failed before the reaching the upload endpoint, so
-		// confirm the status code. You can test this easily with e.g. an invalid
-		// endpoint like -endpoint=https://google.com
-		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-			if resp.StatusCode == http.StatusUnauthorized && strings.Contains(strings.ToLower(string(body)), "must provide github_token") {
-				return fmt.Errorf("error: you must provide -github-token=TOKEN, where TOKEN is a GitHub personal access token with 'repo' or 'public_repo' scope")
+		if *flags.json {
+			serialized, err := json.Marshal(map[string]interface{}{
+				"repo":      *flags.repo,
+				"commit":    *flags.commit,
+				"root":      *flags.root,
+				"file":      *flags.file,
+				"indexer":   *flags.indexer,
+				"uploadId":  uploadID,
+				"uploadUrl": uploadURL,
+			})
+			if err != nil {
+				return err
 			}
 
-			if resp.StatusCode == http.StatusUnauthorized && isatty.IsTerminal(os.Stdout.Fd()) {
-				fmt.Println("You may need to specify or update your GitHub access token to use this endpoint.")
-				fmt.Println("See https://github.com/sourcegraph/src-cli#authentication")
-				fmt.Println("")
-			}
-			return fmt.Errorf("error: %s\n\n%s", resp.Status, body)
+			fmt.Println(string(serialized))
+		} else {
+			fmt.Printf("LSIF dump successfully uploaded for processing.\n")
+			fmt.Printf("View processing status at %s.\n", uploadURL)
 		}
 
-		payload := struct {
-			ID string `json:"id"`
-		}{}
-		if err := json.Unmarshal(body, &payload); err != nil {
-			return err
-		}
-
-		uploadID := string(base64.URLEncoding.EncodeToString([]byte(fmt.Sprintf(`LSIFUpload:"%s"`, payload.ID))))
-		uploadURL := fmt.Sprintf("%s/%s/-/settings/code-intelligence/lsif-uploads/%s", cfg.Endpoint, *repoFlag, uploadID)
-
-		fmt.Println("")
-		fmt.Printf("LSIF dump successfully uploaded for processing.\n")
-		fmt.Printf("View processing status at %s.\n", uploadURL)
-
-		if *openFlag {
+		if *flags.open {
 			if err := browser.OpenURL(uploadURL); err != nil {
 				return err
 			}
@@ -262,53 +206,23 @@ Examples:
 		return nil
 	}
 
-	// Register the command.
 	lsifCommands = append(lsifCommands, &command{
-		flagSet:   flagSet,
-		handler:   handler,
-		usageFunc: usageFunc,
+		flagSet: flagSet,
+		handler: handler,
+		usageFunc: func() {
+			fmt.Fprintf(flag.CommandLine.Output(), "Usage of 'src lsif %s':\n", flagSet.Name())
+			flagSet.PrintDefaults()
+			fmt.Println(usage)
+		},
 	})
 }
 
-func gzipReader(r io.Reader) (io.Reader, <-chan error) {
-	ch := make(chan error)
-	br := bufio.NewReader(r)
-	pr, pw := io.Pipe()
-	gw := gzip.NewWriter(pw)
-
-	go func() {
-		defer close(ch)
-		defer pw.Close() // must be closed 2nd
-		defer gw.Close() // must be closed 1st
-
-		if _, err := br.WriteTo(gw); err != nil {
-			ch <- err
+func isFlagSet(fs *flag.FlagSet, name string) (found bool) {
+	fs.Visit(func(f *flag.Flag) {
+		if f.Name == name {
+			found = true
 		}
-	}()
+	})
 
-	return pr, ch
-}
-
-// parseRemoteURL takes remote URLs such as:
-//
-// git@github.com:gorilla/mux.git
-// https://github.com/gorilla/mux.git
-//
-// and returns:
-//
-// github.com/gorilla/mux
-func parseRemoteURL(urlString string) (string, error) {
-	if strings.HasPrefix(urlString, "git@") {
-		parts := strings.Split(urlString, ":")
-		if len(parts) != 2 {
-			return "", fmt.Errorf("unrecognized remote URL: %s", urlString)
-		}
-		return strings.TrimPrefix(parts[0], "git@") + "/" + strings.TrimPrefix(strings.TrimSuffix(parts[1], ".git"), "/"), nil
-	}
-
-	remoteURL, err := url.Parse(urlString)
-	if err != nil {
-		return "", fmt.Errorf("unrecognized remote URL: %s", urlString)
-	}
-	return remoteURL.Hostname() + strings.TrimSuffix(remoteURL.Path, ".git"), nil
+	return found
 }

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/dustin/go-humanize v1.0.0
 	github.com/fatih/color v1.9.0
 	github.com/gogo/protobuf v1.3.1 // indirect
+	github.com/google/go-cmp v0.4.0
 	github.com/gosuri/uilive v0.0.4
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/gogo/protobuf v1.1.1 h1:72R+M5VuhED/KujmZVcIquuo8mBgX4oVda//DQb3PXo=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.3.1 h1:DqDEcV5aeaTmdFBePNpYsp3FlcVH/2ISVVM9Qf8PSls=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
+github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
+github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-multierror v1.0.0 h1:iVjPR7a6H0tWELX5NxNe7bYopibicUzc7uPribsnS6o=
@@ -74,6 +76,7 @@ golang.org/x/sys v0.0.0-20200124204421-9fbb57f87de9/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20181030221726-6c7e314b6563/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 jaytaylor.com/html2text v0.0.0-20190408195923-01ec452cbe43 h1:y7HMa41LpoE/uvDnLVMLktoTifFpaoMGhxBHn8+h57Q=
 jaytaylor.com/html2text v0.0.0-20190408195923-01ec452cbe43/go.mod h1:OxvTsCwKosqQ1q7B+8FwXqg4rKZ/UG9dUW+g/VL2xH4=
 sourcegraph.com/sqs/pbtypes v0.0.0-20180604144634-d3ebe8f20ae4 h1:JPJh2pk3+X4lXAkZIk2RuE/7/FoK9maXw+TNPJhVS/c=

--- a/internal/codeintel/gitutil.go
+++ b/internal/codeintel/gitutil.go
@@ -1,0 +1,74 @@
+package codeintel
+
+import (
+	"fmt"
+	"net/url"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// InferRepo gets a Sourcegraph-friendly repo name from the git clone enclosing the working dir.
+func InferRepo() (string, error) {
+	remoteURL, err := runGitCommand("remote", "get-url", "origin")
+	if err != nil {
+		return "", err
+	}
+
+	return parseRemote(remoteURL)
+}
+
+// parseRemote converts a git origin url into a Sourcegraph-friendly repo name.
+func parseRemote(remoteURL string) (string, error) {
+	// e.g., git@github.com:sourcegraph/src-cli.git
+	if strings.HasPrefix(remoteURL, "git@") {
+		if parts := strings.Split(remoteURL, ":"); len(parts) == 2 {
+			return strings.Join([]string{
+				strings.TrimPrefix(parts[0], "git@"),
+				strings.TrimSuffix(parts[1], ".git"),
+			}, "/"), nil
+		}
+	}
+
+	// e.g.. https://github.com/sourcegraph/src-cli.git
+	if url, err := url.Parse(remoteURL); err == nil {
+		return url.Hostname() + strings.TrimSuffix(url.Path, ".git"), nil
+	}
+
+	return "", fmt.Errorf("unrecognized remote URL: %s", remoteURL)
+}
+
+// InferCommit gets a 40-character rev hash from the git clone enclosing the working dir.
+func InferCommit() (string, error) {
+	return runGitCommand("rev-parse", "HEAD")
+}
+
+// InferRoot gets the relative path  the root of the git clone enclosing the given file path.
+func InferRoot(file string) (string, error) {
+	topLevel, err := runGitCommand("rev-parse", "--show-toplevel")
+	if err != nil {
+		return "", err
+	}
+
+	absoluteFile, err := filepath.Abs(file)
+	if err != nil {
+		return "", err
+	}
+
+	relative, err := filepath.Rel(topLevel, absoluteFile)
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Dir(relative), nil
+}
+
+// runGitCommand runs a git command and trims all leading/trailing whitespace from the output.
+func runGitCommand(args ...string) (string, error) {
+	output, err := exec.Command("git", args...).CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("failed to run git command: %s\n%s", err, output)
+	}
+
+	return strings.TrimSpace(string(output)), nil
+}

--- a/internal/codeintel/gitutil.go
+++ b/internal/codeintel/gitutil.go
@@ -43,7 +43,7 @@ func InferCommit() (string, error) {
 	return runGitCommand("rev-parse", "HEAD")
 }
 
-// InferRoot gets the relative path  the root of the git clone enclosing the given file path.
+// InferRoot gets the path relative to the root of the git clone enclosing the given file path.
 func InferRoot(file string) (string, error) {
 	topLevel, err := runGitCommand("rev-parse", "--show-toplevel")
 	if err != nil {

--- a/internal/codeintel/gitutil_test.go
+++ b/internal/codeintel/gitutil_test.go
@@ -1,0 +1,59 @@
+package codeintel
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+)
+
+func TestInferRepo(t *testing.T) {
+	repo, err := InferRepo()
+	if err != nil {
+		t.Fatalf("unexpected error inferring repo: %s", err)
+	}
+
+	if repo != "github.com/sourcegraph/src-cli" {
+		t.Errorf("unexpected remote repo. want=%q have=%q", "github.com/sourcegraph/src-cli", repo)
+	}
+}
+
+func TestParseRemote(t *testing.T) {
+	testCases := map[string]string{
+		"git@github.com:sourcegraph/src-cli.git": "github.com/sourcegraph/src-cli",
+		"https://github.com/sourcegraph/src-cli": "github.com/sourcegraph/src-cli",
+	}
+
+	for input, expectedOutput := range testCases {
+		t.Run(fmt.Sprintf("input=%q", input), func(t *testing.T) {
+			output, err := parseRemote(input)
+			if err != nil {
+				t.Fatalf("unexpected error parsing remote: %s", err)
+			}
+
+			if output != expectedOutput {
+				t.Errorf("unexpected repo name. want=%q have=%q", expectedOutput, output)
+			}
+		})
+	}
+}
+
+func TestInferRoot(t *testing.T) {
+	testCases := map[string]string{
+		"gitutil.go":            filepath.Join("internal", "codeintel"),
+		"../../cmd/src/lsif.go": filepath.Join("cmd", "src"),
+		"../../README.md":       ".",
+	}
+
+	for input, expectedOutput := range testCases {
+		t.Run(fmt.Sprintf("input=%q", input), func(t *testing.T) {
+			root, err := InferRoot(input)
+			if err != nil {
+				t.Fatalf("unexpected error inferring root: %s", err)
+			}
+
+			if root != expectedOutput {
+				t.Errorf("unexpected remote root. want=%q have=%q", expectedOutput, root)
+			}
+		})
+	}
+}

--- a/internal/codeintel/gzip.go
+++ b/internal/codeintel/gzip.go
@@ -1,0 +1,31 @@
+package codeintel
+
+import (
+	"compress/gzip"
+	"io"
+
+	"github.com/hashicorp/go-multierror"
+)
+
+// gzipReader decorates a source reader by gzip compressing its contents.
+func gzipReader(source io.Reader) io.Reader {
+	r, w := io.Pipe()
+	go func() {
+		// propagate gzip write errors into new reader
+		w.CloseWithError(gzipPipe(source, w))
+	}()
+	return r
+}
+
+// gzipPipe reads uncompressed data from r and writes compressed data to w.
+func gzipPipe(r io.Reader, w io.Writer) (err error) {
+	gzipWriter := gzip.NewWriter(w)
+	defer func() {
+		if closeErr := gzipWriter.Close(); closeErr != nil {
+			err = multierror.Append(err, err)
+		}
+	}()
+
+	_, err = io.Copy(gzipWriter, r)
+	return err
+}

--- a/internal/codeintel/gzip_test.go
+++ b/internal/codeintel/gzip_test.go
@@ -1,0 +1,34 @@
+package codeintel
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io/ioutil"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestGzipReader(t *testing.T) {
+	var uncompressed []byte
+	for i := 0; i < 20000; i++ {
+		uncompressed = append(uncompressed, byte(i))
+	}
+
+	contents, err := ioutil.ReadAll(gzipReader(bytes.NewReader(uncompressed)))
+	if err != nil {
+		t.Fatalf("unexpected error reading from gzip reader: %s", err)
+	}
+
+	gzipReader, err := gzip.NewReader(bytes.NewReader(contents))
+	if err != nil {
+		t.Fatalf("unexpected error creating gzip.Reader: %s", err)
+	}
+	decompressed, err := ioutil.ReadAll(gzipReader)
+	if err != nil {
+		t.Fatalf("unexpected error reading from gzip.Reader: %s", err)
+	}
+	if diff := cmp.Diff(decompressed, uncompressed); diff != "" {
+		t.Errorf("unexpected gzipped contents (-want +got):\n%s", diff)
+	}
+}

--- a/internal/codeintel/indexer_name.go
+++ b/internal/codeintel/indexer_name.go
@@ -2,7 +2,6 @@ package codeintel
 
 import (
 	"bufio"
-	"compress/gzip"
 	"encoding/json"
 	"errors"
 	"io"
@@ -23,17 +22,11 @@ var ErrMetadataExceedsBuffer = errors.New("metaData vertex exceeds buffer")
 // ErrInvalidMetaDataVertex occurs when teh first line of an LSIF index is not a valid metadata vertex.
 var ErrInvalidMetaDataVertex = errors.New("invalid metaData vertex")
 
-// ReadIndexerName returns the name of the tool that generated the given
-// index contents. This function reads only the first line of the file,
-// where the metadata vertex is assumed to be in all valid dumps.
+// ReadIndexerName returns the name of the tool that generated the given index contents.
+// This function reads only the first line of the file, where the metadata vertex is
+// assumed to be in all valid dumps.
 func ReadIndexerName(r io.Reader) (string, error) {
-	gzipReader, err := gzip.NewReader(r)
-	if err != nil {
-		return "", err
-	}
-	defer gzipReader.Close()
-
-	line, isPrefix, err := bufio.NewReader(gzipReader).ReadLine()
+	line, isPrefix, err := bufio.NewReader(r).ReadLine()
 	if err != nil {
 		return "", err
 	}

--- a/internal/codeintel/indexer_name.go
+++ b/internal/codeintel/indexer_name.go
@@ -19,7 +19,7 @@ type toolInfo struct {
 // ErrMetadataExceedsBuffer occurs when the first line of an LSIF index is too long to read.
 var ErrMetadataExceedsBuffer = errors.New("metaData vertex exceeds buffer")
 
-// ErrInvalidMetaDataVertex occurs when teh first line of an LSIF index is not a valid metadata vertex.
+// ErrInvalidMetaDataVertex occurs when the first line of an LSIF index is not a valid metadata vertex.
 var ErrInvalidMetaDataVertex = errors.New("invalid metaData vertex")
 
 // ReadIndexerName returns the name of the tool that generated the given index contents.

--- a/internal/codeintel/indexer_name.go
+++ b/internal/codeintel/indexer_name.go
@@ -1,0 +1,54 @@
+package codeintel
+
+import (
+	"bufio"
+	"compress/gzip"
+	"encoding/json"
+	"errors"
+	"io"
+)
+
+type metaDataVertex struct {
+	Label    string   `json:"label"`
+	ToolInfo toolInfo `json:"toolInfo"`
+}
+
+type toolInfo struct {
+	Name string `json:"name"`
+}
+
+// ErrMetadataExceedsBuffer occurs when the first line of an LSIF index is too long to read.
+var ErrMetadataExceedsBuffer = errors.New("metaData vertex exceeds buffer")
+
+// ErrInvalidMetaDataVertex occurs when teh first line of an LSIF index is not a valid metadata vertex.
+var ErrInvalidMetaDataVertex = errors.New("invalid metaData vertex")
+
+// ReadIndexerName returns the name of the tool that generated the given
+// index contents. This function reads only the first line of the file,
+// where the metadata vertex is assumed to be in all valid dumps.
+func ReadIndexerName(r io.Reader) (string, error) {
+	gzipReader, err := gzip.NewReader(r)
+	if err != nil {
+		return "", err
+	}
+	defer gzipReader.Close()
+
+	line, isPrefix, err := bufio.NewReader(gzipReader).ReadLine()
+	if err != nil {
+		return "", err
+	}
+	if isPrefix {
+		return "", ErrMetadataExceedsBuffer
+	}
+
+	meta := metaDataVertex{}
+	if err := json.Unmarshal(line, &meta); err != nil {
+		return "", ErrInvalidMetaDataVertex
+	}
+
+	if meta.Label != "metaData" || meta.ToolInfo.Name == "" {
+		return "", ErrInvalidMetaDataVertex
+	}
+
+	return meta.ToolInfo.Name, nil
+}

--- a/internal/codeintel/indexer_name_test.go
+++ b/internal/codeintel/indexer_name_test.go
@@ -1,0 +1,46 @@
+package codeintel
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+	"strings"
+	"testing"
+)
+
+const testMetaDataVertex = `{"label": "metaData", "toolInfo": {"name": "test"}}`
+const testVertex = `{"id": "a", "type": "edge", "label": "textDocument/references", "outV": "b", "inV": "c"}`
+
+func TestReadIndexerName(t *testing.T) {
+	name, err := ReadIndexerName(generateTestIndex(testMetaDataVertex))
+	if err != nil {
+		t.Fatalf("unexpected error reading indexer name: %s", err)
+	}
+	if name != "test" {
+		t.Errorf("unexpected indexer name. want=%s have=%s", "test", name)
+	}
+}
+
+func TestReadIndexerNameMalformed(t *testing.T) {
+	for _, metaDataVertex := range []string{`invalid json`, `{"label": "textDocument/references"}`} {
+		if _, err := ReadIndexerName(generateTestIndex(metaDataVertex)); err != ErrInvalidMetaDataVertex {
+			t.Fatalf("unexpected error reading indexer name. want=%q have=%q", ErrInvalidMetaDataVertex, err)
+		}
+	}
+}
+
+func generateTestIndex(metaDataVertex string) io.Reader {
+	lines := []string{metaDataVertex}
+	for i := 0; i < 20000; i++ {
+		lines = append(lines, testVertex)
+	}
+
+	content := strings.Join(lines, "\n") + "\n"
+
+	var buf bytes.Buffer
+	w := gzip.NewWriter(&buf)
+	_, _ = io.Copy(w, bytes.NewReader([]byte(content)))
+	w.Close()
+
+	return bytes.NewReader(buf.Bytes())
+}

--- a/internal/codeintel/indexer_name_test.go
+++ b/internal/codeintel/indexer_name_test.go
@@ -2,7 +2,6 @@ package codeintel
 
 import (
 	"bytes"
-	"compress/gzip"
 	"io"
 	"strings"
 	"testing"
@@ -35,12 +34,5 @@ func generateTestIndex(metaDataVertex string) io.Reader {
 		lines = append(lines, testVertex)
 	}
 
-	content := strings.Join(lines, "\n") + "\n"
-
-	var buf bytes.Buffer
-	w := gzip.NewWriter(&buf)
-	_, _ = io.Copy(w, bytes.NewReader([]byte(content)))
-	w.Close()
-
-	return bytes.NewReader(buf.Bytes())
+	return bytes.NewReader([]byte(strings.Join(lines, "\n") + "\n"))
 }

--- a/internal/codeintel/query_values.go
+++ b/internal/codeintel/query_values.go
@@ -1,0 +1,57 @@
+package codeintel
+
+import (
+	"net/url"
+	"strconv"
+)
+
+// queryValues is a convenience wrapper around url.Values that adds
+// behaviors to set values of non-string types and optionally set
+// values that may be a zero-value.
+type queryValues struct {
+	values url.Values
+}
+
+// newQueryValues creates a new queryValues.
+func newQueryValues() queryValues {
+	return queryValues{values: url.Values{}}
+}
+
+// Set adds the given name/string-value pairing to the underlying values.
+func (qv queryValues) Set(name string, value string) {
+	qv.values[name] = []string{value}
+}
+
+// SetInt adds the given name/int-value pairing to the underlying values.
+func (qv queryValues) SetInt(name string, value int) {
+	qv.Set(name, strconv.FormatInt(int64(value), 10))
+}
+
+// SetOptionalString adds the given name/string-value pairing to the underlying values.
+// If the value is empty, the underlying values are not modified.
+func (qv queryValues) SetOptionalString(name string, value string) {
+	if value != "" {
+		qv.Set(name, value)
+	}
+}
+
+// SetOptionalInt adds the given name/int-value pairing to the underlying values.
+// If the value is zero, the underlying values are not modified.
+func (qv queryValues) SetOptionalInt(name string, value int) {
+	if value != 0 {
+		qv.SetInt(name, value)
+	}
+}
+
+// SetOptionalBool adds the given name/bool-value pairing to the underlying values.
+// If the value is false, the underlying values are not modified.
+func (qv queryValues) SetOptionalBool(name string, value bool) {
+	if value {
+		qv.Set(name, "true")
+	}
+}
+
+// Encode encodes the underlying values.
+func (qv queryValues) Encode() string {
+	return qv.values.Encode()
+}

--- a/internal/codeintel/sanitation.go
+++ b/internal/codeintel/sanitation.go
@@ -1,0 +1,15 @@
+package codeintel
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// SanitizeRoot removes redundant paths from the given root and replaces
+// references to the root of th repo with an empty string.
+func SanitizeRoot(root string) string {
+	if root = filepath.Clean(root); root == "." || (root != "" && os.IsPathSeparator(root[0])) {
+		return ""
+	}
+	return root
+}

--- a/internal/codeintel/sanitation_test.go
+++ b/internal/codeintel/sanitation_test.go
@@ -1,0 +1,25 @@
+package codeintel
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+)
+
+func TestSanitizeRoot(t *testing.T) {
+	testCases := map[string]string{
+		"":                  "",
+		".":                 "",
+		"/":                 "",
+		"foo/../bar":        "bar",
+		"./bar/baz/../bonk": filepath.Join("bar", "bonk"),
+	}
+
+	for input, expectedOutput := range testCases {
+		t.Run(fmt.Sprintf("input=%q", input), func(t *testing.T) {
+			if SanitizeRoot(input) != expectedOutput {
+				t.Errorf("unexpected root. want=%q have=%q", expectedOutput, SanitizeRoot(input))
+			}
+		})
+	}
+}

--- a/internal/codeintel/split_file.go
+++ b/internal/codeintel/split_file.go
@@ -13,7 +13,7 @@ import (
 // size. The file names are returned in the order in which they were written. The
 // cleanup function removes all temporary files, and wraps the error argument
 // with any additional errors that happen during cleanup.
-func splitFile(file string, maxPayloadSize int) (files []string, _ func(err error) error, err error) {
+func splitFile(file string, maxPayloadSize int) (files []string, _ func(error) error, err error) {
 	cleanup := func(err error) error {
 		for _, file := range files {
 			if removeErr := os.Remove(file); removeErr != nil {

--- a/internal/codeintel/split_file.go
+++ b/internal/codeintel/split_file.go
@@ -1,0 +1,73 @@
+package codeintel
+
+import (
+	"io"
+	"io/ioutil"
+	"os"
+
+	"github.com/hashicorp/go-multierror"
+)
+
+// splitFile writes the contents of the given file into a series of temporary
+// files, each of which are gzipped and are no larger than the given max payload
+// size. The file names are returned in the order in which they were written. The
+// cleanup function removes all temporary files, and wraps the error argument
+// with any additional errors that happen during cleanup.
+func splitFile(file string, maxPayloadSize int) (files []string, _ func(err error) error, err error) {
+	cleanup := func(err error) error {
+		for _, file := range files {
+			if removeErr := os.Remove(file); removeErr != nil {
+				err = multierror.Append(err, removeErr)
+			}
+		}
+
+		return err
+	}
+	defer func() {
+		if err != nil {
+			err = cleanup(err)
+		}
+	}()
+
+	sourceFile, err := os.Open(file)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer sourceFile.Close()
+
+	for {
+		partFile, err := ioutil.TempFile("", "")
+		if err != nil {
+			return nil, nil, err
+		}
+		defer partFile.Close()
+
+		n, err := io.CopyN(partFile, sourceFile, int64(maxPayloadSize))
+		if err != nil && err != io.EOF {
+			return nil, nil, err
+		}
+
+		if n > 0 {
+			files = append(files, partFile.Name())
+		} else {
+			// File must be closed before it's removed (on Windows), so
+			// don't wait for the defer above. Double closing a file is
+			// fine, but the second close will return an ErrClosed value,
+			// which we aren't checking anyway.
+			_ = partFile.Close()
+
+			// Edge case: previous io.CopyN call returned err=nil and
+			// n=maxPayloadSize. Nothing written to this file so we
+			// can just undo its creation and fall-through to the break.
+			if err := os.Remove(partFile.Name()); err != nil {
+				return nil, nil, err
+			}
+		}
+
+		if err == io.EOF {
+			break
+		}
+	}
+
+	return files, cleanup, nil
+}

--- a/internal/codeintel/split_file_test.go
+++ b/internal/codeintel/split_file_test.go
@@ -1,0 +1,60 @@
+package codeintel
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestSplitFile(t *testing.T) {
+	f, err := ioutil.TempFile("", "")
+	if err != nil {
+		t.Fatalf("unexpected error creating temp file: %s", err)
+	}
+	defer func() { os.Remove(f.Name()) }()
+
+	var expectedContents []byte
+	for i := 0; i < 50; i++ {
+		var partContents []byte
+		for j := 0; j < 20000; j++ {
+			partContents = append(partContents, byte(j))
+		}
+
+		expectedContents = append(expectedContents, partContents...)
+		_, _ = f.Write(partContents)
+	}
+	f.Close()
+
+	files, cleanup, err := splitFile(f.Name(), 18000)
+	if err != nil {
+		t.Fatalf("unexpected error splitting file: %s", err)
+	}
+
+	var contents []byte
+	for _, file := range files {
+		temp, err := ioutil.ReadFile(file)
+		if err != nil {
+			t.Fatalf("unexpected error reading file: %s", err)
+		}
+
+		if len(temp) > 18000 {
+			t.Errorf("chunk too large: want<%d have=%d", 18000, len(temp))
+		}
+
+		contents = append(contents, temp...)
+	}
+
+	if diff := cmp.Diff(expectedContents, contents); diff != "" {
+		t.Errorf("unexpected split contents (-want +got):\n%s", diff)
+	}
+
+	cleanup(nil)
+
+	for _, file := range files {
+		if _, err := os.Stat(file); !os.IsNotExist(err) {
+			t.Errorf("unexpected error. want=%q have=%q", os.ErrNotExist, err)
+		}
+	}
+}

--- a/internal/codeintel/upload.go
+++ b/internal/codeintel/upload.go
@@ -1,0 +1,249 @@
+package codeintel
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+
+	"github.com/hashicorp/go-multierror"
+)
+
+type UploadIndexOpts struct {
+	Endpoint            string
+	AccessToken         string
+	Repo                string
+	Commit              string
+	Root                string
+	Indexer             string
+	GitHubToken         string
+	File                string
+	MaxPayloadSizeBytes int
+}
+
+// ErrUnauthorized occurs when the upload endpoint returns a 401 response.
+var ErrUnauthorized = errors.New("unauthorized upload")
+
+// UploadIndex uploads the given index file to the upload endpoint. If the upload
+// file is large, it may be split into multiple chunks locally and uploaded over
+// multiple requests.
+func UploadIndex(opts UploadIndexOpts) (string, error) {
+	fileInfo, err := os.Stat(opts.File)
+	if err != nil {
+		return "", err
+	}
+
+	if fileInfo.Size() <= int64(opts.MaxPayloadSizeBytes) {
+		id, err := uploadIndex(opts)
+		if err != nil {
+			return "", err
+		}
+		return uploadIDToGraphQLID(id), nil
+	}
+
+	id, err := uploadMultipartIndex(opts)
+	if err != nil {
+		return "", err
+	}
+	return uploadIDToGraphQLID(id), nil
+}
+
+// uploadIndex constructs a GraphQL-compatible identifier from the raw identifier returned
+// from the upload endpoint.
+func uploadIDToGraphQLID(uploadID int) string {
+	return string(base64.URLEncoding.EncodeToString([]byte(fmt.Sprintf(`LSIFUpload:"%d"`, uploadID))))
+}
+
+// uploadIndex performs a single request  to the upload endpoint. The new upload id is returned.
+func uploadIndex(opts UploadIndexOpts) (id int, err error) {
+	f, err := os.Open(opts.File)
+	if err != nil {
+		return 0, err
+	}
+	defer func() {
+		if closeErr := f.Close(); closeErr != nil {
+			err = multierror.Append(err, closeErr)
+		}
+	}()
+
+	args := requestArgs{
+		endpoint:    opts.Endpoint,
+		accessToken: opts.AccessToken,
+		repo:        opts.Repo,
+		commit:      opts.Commit,
+		root:        opts.Root,
+		indexer:     opts.Indexer,
+		gitHubToken: opts.GitHubToken,
+	}
+
+	if err := makeUploadRequest(args, gzipReader(f), &id); err != nil {
+		return 0, err
+	}
+
+	return id, nil
+}
+
+// uploadMultipartIndex splits the index file into chunks small enough to upload, then
+// performs a series of request to the upload endpoint. The new upload id is returned.
+func uploadMultipartIndex(opts UploadIndexOpts) (id int, err error) {
+	files, cleanup, err := splitFile(opts.File, opts.MaxPayloadSizeBytes)
+	if err != nil {
+		return 0, err
+	}
+	defer func() {
+		err = cleanup(err)
+	}()
+
+	setupArgs := requestArgs{
+		endpoint:    opts.Endpoint,
+		accessToken: opts.AccessToken,
+		repo:        opts.Repo,
+		commit:      opts.Commit,
+		root:        opts.Root,
+		indexer:     opts.Indexer,
+		gitHubToken: opts.GitHubToken,
+		multiPart:   true,
+		numParts:    len(files),
+	}
+	if err := makeUploadRequest(setupArgs, nil, &id); err != nil {
+		return 0, err
+	}
+
+	for i, file := range files {
+		f, err := os.Open(file)
+		if err != nil {
+			return 0, err
+		}
+		defer func() {
+			if closeErr := f.Close(); closeErr != nil {
+				err = multierror.Append(err, closeErr)
+			}
+		}()
+
+		uploadArgs := requestArgs{
+			endpoint:    opts.Endpoint,
+			accessToken: opts.AccessToken,
+			uploadID:    id,
+			index:       i,
+		}
+		if err := makeUploadRequest(uploadArgs, gzipReader(f), nil); err != nil {
+			return 0, err
+		}
+	}
+
+	finalizeArgs := requestArgs{
+		endpoint:    opts.Endpoint,
+		accessToken: opts.AccessToken,
+		uploadID:    id,
+		done:        true,
+	}
+	if err = makeUploadRequest(finalizeArgs, nil, nil); err != nil {
+		return 0, err
+	}
+
+	return id, nil
+}
+
+// requestArgs are a superset of the values that can be supplied in the query string of the
+// upload endpoint. The endpoint and access token fields must be set on every request, but the
+// remaining fields must be set when appropriate by the caller of makeUploadRequest.
+type requestArgs struct {
+	endpoint    string
+	accessToken string
+	repo        string
+	commit      string
+	root        string
+	indexer     string
+	gitHubToken string
+	multiPart   bool
+	numParts    int
+	uploadID    int
+	index       int
+	done        bool
+}
+
+// EncodeQuery constructs a query string from the args.
+func (args requestArgs) EncodeQuery() string {
+	qs := newQueryValues()
+	qs.SetOptionalString("repository", args.repo)
+	qs.SetOptionalString("commit", args.commit)
+	qs.SetOptionalString("root", args.root)
+	qs.SetOptionalString("indexerName", args.indexer)
+	qs.SetOptionalString("github_token", args.gitHubToken)
+	qs.SetOptionalBool("multiPart", args.multiPart)
+	qs.SetOptionalInt("numParts", args.numParts)
+	qs.SetOptionalInt("uploadId", args.uploadID)
+	qs.SetOptionalBool("done", args.done)
+
+	// Do not set an index of zero unless we're uploading a part
+	if args.uploadID != 0 && !args.multiPart && !args.done {
+		qs.SetInt("index", args.index)
+	}
+
+	return qs.Encode()
+}
+
+// makeUploadRequest performs an HTTP POSt to the upload endpoint. The query string of the request
+// is constructed from teh given request args and the body of the request is the unmodified reader.
+// If target is a non-nil pointer, it will be assigned the value of the upload identifier present
+// in the response body.
+func makeUploadRequest(args requestArgs, payload io.Reader, target *int) error {
+	url, err := url.Parse(args.endpoint + "/.api/lsif/upload")
+	if err != nil {
+		return err
+	}
+	url.RawQuery = args.EncodeQuery()
+
+	req, err := http.NewRequest("POST", url.String(), payload)
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Content-Type", "application/x-ndjson+lsif")
+	if args.accessToken != "" {
+		req.Header.Set("Authorization", fmt.Sprintf("token %s", args.accessToken))
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode >= 300 {
+		if resp.StatusCode == http.StatusUnauthorized {
+			return ErrUnauthorized
+		}
+
+		return fmt.Errorf("unexpected status code: %d\n\n%s", resp.StatusCode, body)
+	}
+
+	if target != nil {
+		var respPayload struct {
+			ID string `json:"id"`
+		}
+		if err := json.Unmarshal(body, &respPayload); err != nil {
+			return err
+		}
+
+		id, err := strconv.Atoi(respPayload.ID)
+		if err != nil {
+			return err
+		}
+
+		*target = id
+	}
+
+	return nil
+}

--- a/internal/codeintel/upload.go
+++ b/internal/codeintel/upload.go
@@ -189,8 +189,8 @@ func (args requestArgs) EncodeQuery() string {
 	return qs.Encode()
 }
 
-// makeUploadRequest performs an HTTP POSt to the upload endpoint. The query string of the request
-// is constructed from teh given request args and the body of the request is the unmodified reader.
+// makeUploadRequest performs an HTTP POST to the upload endpoint. The query string of the request
+// is constructed from the given request args and the body of the request is the unmodified reader.
 // If target is a non-nil pointer, it will be assigned the value of the upload identifier present
 // in the response body.
 func makeUploadRequest(args requestArgs, payload io.Reader, target *int) error {

--- a/internal/codeintel/upload_test.go
+++ b/internal/codeintel/upload_test.go
@@ -1,0 +1,155 @@
+package codeintel
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestUploadIndex(t *testing.T) {
+	var expectedPayload []byte
+	for i := 0; i < 500; i++ {
+		expectedPayload = append(expectedPayload, byte(i))
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		payload, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("unexpected error reading request body: %s", err)
+		}
+
+		gzipReader, err := gzip.NewReader(bytes.NewReader(payload))
+		if err != nil {
+			t.Fatalf("unexpected error creating gzip.Reader: %s", err)
+		}
+		decompressed, err := ioutil.ReadAll(gzipReader)
+		if err != nil {
+			t.Fatalf("unexpected error reading from gzip.Reader: %s", err)
+		}
+
+		if diff := cmp.Diff(expectedPayload, decompressed); diff != "" {
+			t.Errorf("unexpected request payload (-want +got):\n%s", diff)
+		}
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"42"}`)) // graphql id is TFNJRlVwbG9hZDoiNDIi
+	}))
+	defer ts.Close()
+
+	f, err := ioutil.TempFile("", "")
+	if err != nil {
+		t.Fatalf("unexpected error creating temp file: %s", err)
+	}
+	defer func() { os.Remove(f.Name()) }()
+	_, _ = io.Copy(f, bytes.NewReader(expectedPayload))
+	_ = f.Close()
+
+	id, err := UploadIndex(UploadIndexOpts{
+		Endpoint:            ts.URL,
+		AccessToken:         "hunter2",
+		Repo:                "foo/bar",
+		Commit:              "deadbeef",
+		Root:                "proj/",
+		Indexer:             "lsif-go",
+		GitHubToken:         "ght",
+		File:                f.Name(),
+		MaxPayloadSizeBytes: 1000,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error uploading index: %s", err)
+	}
+
+	if id != "TFNJRlVwbG9hZDoiNDIi" {
+		t.Errorf("unexpected id. want=%s have=%s", "TFNJRlVwbG9hZDoiNDIi", id)
+	}
+}
+
+func TestUploadIndexMultipart(t *testing.T) {
+	var expectedPayload []byte
+	for i := 0; i < 20000; i++ {
+		expectedPayload = append(expectedPayload, byte(i))
+	}
+
+	var m sync.Mutex
+	payloads := map[int][]byte{}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("multiPart") != "" {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"id":"42"}`)) // graphql id is TFNJRlVwbG9hZDoiNDIi
+			return
+		}
+
+		if r.URL.Query().Get("index") != "" {
+			payload, err := ioutil.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("unexpected error reading request body: %s", err)
+			}
+
+			index, _ := strconv.Atoi(r.URL.Query().Get("index"))
+			m.Lock()
+			payloads[index] = payload
+			m.Unlock()
+		}
+
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer ts.Close()
+
+	f, err := ioutil.TempFile("", "")
+	if err != nil {
+		t.Fatalf("unexpected error creating temp file: %s", err)
+	}
+	defer func() { os.Remove(f.Name()) }()
+	_, _ = io.Copy(f, bytes.NewReader(expectedPayload))
+	_ = f.Close()
+
+	id, err := UploadIndex(UploadIndexOpts{
+		Endpoint:            ts.URL,
+		AccessToken:         "hunter2",
+		Repo:                "foo/bar",
+		Commit:              "deadbeef",
+		Root:                "proj/",
+		Indexer:             "lsif-go",
+		GitHubToken:         "ght",
+		File:                f.Name(),
+		MaxPayloadSizeBytes: 1000,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error uploading index: %s", err)
+	}
+
+	if id != "TFNJRlVwbG9hZDoiNDIi" {
+		t.Errorf("unexpected id. want=%s have=%s", "TFNJRlVwbG9hZDoiNDIi", id)
+	}
+
+	if len(payloads) != 20 {
+		t.Errorf("unexpected payloads size. want=%d have=%d", 20, len(payloads))
+	}
+
+	var allPayloads []byte
+	for i := 0; i < 20; i++ {
+		allPayloads = append(allPayloads, payloads[i]...)
+	}
+
+	gzipReader, err := gzip.NewReader(bytes.NewReader(allPayloads))
+	if err != nil {
+		t.Fatalf("unexpected error creating gzip.Reader: %s", err)
+	}
+	decompressed, err := ioutil.ReadAll(gzipReader)
+	if err != nil {
+		t.Fatalf("unexpected error reading from gzip.Reader: %s", err)
+	}
+	if diff := cmp.Diff(expectedPayload, decompressed); diff != "" {
+		t.Errorf("unexpected gzipped contents (-want +got):\n%s", diff)
+	}
+}


### PR DESCRIPTION
This PR introduces behavior that will only be available in Sourcegraph 3.16 (via https://github.com/sourcegraph/sourcegraph/pull/10456).

Behavioral changes:

- Moved reading the indexer name from the precise-code-intel-api-server to here so we don't have to write to disk in the upload path (before re-proxying to the bundle manager). Users can still specify the indexer name via a flag.
- Added `-json` flag to output a machine-readable to aid in integration tests. This will become more popular as we add additional precise-code-intel actions that will help indexing monorepos.
- Removed `-get-curl` for the lsif upload action as we can't guarantee a bounded number of HTTP requests anymore.
- Added support for chunking the LSIF index into parts and making several requests when the file size is too large. This threshold is default 100Mb, but is configurable with a flag for environments that are more or less constrained.

Code changes:

- Introduced internal/codeintel package
- Added tests

Build changes:

- New tests require they be run inside a git root, so the `shallow_clone` option has been removed from the appveyor config.

Notes to reviewers:

- Don't try to read the diff for lsif_upload.go, just read the new code.