### PR TITLE
Add support for binary file changes

### DIFF
--- a/cmd/src/actions_exec_backend_runner.go
+++ b/cmd/src/actions_exec_backend_runner.go
@@ -253,7 +253,9 @@ func runAction(ctx context.Context, prefix, repoID, repoName, rev string, steps 
 	// That means we need to strip away the `a/` and `/b` prefixes with `--no-prefix`.
 	// See: https://github.com/sourcegraph/sourcegraph/blob/82d5e7e1562fef6be5c0b17f18631040fd330835/enterprise/internal/campaigns/service.go#L324-L329
 	//
-	diffOut, err := runGitCmd("diff", "--cached", "--no-prefix")
+	// Also, we need to add --binary so binary file changes are inlined in the patch.
+	//
+	diffOut, err := runGitCmd("diff", "--cached", "--no-prefix", "--binary")
 	if err != nil {
 		return nil, errors.Wrap(err, "git diff failed")
 	}


### PR DESCRIPTION
Previously, the patch was not complete and didn't apply in case any binary file changes were involved.

This is non-breaking. Additional changes on the frontend need to be performed so they show up though.