### PR TITLE
Fix progress bar when previously printed text has color

### DIFF
--- a/internal/campaigns/logger.go
+++ b/internal/campaigns/logger.go
@@ -352,7 +352,7 @@ func (w *progressWriter) Write(data []byte) (int, error) {
 		return w.w.Write(data)
 	}
 
-	if !bytes.HasSuffix(data, []byte("\n")) {
+	if !bytes.HasSuffix(data, []byte("\n")) && !bytes.HasSuffix(data, []byte("\n\x1b[0m")) {
 		w.shouldClear = false
 		return w.w.Write(data)
 	}

--- a/internal/campaigns/logger.go
+++ b/internal/campaigns/logger.go
@@ -374,10 +374,10 @@ func (w *progressWriter) Write(data []byte) (int, error) {
 		bar += ">"
 	}
 	bar += strings.Repeat(" ", maxLength-len(bar))
-	progessText := fmt.Sprintf("[%s] Steps: %d/%d (%s, %s)", bar, w.p.StepsComplete(), w.p.TotalSteps(), boldRed.Sprintf("%d failed", w.p.TotalStepsFailed()), hiGreen.Sprintf("%d patches", w.p.PatchCount()))
-	fmt.Fprint(w.w, progessText)
+	progressText := fmt.Sprintf("[%s] Steps: %d/%d (%s, %s)", bar, w.p.StepsComplete(), w.p.TotalSteps(), boldRed.Sprintf("%d failed", w.p.TotalStepsFailed()), hiGreen.Sprintf("%d patches", w.p.PatchCount()))
+	fmt.Fprint(w.w, progressText)
 	w.shouldClear = true
-	w.progressLogLength = len(progessText)
+	w.progressLogLength = len(progressText)
 	return n, err
 }
 

--- a/internal/campaigns/logger.go
+++ b/internal/campaigns/logger.go
@@ -31,8 +31,6 @@ type ActionLogger struct {
 	verbose  bool
 	keepLogs bool
 
-	highlight func(a ...interface{}) string
-
 	progress *progress
 	out      io.WriteCloser
 
@@ -50,10 +48,9 @@ func NewActionLogger(verbose, keepLogs bool) *ActionLogger {
 	progress := new(progress)
 
 	return &ActionLogger{
-		verbose:   verbose,
-		keepLogs:  keepLogs,
-		highlight: color.New(color.Bold, color.FgGreen).SprintFunc(),
-		progress:  progress,
+		verbose:  verbose,
+		keepLogs: keepLogs,
+		progress: progress,
 		out: &progressWriter{
 			p: progress,
 			w: os.Stderr,


### PR DESCRIPTION
This change in a previous PR broke the display of the progress bar:

https://github.com/sourcegraph/src-cli/pull/236/files#diff-f88fc84c78d26d5dc5fde4a5223bc866L258

Why did it break? Because the "display progress bar?"-check checked whether the just-printed data ended in a newline or not. That worked until the just mentioned change, after which every line was wrapped in "set color" and "reset color" escape codes. They wouldn't end in `\n` but in `\n\x1b[0m`.

The new check fixes the progress bar.

The other two commits fix a typo and remove an unused dependency.