### PR TITLE
Render alert fields when performing searches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ All notable changes to `src-cli` are documented in this file.
 
 - Pull missing docker images automatically. [#191](https://github.com/sourcegraph/src-cli/pull/191)
 
+- Searches that result in errors will now display any alerts returned by Sourcegraph, including suggestions for how the search could be corrected. [#221](https://github.com/sourcegraph/src-cli/pull/221)
+
 ### Changed
 
 - The terminal UI has been replaced by the logger-based UI that was previously only visible in verbose-mode (`-v`). [#228](https://github.com/sourcegraph/src-cli/pull/228)

--- a/cmd/src/actions_exec.go
+++ b/cmd/src/actions_exec.go
@@ -483,14 +483,7 @@ query ActionRepos($query: String!) {
 					}
 				}
 			}
-			alert {
-				title
-				description
-				proposedQueries {
-					description
-					query
-				}
-			}
+			...SearchResultsAlertFields
 		}
 	}
 }
@@ -508,7 +501,8 @@ fragment repositoryFields on Repository {
 		}
 	}
 }
-`
+` + searchResultsAlertFragment
+
 	type Repository struct {
 		ID, Name           string
 		ExternalRepository struct {

--- a/cmd/src/actions_exec.go
+++ b/cmd/src/actions_exec.go
@@ -637,8 +637,7 @@ fragment repositoryFields on Repository {
 		yellow.Fprintf(os.Stderr, "WARNING: No repositories matched by scopeQuery\n")
 	}
 
-	alert := result.Data.Search.Results.Alert
-	if content, err := alert.Render(); err != nil {
+	if content, err := result.Data.Search.Results.Alert.Render(); err != nil {
 		yellow.Fprint(os.Stderr, err)
 	} else {
 		os.Stderr.WriteString(content)

--- a/cmd/src/actions_exec.go
+++ b/cmd/src/actions_exec.go
@@ -637,12 +637,11 @@ fragment repositoryFields on Repository {
 		yellow.Fprintf(os.Stderr, "WARNING: No repositories matched by scopeQuery\n")
 	}
 
-	if alert := result.Data.Search.Results.Alert; alert.HasAlert() {
-		if content, err := alert.Render(); err != nil {
-			yellow.Fprint(os.Stderr, err)
-		} else {
-			os.Stderr.WriteString(content)
-		}
+	alert := result.Data.Search.Results.Alert
+	if content, err := alert.Render(); err != nil {
+		yellow.Fprint(os.Stderr, err)
+	} else {
+		os.Stderr.WriteString(content)
 	}
 
 	return repos, nil

--- a/cmd/src/actions_exec.go
+++ b/cmd/src/actions_exec.go
@@ -483,6 +483,14 @@ query ActionRepos($query: String!) {
 					}
 				}
 			}
+			alert {
+				title
+				description
+				proposedQueries {
+					description
+					query
+				}
+			}
 		}
 	}
 }
@@ -527,6 +535,7 @@ fragment repositoryFields on Repository {
 						}
 						Repository Repository `json:"repository"`
 					}
+					Alert searchResultsAlert
 				}
 			}
 		} `json:"data,omitempty"`
