### PR TITLE
Use Go 1.14 on AppVeyor

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -32,3 +32,11 @@ For example, suppose we have the the recommended versions.
 If a new feature is added to a new `3.91.6` release of src-cli and this change requires only features available in Sourcegraph `3.99`, then this feature should also be present in a new `3.85.8` release of src-cli. Because a Sourcegraph instance will automatically select the highest patch version, all non-breaking changes should increment only the patch version. 
 
 Note that if instead the recommended src-cli version for Sourcegraph `3.99` was `3.90.4` in the example above, there is no additional step required, and the new patch version of src-cli will be available to both Sourcegraph versions.
+
+## AppVeyor builds
+
+We use AppVeyor to test `src-cli` on Windows.
+
+Configure the AppVeyor builds by editing the `appveyor.yml` file and logging in to AppVeyor and changing the settings there.
+
+Login with your GitHub account, switch to the `sourcegraph` account and change the settings here: https://ci.appveyor.com/project/sourcegraph/src-cli/settings/environment

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,13 +1,24 @@
 version: "{build}"
 clone_folder: c:\gopath\src\github.com\sourcegraph\src-cli
+
 environment:
+  GOROOT: 'c:\go'
   GOPATH: c:\gopath
+  GOVERSION: 1.14
+  PATH: '%GOPATH%\bin;%GOROOT%\bin;%PATH%'
+  GO111MODULE: 'on'
+
 install:
-  - set PATH=%GOPATH%\bin;c:\go\bin;%PATH%
-  - echo %PATH%
-  - echo %GOPATH%
+  # Install the specific Go version.
+  - rmdir c:\go /s /q
+  - appveyor DownloadFile https://storage.googleapis.com/golang/go%GOVERSION%.windows-amd64.msi
+  - msiexec /i go%GOVERSION%.windows-amd64.msi /q
   - go version
   - go env
-  - go get -t -v ./...
+
 build_script:
-  - go test -v ./...
+  - go version
+  - go get -v -t ./...
+
+test_script:
+  - go test ./...


### PR DESCRIPTION
This fixes the Appveyor part of https://github.com/sourcegraph/src-cli/issues/237 - Travis CI also needs to be updated.

After struggling to get this running with Go 1.14 I simply searched sourcegraph.com for `appveyor.yml` files 😎 

Turns out `golang/dep` has the [only configuration](https://sourcegraph.com/github.com/golang/dep@87f309484f0da00d4559dbe0ae5698f589f9a0d0/-/blob/appveyor.yml) that works.

Even switching worker images to the newest version didn't make Go 1.14 available — changing `GOROOT`, `PATH` etc. didn't help.