### PR TITLE
Visualize unsupported repos better

### DIFF
--- a/cmd/src/actions_exec.go
+++ b/cmd/src/actions_exec.go
@@ -476,10 +476,7 @@ fragment repositoryFields on Repository {
 	for _, repo := range reposByID {
 		repos = append(repos, repo)
 	}
-	for _, r := range skipped {
-		logger.Infof("Skipping repository %s because we couldn't determine default branch.\n", r)
-	}
-	logger.RepoMatches(len(repos), unsupported)
+	logger.RepoMatches(len(repos), skipped, unsupported)
 
 	if content, err := result.Data.Search.Results.Alert.Render(); err != nil {
 		yellow.Fprint(os.Stderr, err)

--- a/cmd/src/actions_exec.go
+++ b/cmd/src/actions_exec.go
@@ -479,25 +479,7 @@ fragment repositoryFields on Repository {
 	for _, r := range skipped {
 		logger.Infof("Skipping repository %s because we couldn't determine default branch.\n", r)
 	}
-	for _, r := range unsupported {
-		logger.Infof("# Skipping repository %s because it's on a not supported code host.\n", r)
-	}
-	matchesStr := fmt.Sprintf("%d repositories match.", len(repos))
-	unsupportedCount := len(unsupported)
-	if includeUnsupported {
-		if unsupportedCount > 0 {
-			matchesStr += fmt.Sprintf(" (Including %d on unsupported code hosts.)", unsupportedCount)
-		}
-	} else {
-		if unsupportedCount > 0 {
-			matchesStr += " (Some repositories were filtered out because their code host is not supported by campaigns. Use -include-unsupported to generate patches for them anyways.)"
-		}
-	}
-	logger.Infof("%s\n", matchesStr)
-
-	if len(repos) == 0 && !*verbose {
-		yellow.Fprintf(os.Stderr, "WARNING: No repositories matched by scopeQuery\n")
-	}
+	logger.RepoMatches(len(repos), unsupported)
 
 	if content, err := result.Data.Search.Results.Alert.Render(); err != nil {
 		yellow.Fprint(os.Stderr, err)

--- a/internal/campaigns/logger.go
+++ b/internal/campaigns/logger.go
@@ -242,6 +242,38 @@ func (a *ActionLogger) DockerStepDone(repoName string, step int, elapsed time.Du
 	a.write(repoName, yellow, "%s Done. (%s)\n", boldBlack.Sprintf("[Step %d]", step), elapsed)
 }
 
+func (a *ActionLogger) RepoMatches(repoCount int, unsupported []string) {
+	unsupportedCount := len(unsupported)
+	var matchesStr string
+	if repoCount == 1 {
+		matchesStr = fmt.Sprintf("%d repository matches the scopeQuery.", repoCount)
+	} else {
+		var warnStr string
+		if repoCount == 0 {
+			warnStr = "WARNING: "
+		}
+		matchesStr = fmt.Sprintf("%s%d repositories match the scopeQuery.", warnStr, repoCount)
+	}
+	if unsupportedCount > 0 {
+		matchesStr += fmt.Sprintf(" (Including %d on unsupported code hosts.)", unsupportedCount)
+	}
+	if unsupportedCount > 0 {
+		matchesStr += "\n\nThe following repositories were filtered out because they are on a codehost not supported by campaigns (Use -include-unsupported to generate patches for them anyways.):\n"
+		for i, repo := range unsupported {
+			matchesStr += color.HiYellowString("- %s\n", repo)
+			if i == 10 {
+				matchesStr += fmt.Sprintf("and %d more.\n", unsupportedCount-10)
+				break
+			}
+		}
+	}
+	color := yellow
+	if repoCount > 0 {
+		color = boldGreen
+	}
+	a.write("", color, "%s\n\n", matchesStr)
+}
+
 // write writes to the RepoWriter associated with the given repoName and logs the message using the log method.
 func (a *ActionLogger) write(repoName string, c *color.Color, format string, args ...interface{}) {
 	if w, ok := a.RepoWriter(repoName); ok {
@@ -255,7 +287,7 @@ func (a *ActionLogger) log(repoName string, c *color.Color, format string, args 
 	if len(repoName) > 0 {
 		format = fmt.Sprintf("%s -> %s", c.Sprint(repoName), format)
 	}
-	fmt.Fprintf(a.out, format, args...)
+	fmt.Fprintf(a.out, c.Sprintf(format, args...))
 }
 
 type progress struct {

--- a/internal/campaigns/logger.go
+++ b/internal/campaigns/logger.go
@@ -242,7 +242,10 @@ func (a *ActionLogger) DockerStepDone(repoName string, step int, elapsed time.Du
 	a.write(repoName, yellow, "%s Done. (%s)\n", boldBlack.Sprintf("[Step %d]", step), elapsed)
 }
 
-func (a *ActionLogger) RepoMatches(repoCount int, unsupported []string) {
+func (a *ActionLogger) RepoMatches(repoCount int, skipped, unsupported []string) {
+	for _, r := range skipped {
+		a.Infof("Skipping repository %s because we couldn't determine default branch.\n", r)
+	}
 	unsupportedCount := len(unsupported)
 	var matchesStr string
 	if repoCount == 1 {
@@ -255,10 +258,7 @@ func (a *ActionLogger) RepoMatches(repoCount int, unsupported []string) {
 		matchesStr = fmt.Sprintf("%s%d repositories match the scopeQuery.", warnStr, repoCount)
 	}
 	if unsupportedCount > 0 {
-		matchesStr += fmt.Sprintf(" (Including %d on unsupported code hosts.)", unsupportedCount)
-	}
-	if unsupportedCount > 0 {
-		matchesStr += "\n\nThe following repositories were filtered out because they are on a codehost not supported by campaigns (Use -include-unsupported to generate patches for them anyways.):\n"
+		matchesStr += fmt.Sprintf("\n\n%d repositories were filtered out because they are on a codehost not supported by campaigns. (use -include-unsupported to generate patches for them anyway):\n", unsupportedCount)
 		for i, repo := range unsupported {
 			matchesStr += color.HiYellowString("- %s\n", repo)
 			if i == 10 {


### PR DESCRIPTION
In order to make more transparent why some repos are excluded, we now visualize better which repos are excluded because they aren't supported, and also display the hint on how to use them in non-verbose mode. In addition, up to 10 repo names will appear in the UI to get a better sense which are the unsupported ones.

![image](https://user-images.githubusercontent.com/19534377/86149845-d23d9e80-bafc-11ea-9e37-be1ead7363a9.png)
