### PR TITLE
Handle HiddenPatches in PatchSet response

### DIFF
--- a/cmd/src/patch_sets.go
+++ b/cmd/src/patch_sets.go
@@ -46,39 +46,45 @@ fragment PatchSetFields on PatchSet {
     id
     patches(first: %d) {
         nodes {
-            repository {
+            __typename
+            ... on HiddenPatch {
                 id
-                name
-                url
             }
-            diff {
-                fileDiffs {
-                    rawDiff
-                    diffStat {
-                        added
-                        deleted
-                        changed
-                    }
-                    nodes {
-                        oldPath
-                        newPath
-                        hunks {
-                            body
-                            section
-                            newRange { startLine, lines }
-                            oldRange { startLine, lines }
-                            oldNoNewlineAt
-                        }
-                        stat {
+            ... on Patch {
+                repository {
+                    id
+                    name
+                    url
+                }
+                diff {
+                    fileDiffs {
+                        rawDiff
+                        diffStat {
                             added
                             deleted
                             changed
                         }
-                        oldFile {
-                            name
-                            externalURLs {
-                                serviceType
-                                url
+                        nodes {
+                            oldPath
+                            newPath
+                            hunks {
+                                body
+                                section
+                                newRange { startLine, lines }
+                                oldRange { startLine, lines }
+                                oldNoNewlineAt
+                            }
+                            stat {
+                                added
+                                deleted
+                                changed
+                            }
+                            oldFile {
+                                name
+                                externalURLs {
+                                    serviceType
+                                    url
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
https://github.com/sourcegraph/sourcegraph/pull/11071 changes parts of our GraphQL API that make this change necessary.

In order to not break older Sourcegraph versions, we need to release this in a minor-version bump (so that older Sourcegraph versions don't recommend it) and increase the "required src-cli version" in Sourcegraph.