@@ -632,6 +641,14 @@ fragment repositoryFields on Repository {
 
 	if len(repos) == 0 && !*verbose {
 		yellow.Fprintf(os.Stderr, "WARNING: No repositories matched by scopeQuery\n")
+	}
+
+	if alert := result.Data.Search.Results.Alert; alert.HasAlert() {
+		if content, err := alert.Render(); err != nil {
+			yellow.Fprint(os.Stderr, err)
+		} else {
+			os.Stderr.WriteString(content)
+		}
 	}
 
 	return repos, nil

--- a/cmd/src/colors.go
+++ b/cmd/src/colors.go
@@ -37,6 +37,13 @@ var ansiColors = map[string]string{
 	"search-commit-author":  fg256Color(2),
 	"search-commit-subject": fg256Color(68),
 	"search-commit-date":    fg256Color(23),
+
+	// Search alert specific colors.
+	"search-alert-title":                fg256Color(124),
+	"search-alert-description":          fg256Color(172),
+	"search-alert-proposed-title":       "",
+	"search-alert-proposed-query":       fg256Color(69),
+	"search-alert-proposed-description": "",
 }
 
 // Borrowed from https://github.com/acarl005/stripansi/blob/master/stripansi.go

--- a/cmd/src/colors.go
+++ b/cmd/src/colors.go
@@ -40,7 +40,7 @@ var ansiColors = map[string]string{
 
 	// Search alert specific colors.
 	"search-alert-title":                fg256Color(124),
-	"search-alert-description":          fg256Color(172),
+	"search-alert-description":          fg256Color(124),
 	"search-alert-proposed-title":       "",
 	"search-alert-proposed-query":       fg256Color(69),
 	"search-alert-proposed-description": "",

--- a/cmd/src/format.go
+++ b/cmd/src/format.go
@@ -151,14 +151,12 @@ func parseTemplate(text string) (*template.Template, error) {
 
 		// Alert rendering
 		"searchAlertRender": func(alert searchResultsAlert) string {
-			if alert.HasAlert() {
-				if content, err := alert.Render(); err != nil {
-					fmt.Fprintf(os.Stderr, "Error rendering search alert: %v\n", err)
-				} else {
-					return content
-				}
+			if content, err := alert.Render(); err != nil {
+				fmt.Fprintf(os.Stderr, "Error rendering search alert: %v\n", err)
+				return ""
+			} else {
+				return content
 			}
-			return ""
 		},
 	})
 	return tmpl.Parse(text)

--- a/cmd/src/format.go
+++ b/cmd/src/format.go
@@ -148,6 +148,18 @@ func parseTemplate(text string) (*template.Template, error) {
 
 			return buf.String()
 		},
+
+		// Alert rendering
+		"searchAlertRender": func(alert searchResultsAlert) string {
+			if alert.HasAlert() {
+				if content, err := alert.Render(); err != nil {
+					fmt.Fprintf(os.Stderr, "Error rendering search alert: %v\n", err)
+				} else {
+					return content
+				}
+			}
+			return ""
+		},
 	})
 	return tmpl.Parse(text)
 }

--- a/cmd/src/search.go
+++ b/cmd/src/search.go
@@ -211,18 +211,11 @@ Other tips:
 				}
 				resultCount
 				elapsedMilliseconds
-				alert {
-				  title
-				  description
-				  proposedQueries {
-				   description
-				   query
-				  }
-				}
+				...SearchResultsAlertFields
 			  }
 			}
 		  }
-		`
+		` + searchResultsAlertFragment
 
 		var result struct {
 			Site struct {

--- a/cmd/src/search.go
+++ b/cmd/src/search.go
@@ -211,6 +211,14 @@ Other tips:
 				}
 				resultCount
 				elapsedMilliseconds
+				alert {
+				  title
+				  description
+				  proposedQueries {
+				   description
+				   query
+				  }
+				}
 			  }
 			}
 		  }
@@ -281,6 +289,7 @@ type searchResults struct {
 	Cloning, Missing, Timedout []map[string]interface{}
 	ResultCount                int
 	ElapsedMilliseconds        int
+	Alert                      searchResultsAlert
 }
 
 // searchResultsImproved is a superset of what the GraphQL API returns. It
@@ -568,6 +577,9 @@ const searchResultsTemplate = `{{- /* ignore this line for template formatting s
 	{{- with .Missing}}{{color "warning"}}{{"\n"}}({{len .}}) missing:{{color "nc"}} {{join (repoNames .) ", "}}{{end -}}
 	{{- with .Timedout}}{{color "warning"}}{{"\n"}}({{len .}}) timed out:{{color "nc"}} {{join (repoNames .) ", "}}{{end -}}
 	{{"\n"}}
+
+{{- /* Any alert returned from the search */ -}}
+	{{- searchAlertRender .Alert -}}
 
 {{- /* Rendering of results */ -}}
 	{{- range .Results -}}

--- a/cmd/src/search_alert.go
+++ b/cmd/src/search_alert.go
@@ -19,6 +19,8 @@ func init() {
 	}
 }
 
+// searchResultsAlert is a type that can be used to unmarshal values returned by
+// the searchResultsAlertFragment GraphQL fragment below.
 type searchResultsAlert struct {
 	Title           string
 	Description     string
@@ -39,6 +41,21 @@ func (alert *searchResultsAlert) Render() (string, error) {
 	}
 	return b.String(), nil
 }
+
+// searchResultsAlertFragment provides a GraphQL fragment that can be used to
+// hydrate a searchResultsAlert instance.
+const searchResultsAlertFragment = `
+	fragment SearchResultsAlertFields on SearchResults {
+		alert {
+			title
+			description
+			proposedQueries {
+				description
+				query
+			}
+		}
+	}
+`
 
 const searchResultsAlertTemplateContent = `
 {{- color "search-alert-title"}}❗{{.Title}}{{color "nc" -}}{{"\n"}}

