### PR TITLE
Check that $VERSION is in MAJOR.MINOR.PATCH format in release.sh

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -1,4 +1,12 @@
-set -ex
-git tag $VERSION -a -m "release v$VERSION"
-git tag latest -f -a -m "release v$VERSION"
+#!/usr/bin/env bash
+
+set -euf -o pipefail
+
+if ! echo "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+  echo "\$VERSION is not in MAJOR.MINOR.PATCH format"
+  exit 1
+fi
+
+git tag "${VERSION}" -a -m "release v${VERSION}"
+git tag latest -f -a -m "release v${VERSION}"
 git push -f --tags


### PR DESCRIPTION
Lack of this check was the cause for two botched releases in the past
few weeks where we forgot to add the `.0` at the end.