### PR TITLE
migrate Configuration usage to Settings

### DIFF
--- a/cmd/src/config.go
+++ b/cmd/src/config.go
@@ -50,7 +50,7 @@ Use "src config [command] -h" for more information about a command.
 }
 
 const configurationSubjectFragment = `
-fragment ConfigurationSubjectFields on ConfigurationSubject {
+fragment ConfigurationSubjectFields on SettingsSubject {
     id
     latestSettings {
         id

--- a/cmd/src/config.go
+++ b/cmd/src/config.go
@@ -54,7 +54,7 @@ fragment SettingsSubjectFields on SettingsSubject {
     id
     latestSettings {
         id
-		contents
+        contents
         author {
             ...UserFields
         }

--- a/cmd/src/config.go
+++ b/cmd/src/config.go
@@ -11,7 +11,7 @@ var configCommands commander
 func init() {
 	usage := `'src config' is a tool that manages global, organization, and user settings on a Sourcegraph instance.
 
-The effective configuration is computed by shallow-merging the following settings, in order from lowest to highest precedence:
+The effective setting is computed by shallow-merging the following settings, in order from lowest to highest precedence:
 
 - Global settings (site-wide)
 - Organization settings for the user's organizations (if any)
@@ -26,9 +26,9 @@ Usage:
 
 The commands are:
 