--- a/cmd/src/search_alert.go
+++ b/cmd/src/search_alert.go
@@ -30,10 +30,9 @@ type searchResultsAlert struct {
 	}
 }
 
-func (alert *searchResultsAlert) HasAlert() bool {
-	return alert.Title != ""
-}
-
+// Render renders an alert to a string ready to be output to a console,
+// respecting the colour configuration in use by the current process. If the
+// alert is empty, then an empty string will be returned.
 func (alert *searchResultsAlert) Render() (string, error) {
 	b := &strings.Builder{}
 	if err := searchResultsAlertTemplate.Execute(b, alert); err != nil {
@@ -58,18 +57,22 @@ const searchResultsAlertFragment = `
 `
 
 const searchResultsAlertTemplateContent = `
-{{- color "search-alert-title"}}❗{{.Title}}{{color "nc" -}}{{"\n"}}
-{{- if gt (len .Description) 0 -}}
-	{{- color "search-alert-description"}}{{.Description}}{{"\n"}}{{color "nc" -}}
-{{- end -}}
-{{- if gt (len .ProposedQueries) 0 -}}
-	{{- color "search-alert-proposed-title"}}Did you mean:{{color "nc" -}}
-	{{- "\n" -}}
-	{{- range .ProposedQueries -}}
-		{{- color "search-alert-proposed-query"}}{{.Query}}{{color "nc" -}}
-		{{- " - " -}}
-		{{- color "search-alert-proposed-description"}}{{.Description}}{{color "nc" -}}
-		{{- "\n" -}}
+	{{- if gt (len .Title) 0 -}}
+		{{- color "search-alert-title"}}❗{{.Title}}{{color "nc"}}{{"\n"}}
 	{{- end -}}
-{{- end -}}
+
+	{{- if gt (len .Description) 0 -}}
+		{{- color "search-alert-description"}}{{.Description}}{{color "nc"}}{{"\n"}}
+	{{- end -}}
+
+	{{- if gt (len .ProposedQueries) 0 -}}
+		{{- color "search-alert-proposed-title"}}Did you mean:{{color "nc" -}}
+		{{- "\n" -}}
+		{{- range .ProposedQueries -}}
+			{{- color "search-alert-proposed-query"}}{{.Query}}{{color "nc" -}}
+			{{- " - " -}}
+			{{- color "search-alert-proposed-description"}}{{.Description}}{{color "nc" -}}
+			{{- "\n" -}}
+		{{- end -}}
+	{{- end -}}
 `

--- a/cmd/src/search_alert.go
+++ b/cmd/src/search_alert.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"strings"
+	"text/template"
+
+	"github.com/pkg/errors"
+)
+
+var searchResultsAlertTemplate *template.Template
+
+func init() {
+	var err error
+
+	if searchResultsAlertTemplate, err = parseTemplate(searchResultsAlertTemplateContent); err != nil {
+		// This shouldn't fail, since we control the template content via a
+		// constant below.
+		panic(err)
+	}
+}
+
+type searchResultsAlert struct {
+	Title           string
+	Description     string
+	ProposedQueries []struct {
+		Description string
+		Query       string
+	}
+}
+
+func (alert *searchResultsAlert) HasAlert() bool {
+	return alert.Title != ""
+}
+
+func (alert *searchResultsAlert) Render() (string, error) {
+	b := &strings.Builder{}
+	if err := searchResultsAlertTemplate.Execute(b, alert); err != nil {
+		return "", errors.Wrap(err, "rendering alert template")
+	}
+	return b.String(), nil
+}
+
+const searchResultsAlertTemplateContent = `
+{{- color "search-alert-title"}}❗{{.Title}}{{color "nc" -}}{{"\n"}}
+{{- if gt (len .Description) 0 -}}
+	{{- color "search-alert-description"}}{{.Description}}{{"\n"}}{{color "nc" -}}
+{{- end -}}
+{{- if gt (len .ProposedQueries) 0 -}}
+	{{- color "search-alert-proposed-title"}}Did you mean:{{color "nc" -}}
+	{{- "\n" -}}
+	{{- range .ProposedQueries -}}
+		{{- color "search-alert-proposed-query"}}{{.Query}}{{color "nc" -}}
+		{{- " - " -}}
+		{{- color "search-alert-proposed-description"}}{{.Description}}{{color "nc" -}}
+		{{- "\n" -}}
+	{{- end -}}
+{{- end -}}
+`

--- a/cmd/src/search_alert.go
+++ b/cmd/src/search_alert.go
@@ -62,14 +62,14 @@ const searchResultsAlertTemplateContent = `
 	{{- end -}}
 
 	{{- if gt (len .Description) 0 -}}
-		{{- color "search-alert-description"}}{{.Description}}{{color "nc"}}{{"\n"}}
+		{{- color "search-alert-description"}}  {{.Description}}{{color "nc"}}{{"\n"}}
 	{{- end -}}
 
 	{{- if gt (len .ProposedQueries) 0 -}}
-		{{- color "search-alert-proposed-title"}}Did you mean:{{color "nc" -}}
+		{{- color "search-alert-proposed-title"}}  Did you mean:{{color "nc" -}}
 		{{- "\n" -}}
 		{{- range .ProposedQueries -}}
-			{{- color "search-alert-proposed-query"}}{{.Query}}{{color "nc" -}}
+			{{- color "search-alert-proposed-query"}}  {{.Query}}{{color "nc" -}}
 			{{- " - " -}}
 			{{- color "search-alert-proposed-description"}}{{.Description}}{{color "nc" -}}
 			{{- "\n" -}}

--- a/cmd/src/search_alert_test.go
+++ b/cmd/src/search_alert_test.go
@@ -98,7 +98,7 @@ func TestRender(t *testing.T) {
 	})
 }
 
-var subColourCodesRegex = regexp.MustCompile(`\[\[[a-zA-Z0-9-]+\]\]`)
+var subColorCodesRegex = regexp.MustCompile(`\[\[[a-zA-Z0-9-]+\]\]`)
 
 // subColourCodes provides ad-hoc templating of just ANSI colour codes from our
 // ansiColors map, using a [[colour-code]] syntax.

--- a/cmd/src/search_alert_test.go
+++ b/cmd/src/search_alert_test.go
@@ -52,9 +52,9 @@ func TestRender(t *testing.T) {
 
 		expected := subColourCodes(strings.Join([]string{
 			"[[search-alert-title]]❗foo[[nc]]\n",
-			"[[search-alert-proposed-title]]Did you mean:[[nc]]\n",
-			"[[search-alert-proposed-query]]xyz:abc[[nc]] - [[search-alert-proposed-description]]quux[[nc]]\n",
-			"[[search-alert-proposed-query]]def:ghi[[nc]] - [[search-alert-proposed-description]]baz[[nc]]\n",
+			"[[search-alert-proposed-title]]  Did you mean:[[nc]]\n",
+			"[[search-alert-proposed-query]]  xyz:abc[[nc]] - [[search-alert-proposed-description]]quux[[nc]]\n",
+			"[[search-alert-proposed-query]]  def:ghi[[nc]] - [[search-alert-proposed-description]]baz[[nc]]\n",
 		}, ""))
 		if diff := cmp.Diff(expected, content); diff != "" {
 			t.Errorf("alert without description content incorrect: %s", diff)
@@ -72,7 +72,7 @@ func TestRender(t *testing.T) {
 
 		expected := subColourCodes(strings.Join([]string{
 			"[[search-alert-title]]❗foo[[nc]]\n",
-			"[[search-alert-description]]bar[[nc]]\n",
+			"[[search-alert-description]]  bar[[nc]]\n",
 		}, ""))
 		if diff := cmp.Diff(expected, content); diff != "" {
 			t.Errorf("alert without queries content incorrect: %s", diff)
@@ -87,10 +87,10 @@ func TestRender(t *testing.T) {
 
 		expected := subColourCodes(strings.Join([]string{
 			"[[search-alert-title]]❗foo[[nc]]\n",
-			"[[search-alert-description]]bar[[nc]]\n",
-			"[[search-alert-proposed-title]]Did you mean:[[nc]]\n",
-			"[[search-alert-proposed-query]]xyz:abc[[nc]] - [[search-alert-proposed-description]]quux[[nc]]\n",
-			"[[search-alert-proposed-query]]def:ghi[[nc]] - [[search-alert-proposed-description]]baz[[nc]]\n",
+			"[[search-alert-description]]  bar[[nc]]\n",
+			"[[search-alert-proposed-title]]  Did you mean:[[nc]]\n",
+			"[[search-alert-proposed-query]]  xyz:abc[[nc]] - [[search-alert-proposed-description]]quux[[nc]]\n",
+			"[[search-alert-proposed-query]]  def:ghi[[nc]] - [[search-alert-proposed-description]]baz[[nc]]\n",
 		}, ""))
 		if diff := cmp.Diff(expected, content); diff != "" {
 			t.Errorf("full alert content incorrect: %s", diff)

--- a/cmd/src/search_alert_test.go
+++ b/cmd/src/search_alert_test.go
@@ -50,7 +50,7 @@ func TestRender(t *testing.T) {
 			t.Errorf("unexpected error rendering alert without description: %v", err)
 		}
 
-		expected := subColourCodes(strings.Join([]string{
+		expected := subColorCodes(strings.Join([]string{
 			"[[search-alert-title]]❗foo[[nc]]\n",
 			"[[search-alert-proposed-title]]  Did you mean:[[nc]]\n",
 			"[[search-alert-proposed-query]]  xyz:abc[[nc]] - [[search-alert-proposed-description]]quux[[nc]]\n",
@@ -70,7 +70,7 @@ func TestRender(t *testing.T) {
 			t.Errorf("unexpected error rendering alert without queries: %v", err)
 		}
 
-		expected := subColourCodes(strings.Join([]string{
+		expected := subColorCodes(strings.Join([]string{
 			"[[search-alert-title]]❗foo[[nc]]\n",
 			"[[search-alert-description]]  bar[[nc]]\n",
 		}, ""))
@@ -85,7 +85,7 @@ func TestRender(t *testing.T) {
 			t.Errorf("unexpected error rendering full alert: %v", err)
 		}
 
-		expected := subColourCodes(strings.Join([]string{
+		expected := subColorCodes(strings.Join([]string{
 			"[[search-alert-title]]❗foo[[nc]]\n",
 			"[[search-alert-description]]  bar[[nc]]\n",
 			"[[search-alert-proposed-title]]  Did you mean:[[nc]]\n",
@@ -100,15 +100,15 @@ func TestRender(t *testing.T) {
 
 var subColorCodesRegex = regexp.MustCompile(`\[\[[a-zA-Z0-9-]+\]\]`)
 
-// subColourCodes provides ad-hoc templating of just ANSI colour codes from our
+// subColorCodes provides ad-hoc templating of just ANSI colour codes from our
 // ansiColors map, using a [[colour-code]] syntax.
-func subColourCodes(in string) string {
+func subColorCodes(in string) string {
 	// We could use text/template here, but at a certain point it feels like
 	// we're just reinventing the template string that's a const in
 	// search_alert.go. This allows us to express the colour codes in the
 	// expected string literals above while hopefully maintaining some meaning
 	// to the tests.
-	return subColourCodesRegex.ReplaceAllStringFunc(in, func(code string) string {
+	return subColorCodesRegex.ReplaceAllStringFunc(in, func(code string) string {
 		esc, ok := ansiColors[strings.Trim(code, "[]")]
 		if !ok {
 			panic(fmt.Sprintf("cannot find colour %s", code))

--- a/cmd/src/search_alert_test.go
+++ b/cmd/src/search_alert_test.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestRender(t *testing.T) {
+	full := &searchResultsAlert{
+		Title:       "foo",
+		Description: "bar",
+		ProposedQueries: []struct {
+			Description string
+			Query       string
+		}{
+			{
+				Description: "quux",
+				Query:       "xyz:abc",
+			},
+			{
+				Description: "baz",
+				Query:       "def:ghi",
+			},
+		},
+	}
+
+	zero := &searchResultsAlert{}
+
+	t.Run("zero value", func(t *testing.T) {
+		content, err := zero.Render()
+		if err != nil {
+			t.Errorf("unexpected error rendering zero alert: %v", err)
+		}
+
+		if content != "" {
+			t.Errorf("unexpected content for zero alert: %s", content)
+		}
+	})
+
+	t.Run("no description", func(t *testing.T) {
+		alert := *full
+		alert.Description = zero.Description
+
+		content, err := alert.Render()
+		if err != nil {
+			t.Errorf("unexpected error rendering alert without description: %v", err)
+		}
+
+		expected := subColourCodes(strings.Join([]string{
+			"[[search-alert-title]]❗foo[[nc]]\n",
+			"[[search-alert-proposed-title]]Did you mean:[[nc]]\n",
+			"[[search-alert-proposed-query]]xyz:abc[[nc]] - [[search-alert-proposed-description]]quux[[nc]]\n",
+			"[[search-alert-proposed-query]]def:ghi[[nc]] - [[search-alert-proposed-description]]baz[[nc]]\n",
+		}, ""))
+		if diff := cmp.Diff(expected, content); diff != "" {
+			t.Errorf("alert without description content incorrect: %s", diff)
+		}
+	})
+
+	t.Run("no proposed queries", func(t *testing.T) {
+		alert := *full
+		alert.ProposedQueries = zero.ProposedQueries
+
+		content, err := alert.Render()
+		if err != nil {
+			t.Errorf("unexpected error rendering alert without queries: %v", err)
+		}
+
+		expected := subColourCodes(strings.Join([]string{
+			"[[search-alert-title]]❗foo[[nc]]\n",
+			"[[search-alert-description]]bar[[nc]]\n",
+		}, ""))
+		if diff := cmp.Diff(expected, content); diff != "" {
+			t.Errorf("alert without queries content incorrect: %s", diff)
+		}
+	})
+
+	t.Run("full", func(t *testing.T) {
+		content, err := full.Render()
+		if err != nil {
+			t.Errorf("unexpected error rendering full alert: %v", err)
+		}
+
+		expected := subColourCodes(strings.Join([]string{
+			"[[search-alert-title]]❗foo[[nc]]\n",
+			"[[search-alert-description]]bar[[nc]]\n",
+			"[[search-alert-proposed-title]]Did you mean:[[nc]]\n",
+			"[[search-alert-proposed-query]]xyz:abc[[nc]] - [[search-alert-proposed-description]]quux[[nc]]\n",
+			"[[search-alert-proposed-query]]def:ghi[[nc]] - [[search-alert-proposed-description]]baz[[nc]]\n",
+		}, ""))
+		if diff := cmp.Diff(expected, content); diff != "" {
+			t.Errorf("full alert content incorrect: %s", diff)
+		}
+	})
+}
+
+var subColourCodesRegex = regexp.MustCompile(`\[\[[a-zA-Z0-9-]+\]\]`)
+
+// subColourCodes provides ad-hoc templating of just ANSI colour codes from our
+// ansiColors map, using a [[colour-code]] syntax.
+func subColourCodes(in string) string {
+	// We could use text/template here, but at a certain point it feels like
+	// we're just reinventing the template string that's a const in
+	// search_alert.go. This allows us to express the colour codes in the
+	// expected string literals above while hopefully maintaining some meaning
+	// to the tests.
+	return subColourCodesRegex.ReplaceAllStringFunc(in, func(code string) string {
+		esc, ok := ansiColors[strings.Trim(code, "[]")]
+		if !ok {
+			panic(fmt.Sprintf("cannot find colour %s", code))
+		}
+		return esc
+	})
+}


### PR DESCRIPTION
We have all this useful information in the web UI that comes back from GraphQL, but isn't exposed in `src`. This PR wires up a common renderer to the `actions exec` and `search` commands to render any alert that comes back in a (hopefully) human readable form.

Here are a couple of examples of it in use:

![image](https://user-images.githubusercontent.com/229984/84093682-c6eccc80-a9af-11ea-916d-2ca1102b911b.png)
![image](https://user-images.githubusercontent.com/229984/84093726-dec45080-a9af-11ea-962e-29421aa29060.png)

If we think this is useful, I'll add a couple of tests to the alert rendering and we can get this merged.