### PR TITLE
Handle ~/ prefix in config path

### DIFF
--- a/cmd/src/main.go
+++ b/cmd/src/main.go
@@ -75,12 +75,15 @@ type config struct {
 func readConfig() (*config, error) {
 	cfgPath := *configPath
 	userSpecified := *configPath != ""
+
+	user, err := user.Current()
+	if err != nil {
+		return nil, err
+	}
 	if !userSpecified {
-		user, err := user.Current()
-		if err != nil {
-			return nil, err
-		}
 		cfgPath = filepath.Join(user.HomeDir, "src-config.json")
+	} else if strings.HasPrefix(cfgPath, "~/") {
+		cfgPath = filepath.Join(user.HomeDir, cfgPath[2:])
 	}
 	data, err := ioutil.ReadFile(os.ExpandEnv(cfgPath))
 	if err != nil && (!os.IsNotExist(err) || userSpecified) {


### PR DESCRIPTION
We handle this special case so that the home directory is expanded. This
is only an issue when the path is specified using an equal sign, eg. -config=~/foo.json

We just fix this one specific edge case since config files are being
deprecated soon.

Closes: https://github.com/sourcegraph/src-cli/issues/187