-	get       gets the effective (merged) configuration
-	edit      updates configuration settings
-	list      lists the partial settings (that, when merged, yield the effective configuration)
+	get       gets the effective (merged) settings
+	edit      updates settings
+	list      lists the partial settings (that, when merged, yield the effective settings)
 
 Use "src config [command] -h" for more information about a command.
 `
@@ -49,14 +49,12 @@ Use "src config [command] -h" for more information about a command.
 	})
 }
 
-const configurationSubjectFragment = `
-fragment ConfigurationSubjectFields on SettingsSubject {
+const settingsSubjectFragment = `
+fragment SettingsSubjectFields on SettingsSubject {
     id
     latestSettings {
         id
-        configuration {
-            ...ConfigurationFields
-        }
+		contents
         author {
             ...UserFields
         }
@@ -67,60 +65,48 @@ fragment ConfigurationSubjectFields on SettingsSubject {
 }
 `
 
-type ConfigurationSubject struct {
-	ID                   string
-	LatestSettings       *Settings
-	SettingsURL          string
-	ViewerCanAdminister  bool
-	ConfigurationCascade ConfigurationCascade
+type SettingsSubject struct {
+	ID                  string
+	LatestSettings      *Settings
+	SettingsURL         string
+	ViewerCanAdminister bool
+	SettingsCascade     SettingsCascade
 }
 
 type Settings struct {
-	ID            int32
-	Configuration Configuration
-	Author        *User
-	CreatedAt     string
+	ID        int32
+	Contents  string
+	Author    *User
+	CreatedAt string
 }
 
-const configurationCascadeFragment = `
-fragment ConfigurationCascadeFields on ConfigurationCascade {
+const settingsCascadeFragment = `
+fragment SettingsCascadeFields on SettingsCascade {
     subjects {
-        ...ConfigurationSubjectFields
+        ...SettingsSubjectFields
     }
-    merged {
-        ...ConfigurationFields
-    }
+    final
 }
 `
 
-type ConfigurationCascade struct {
-	Subjects []ConfigurationSubject
-	Merged   Configuration
+type SettingsCascade struct {
+	Subjects []SettingsSubject
+	Final    string
 }
 
-const configurationFragment = `
-fragment ConfigurationFields on Configuration {
-    contents
-}
-`
-
-type Configuration struct {
-	Contents string
-}
-
-const viewerConfigurationQuery = `query ViewerConfiguration {
-  viewerConfiguration {
-    ...ConfigurationCascadeFields
+const viewerSettingsQuery = `query ViewerSettings {
+  viewerSettings {
+    ...SettingsCascadeFields
   }
-}` + configurationCascadeFragment + configurationSubjectFragment + configurationFragment + userFragment
+}` + settingsCascadeFragment + settingsSubjectFragment + userFragment
 
-const configurationSubjectCascadeQuery = `query ConfigurationSubjectCascade($subject: ID!) {
-  configurationSubject(id: $subject) {
-    configurationCascade {
-      ...ConfigurationCascadeFields
+const settingsSubjectCascadeQuery = `query SettingsSubjectCascade($subject: ID!) {
+  settingsSubject(id: $subject) {
+    settingsCascade {
+      ...SettingsCascadeFields
     }
   }
-}` + configurationCascadeFragment + configurationSubjectFragment + configurationFragment + userFragment
+}` + settingsCascadeFragment + settingsSubjectFragment + userFragment
 
 type KeyPath struct {
 	Property string `json:"property,omitempty"`
@@ -150,9 +136,9 @@ query ViewerUserID {
 	return result.CurrentUser.ID, nil
 }
 
-func getConfigurationSubjectLatestSettingsID(subjectID string) (*int, error) {
+func getSettingsSubjectLatestSettingsID(subjectID string) (*int, error) {
 	var result struct {
-		ConfigurationSubject *struct {
+		SettingsSubject *struct {
 			LatestSettings *struct {
 				ID int
 			}
@@ -160,8 +146,8 @@ func getConfigurationSubjectLatestSettingsID(subjectID string) (*int, error) {
 	}
 	req := &apiRequest{
 		query: `
-query ConfigurationSubjectLatestSettingsID($subject: ID!) {
-  configurationSubject(id: $subject) {
+query SettingsSubjectLatestSettingsID($subject: ID!) {
+  settingsSubject(id: $subject) {
     latestSettings {
       id
     }
@@ -174,11 +160,11 @@ query ConfigurationSubjectLatestSettingsID($subject: ID!) {
 	if err := req.do(); err != nil {
 		return nil, err
 	}
-	if result.ConfigurationSubject == nil {
-		return nil, fmt.Errorf("unable to find configuration subject with ID %s", subjectID)
+	if result.SettingsSubject == nil {
+		return nil, fmt.Errorf("unable to find settings subject with ID %s", subjectID)
 	}
-	if result.ConfigurationSubject.LatestSettings == nil {
+	if result.SettingsSubject.LatestSettings == nil {
 		return nil, nil
 	}
-	return &result.ConfigurationSubject.LatestSettings.ID, nil
+	return &result.SettingsSubject.LatestSettings.ID, nil
 }

--- a/cmd/src/config_edit.go
+++ b/cmd/src/config_edit.go
@@ -11,23 +11,23 @@ func init() {
 	usage := `
 Examples:
 
-  Edit configuration property for the current user (authenticated by the src CLI's access token, if any):
+  Edit settings property for the current user (authenticated by the src CLI's access token, if any):
 
     	$ src config edit -property motd -value '["Hello!"]'
 
-  Overwrite all configuration settings for the current user:
+  Overwrite all settings settings for the current user:
 
     	$ src config edit -overwrite -value '{"motd":["Hello!"]}'
 
-  Overwrite all configuration settings for the current user with the file contents:
+  Overwrite all settings settings for the current user with the file contents:
 
     	$ src config edit -overwrite -value-file myconfig.json
 
-  Edit a configuration property for the user with username alice:
+  Edit a settings property for the user with username alice:
 
     	$ src config edit -subject=$(src users get -f '{{.ID}}' -username=alice) -property motd -value '["Hello!"]'
 
-  Overwrite all configuration settings for the organization named abc-org:
+  Overwrite all settings settings for the organization named abc-org:
 
     	$ src config edit -subject=$(src orgs get -f '{{.ID}}' -name=abc-org) -overwrite -value '{"motd":["Hello!"]}'
 
@@ -40,9 +40,9 @@ Examples:
 		fmt.Println(usage)
 	}
 	var (
-		subjectFlag   = flagSet.String("subject", "", "The ID of the configuration subject whose configuration to edit. (default: authenticated user)")
-		propertyFlag  = flagSet.String("property", "", "The name of the configuration property to set.")
-		valueFlag     = flagSet.String("value", "", "The value for the configuration property (when used with -property).")
+		subjectFlag   = flagSet.String("subject", "", "The ID of the settings subject whose settings to edit. (default: authenticated user)")
+		propertyFlag  = flagSet.String("property", "", "The name of the settings property to set.")
+		valueFlag     = flagSet.String("value", "", "The value for the settings property (when used with -property).")
 		valueFileFlag = flagSet.String("value-file", "", "Read the value from this file instead of from the -value command-line option.")
 		overwriteFlag = flagSet.Bool("overwrite", false, "Overwrite the entire settings with the value given in -value (not just a single property).")
 		apiFlags      = newAPIFlags(flagSet)
@@ -85,15 +85,15 @@ Examples:
 			subjectID = *subjectFlag
 		}
 
-		lastID, err := getConfigurationSubjectLatestSettingsID(subjectID)
+		lastID, err := getSettingsSubjectLatestSettingsID(subjectID)
 		if err != nil {
 			return err
 		}
 
 		query := `
-mutation EditConfiguration($input: ConfigurationMutationGroupInput!, $edit: ConfigurationEdit!) {
-  configurationMutation(input: $input) {
-    editConfiguration(edit: $edit) {
+mutation EditSettings($input: SettingsMutationGroupInput!, $edit: SettingsEdit!) {
+  settingsMutation(input: $input) {
+    editSettings(edit: $edit) {
       empty {
         alwaysNil
       }
@@ -113,8 +113,8 @@ mutation EditConfiguration($input: ConfigurationMutationGroupInput!, $edit: Conf
 		}
 
 		var result struct {
-			ViewerConfiguration  *ConfigurationCascade
-			ConfigurationSubject *ConfigurationSubject
+			ViewerSettings  *SettingsCascade
+			SettingsSubject *SettingsSubject
 		}
 		return (&apiRequest{
 			query:  query,


### PR DESCRIPTION
closes https://github.com/sourcegraph/sourcegraph/issues/10419

looks like `ConfigurationSubject` was removed a while back, and `SettingsSubject` has replaced it

> SettingsSubject is something that can have settings: a site ("global settings", which is different from "site configuration"), an organization, or a user.

```
go build ./cmd/src
./src config list
./src config get
```

a variety of other `Configuration`-related fields have been listed as deprecated, so I've gone ahead and migrated them to use `Settings`