### PR TITLE
Deprecate config file in favour of env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,16 +73,6 @@ Point `src` to your instance and access token using environment variables:
 SRC_ENDPOINT=https://sourcegraph.example.com SRC_ACCESS_TOKEN="secret" src search 'foobar'
 ```
 
-### Via global configuration file
-
-Create a `$HOME/src-config.json` with:
-
-```sh
-{"endpoint": "https://sourcegraph.example.com", "accessToken": "secret"}
-```
-
-Then `src search 'foobar'` and other commands will automatically use that configuration!
-
 ### Where to get an access token
 
 Visit your Sourcegraph instance (or https://sourcegraph.com), click your username in the top right to open the user menu, select **Settings**, and then select **Access tokens** in the left hand menu.

--- a/cmd/src/main.go
+++ b/cmd/src/main.go
@@ -18,10 +18,13 @@ Usage:
 
 	src [options] command [command options]
 
+Environment variables
+	SRC_ACCESS_TOKEN  Sourcegraph access token
+	SRC_ENDPOINT      endpoint to use, if unset will default to "https://sourcegraph.com"
+
 The options are:
 
-	-config=$HOME/src-config.json    specifies a file containing {"accessToken": "<secret>", "endpoint": "https://sourcegraph.com"}
-	-endpoint=                       specifies the endpoint to use e.g. "https://sourcegraph.com" (overrides -config, if any)
+	-endpoint=                       specifies the endpoint to use e.g. "https://sourcegraph.com" (overrides SRC_ENDPOINT if set)
 	-v                               print verbose output
 
 The commands are:


### PR DESCRIPTION
We still read from the config file but it has been undocumented so
that we can remove it at a later point.

Users should instead use the `SRC_ACCESS_TOKEN` and 
`SRC_ENDPOINT` environment variables.

Part of: https://github.com/sourcegraph/src-cli/issues/156