### PR TITLE
Do not attempt multipart LSIF upload pre-3.16

### DIFF
--- a/cmd/src/format.go
+++ b/cmd/src/format.go
@@ -13,6 +13,7 @@ import (
 	humanize "github.com/dustin/go-humanize"
 	"github.com/fatih/color"
 	"github.com/sourcegraph/jsonx"
+	"github.com/sourcegraph/src-cli/internal/version"
 )
 
 func parseTemplate(text string) (*template.Template, error) {
@@ -106,13 +107,13 @@ func parseTemplate(text string) (*template.Template, error) {
 
 			// Hacky to do this in a formatting helper, but better than
 			// globally querying the version and only using it here for now.
-			version, err := getSourcegraphVersion()
+			sourcegraphVersion, err := getSourcegraphVersion()
 			if err != nil {
 				// We ignore the error and return what we have
 				return buf.String()
 			}
 
-			supportsUpdatingPatchSet, err := sourcegraphVersionCheck(version, ">= 3.13-0", "2020-02-14")
+			supportsUpdatingPatchSet, err := version.SourcegraphVersionCheck(sourcegraphVersion, ">= 3.13-0", "2020-02-14")
 			if err != nil {
 				return buf.String()
 			}

--- a/cmd/src/lsif_upload.go
+++ b/cmd/src/lsif_upload.go
@@ -11,6 +11,7 @@ import (
 	"github.com/pkg/browser"
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/src-cli/internal/codeintel"
+	"github.com/sourcegraph/src-cli/internal/version"
 )
 
 func init() {
@@ -149,16 +150,26 @@ Examples:
 			return &usageError{err}
 		}
 
+		sourcegraphVersion, err := getSourcegraphVersion()
+		if err != nil {
+			return err
+		}
+		supportsMultipartUpload, err := version.SourcegraphVersionCheck(sourcegraphVersion, ">= 3.16-0", "2020-05-13")
+		if err != nil {
+			return err
+		}
+
 		opts := codeintel.UploadIndexOpts{
-			Endpoint:            cfg.Endpoint,
-			AccessToken:         cfg.AccessToken,
-			Repo:                *flags.repo,
-			Commit:              *flags.commit,
-			Root:                *flags.root,
-			Indexer:             *flags.indexer,
-			GitHubToken:         *flags.gitHubToken,
-			File:                *flags.file,
-			MaxPayloadSizeBytes: *flags.maxPayloadSizeMb * 1000 * 1000,
+			Endpoint:                cfg.Endpoint,
+			AccessToken:             cfg.AccessToken,
+			Repo:                    *flags.repo,
+			Commit:                  *flags.commit,
+			Root:                    *flags.root,
+			Indexer:                 *flags.indexer,
+			GitHubToken:             *flags.gitHubToken,
+			File:                    *flags.file,
+			MaxPayloadSizeBytes:     *flags.maxPayloadSizeMb * 1000 * 1000,
+			SupportsMultipartUpload: supportsMultipartUpload,
 		}
 
 		uploadID, err := codeintel.UploadIndex(opts)

--- a/cmd/src/patch_sets_create_from_patches.go
+++ b/cmd/src/patch_sets_create_from_patches.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/mattn/go-isatty"
 	"github.com/pkg/errors"
+	"github.com/sourcegraph/src-cli/internal/version"
 )
 
 func init() {
@@ -98,11 +99,11 @@ func createPatchSetFromPatches(
 		CreatePatchSetFromPatches PatchSet
 	}
 
-	version, err := getSourcegraphVersion()
+	sourcegraphVersion, err := getSourcegraphVersion()
 	if err != nil {
 		return err
 	}
-	supportsBaseRef, err := sourcegraphVersionCheck(version, ">= 3.14.0", "2020-03-11")
+	supportsBaseRef, err := version.SourcegraphVersionCheck(sourcegraphVersion, ">= 3.14.0", "2020-03-11")
 	if err != nil {
 		return err
 	}

--- a/cmd/src/version.go
+++ b/cmd/src/version.go
@@ -92,3 +92,33 @@ func getRecommendedVersion() (string, error) {
 
 	return payload.Version, nil
 }
+
+//
+//
+
+const sourcegraphVersionQuery = `query SourcegraphVersion {
+	site {
+	  productVersion
+	}
+  }
+  `
+
+// TODO(efritz) - move this into internal as well
+// (punting for now so we don't move the forest for the banana)
+func getSourcegraphVersion() (string, error) {
+	var sourcegraphVersion struct {
+		Site struct {
+			ProductVersion string
+		}
+	}
+
+	err := (&apiRequest{
+		query:  sourcegraphVersionQuery,
+		result: &sourcegraphVersion,
+	}).do()
+	if err != nil {
+		return "", err
+	}
+
+	return sourcegraphVersion.Site.ProductVersion, nil
+}

--- a/internal/codeintel/upload.go
+++ b/internal/codeintel/upload.go
@@ -16,15 +16,16 @@ import (
 )
 
 type UploadIndexOpts struct {
-	Endpoint            string
-	AccessToken         string
-	Repo                string
-	Commit              string
-	Root                string
-	Indexer             string
-	GitHubToken         string
-	File                string
-	MaxPayloadSizeBytes int
+	Endpoint                string
+	AccessToken             string
+	Repo                    string
+	Commit                  string
+	Root                    string
+	Indexer                 string
+	GitHubToken             string
+	File                    string
+	MaxPayloadSizeBytes     int
+	SupportsMultipartUpload bool
 }
 
 // ErrUnauthorized occurs when the upload endpoint returns a 401 response.
@@ -39,7 +40,7 @@ func UploadIndex(opts UploadIndexOpts) (string, error) {
 		return "", err
 	}
 
-	if fileInfo.Size() <= int64(opts.MaxPayloadSizeBytes) {
+	if !opts.SupportsMultipartUpload || fileInfo.Size() <= int64(opts.MaxPayloadSizeBytes) {
 		id, err := uploadIndex(opts)
 		if err != nil {
 			return "", err

--- a/internal/codeintel/upload_test.go
+++ b/internal/codeintel/upload_test.go
@@ -54,15 +54,16 @@ func TestUploadIndex(t *testing.T) {
 	_ = f.Close()
 
 	id, err := UploadIndex(UploadIndexOpts{
-		Endpoint:            ts.URL,
-		AccessToken:         "hunter2",
-		Repo:                "foo/bar",
-		Commit:              "deadbeef",
-		Root:                "proj/",
-		Indexer:             "lsif-go",
-		GitHubToken:         "ght",
-		File:                f.Name(),
-		MaxPayloadSizeBytes: 1000,
+		Endpoint:                ts.URL,
+		AccessToken:             "hunter2",
+		Repo:                    "foo/bar",
+		Commit:                  "deadbeef",
+		Root:                    "proj/",
+		Indexer:                 "lsif-go",
+		GitHubToken:             "ght",
+		File:                    f.Name(),
+		MaxPayloadSizeBytes:     1000,
+		SupportsMultipartUpload: true,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error uploading index: %s", err)
@@ -114,15 +115,16 @@ func TestUploadIndexMultipart(t *testing.T) {
 	_ = f.Close()
 
 	id, err := UploadIndex(UploadIndexOpts{
-		Endpoint:            ts.URL,
-		AccessToken:         "hunter2",
-		Repo:                "foo/bar",
-		Commit:              "deadbeef",
-		Root:                "proj/",
-		Indexer:             "lsif-go",
-		GitHubToken:         "ght",
-		File:                f.Name(),
-		MaxPayloadSizeBytes: 1000,
+		Endpoint:                ts.URL,
+		AccessToken:             "hunter2",
+		Repo:                    "foo/bar",
+		Commit:                  "deadbeef",
+		Root:                    "proj/",
+		Indexer:                 "lsif-go",
+		GitHubToken:             "ght",
+		File:                    f.Name(),
+		MaxPayloadSizeBytes:     1000,
+		SupportsMultipartUpload: true,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error uploading index: %s", err)

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,31 @@
+package version
+
+import (
+	"regexp"
+
+	"github.com/Masterminds/semver"
+)
+
+var buildDate = regexp.MustCompile(`^\d+_(\d{4}-\d{2}-\d{2})_[a-z0-9]{7}$`)
+
+func SourcegraphVersionCheck(version, constraint, minDate string) (bool, error) {
+	if version == "dev" || version == "0.0.0+dev" {
+		return true, nil
+	}
+
+	matches := buildDate.FindStringSubmatch(version)
+	if len(matches) > 1 {
+		return matches[1] >= minDate, nil
+	}
+
+	c, err := semver.NewConstraint(constraint)
+	if err != nil {
+		return false, nil
+	}
+
+	v, err := semver.NewVersion(version)
+	if err != nil {
+		return false, err
+	}
+	return c.Check(v), nil
+}

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,4 +1,4 @@
-package main
+package version
 
 import "testing"
 
@@ -62,7 +62,7 @@ func TestSourcegraphVersionCheck(t *testing.T) {
 			expected:       true,
 		},
 	} {
-		actual, err := sourcegraphVersionCheck(tc.currentVersion, tc.constraint, tc.minDate)
+		actual, err := SourcegraphVersionCheck(tc.currentVersion, tc.constraint, tc.minDate)
 		if err != nil {
 			t.Errorf("err: %s", err)
 		}


### PR DESCRIPTION
This probably should have made it into the 3.12 src-cli release so that we maintain large-upload backwards compat (but this is trading one error for another in most cases).

I'll release 3.12.1 with this fix so that this version can still work with pre-3.16 Sourcegraph instances.