### PR TITLE
servegit: use git protocol v2

### DIFF
--- a/internal/servegit/serve.go
+++ b/internal/servegit/serve.go
@@ -1,11 +1,9 @@
 package servegit
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"html/template"
-	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
@@ -14,7 +12,6 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
-	"sync/atomic"
 
 	"github.com/pkg/errors"
 )
@@ -24,10 +21,6 @@ type Serve struct {
 	Root  string
 	Info  *log.Logger
 	Debug *log.Logger
-
-	// updatingServerInfo is used to ensure we only have 1 goroutine running
-	// git update-server-info.
-	updatingServerInfo uint64
 }
 
 func (s *Serve) Start() error {
@@ -88,7 +81,7 @@ func (s *Serve) handler() http.Handler {
 	mux.HandleFunc("/v1/list-repos", func(w http.ResponseWriter, r *http.Request) {
 		var repos []Repo
 		var reposRootIsRepo bool
-		for _, name := range s.configureRepos() {
+		for _, name := range s.repos() {
 			if name == "." {
 				reposRootIsRepo = true
 			}
@@ -145,17 +138,13 @@ func (s *Serve) handler() http.Handler {
 	})))
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if !strings.Contains(r.URL.Path, "/.git/objects/") { // exclude noisy path
-			s.Info.Printf("%s %s", r.Method, r.URL.Path)
-		}
 		mux.ServeHTTP(w, r)
 	})
 }
 
-// configureRepos finds all .git directories and configures them to be served.
-// It returns a slice of all the git directories it finds. The paths are
+// repos returns a slice of all the git directories it finds. The paths are
 // relative to root.
-func (s *Serve) configureRepos() []string {
+func (s *Serve) repos() []string {
 	var gitDirs []string
 
 	err := filepath.Walk(s.Root, func(path string, fi os.FileInfo, fileErr error) error {
@@ -180,11 +169,6 @@ func (s *Serve) configureRepos() []string {
 		gitdir := filepath.Join(path, ".git")
 		if fi, err := os.Stat(gitdir); err != nil || !fi.IsDir() {
 			s.Debug.Printf("not a repository root: %s", path)
-			return nil
-		}
-
-		if err := configurePostUpdateHook(s.Info, gitdir); err != nil {
-			s.Info.Printf("failed configuring repo at %s: %v", gitdir, err)
 			return nil
 		}
 
@@ -217,63 +201,7 @@ func (s *Serve) configureRepos() []string {
 		panic(err)
 	}
 
-	go s.allUpdateServerInfo(gitDirs)
-
 	return gitDirs
-}
-
-// allUpdateServerInfo will run updateServerInfo on each gitDirs. To prevent
-// too many of these processes running, it will only run one at a time.
-func (s *Serve) allUpdateServerInfo(gitDirs []string) {
-	if !atomic.CompareAndSwapUint64(&s.updatingServerInfo, 0, 1) {
-		return
-	}
-
-	for _, dir := range gitDirs {
-		gitdir := filepath.Join(s.Root, dir)
-		if err := updateServerInfo(gitdir); err != nil {
-			s.Info.Printf("git update-server-info failed for %s: %v", gitdir, err)
-		}
-	}
-
-	atomic.StoreUint64(&s.updatingServerInfo, 0)
-}
-
-var postUpdateHook = []byte("#!/bin/sh\nexec git update-server-info\n")
-
-// configureOneRepos tweaks a .git repo such that it can be git cloned.
-// See https://theartofmachinery.com/2016/07/02/git_over_http.html
-// for background.
-func configurePostUpdateHook(logger *log.Logger, gitDir string) error {
-	postUpdatePath := filepath.Join(gitDir, "hooks", "post-update")
-	if b, _ := ioutil.ReadFile(postUpdatePath); bytes.Equal(b, postUpdateHook) {
-		return nil
-	}
-
-	logger.Printf("configuring git post-update hook for %s", gitDir)
-
-	if err := updateServerInfo(gitDir); err != nil {
-		return err
-	}
-
-	if err := os.MkdirAll(filepath.Dir(postUpdatePath), 0755); err != nil {
-		return errors.Wrap(err, "create git hooks dir")
-	}
-	if err := ioutil.WriteFile(postUpdatePath, postUpdateHook, 0755); err != nil {
-		return errors.Wrap(err, "setting post-update hook")
-	}
-
-	return nil
-}
-
-func updateServerInfo(gitDir string) error {
-	c := exec.Command("git", "update-server-info")
-	c.Dir = gitDir
-	out, err := c.CombinedOutput()
-	if err != nil {
-		return errors.Wrapf(err, "updating server info: %s", out)
-	}
-	return nil
 }
 
 func explainAddr(addr string) string {

--- a/internal/servegit/serve_test.go
+++ b/internal/servegit/serve_test.go
@@ -43,8 +43,6 @@ func TestReposHandler(t *testing.T) {
 				Debug: discardLogger,
 				Addr:  testAddress,
 				Root:  root,
-
-				updatingServerInfo: 2, // disables background updates
 			}).handler()
 
 			var want []Repo
@@ -73,8 +71,6 @@ func TestReposHandler(t *testing.T) {
 				Debug: discardLogger,
 				Addr:  testAddress,
 				Root:  root,
-
-				updatingServerInfo: 2, // disables background updates
 			}).handler()
 
 			// project-root is served from /repos, etc
@@ -183,9 +179,7 @@ func TestIgnoreGitSubmodules(t *testing.T) {
 		Info:  testLogger(t),
 		Debug: discardLogger,
 		Root:  root,
-
-		updatingServerInfo: 2, // disables background updates
-	}).configureRepos()
+	}).repos()
 	if len(repos) != 0 {
 		t.Fatalf("expected no repos, got %v", repos)
 	}

--- a/internal/servegit/service.go
+++ b/internal/servegit/service.go
@@ -1,0 +1,109 @@
+package servegit
+
+import (
+	"log"
+	"net/http"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var uploadPackArgs = []string{
+	// Partial clones/fetches
+	"-c", "uploadpack.allowFilter=true",
+
+	// Can fetch any object. Used in case of race between a resolve ref and a
+	// fetch of a commit. Safe to do, since this is only used internally.
+	"-c", "uploadpack.allowAnySHA1InWant=true",
+
+	"upload-pack",
+
+	"--stateless-rpc",
+}
+
+// gitServiceHandler is a smart Git HTTP transfer protocol as documented at
+// https://www.git-scm.com/docs/http-protocol.
+//
+// This allows users to clone any git repo. We only support the smart
+// protocol. We aim to support modern git features such as protocol v2 to
+// minimize traffic.
+type gitServiceHandler struct {
+	// Dir is a funcion which takes a repository name and returns an absolute
+	// path to the filepath for it.
+	Dir   func(string) string
+	Debug *log.Logger
+}
+
+func (s *gitServiceHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Only support clones and fetches (git upload-pack). /info/refs sets the
+	// service field.
+	if svcQ := r.URL.Query().Get("service"); svcQ != "" && svcQ != "git-upload-pack" {
+		http.Error(w, "only support service git-upload-pack", http.StatusBadRequest)
+		return
+	}
+
+	var repo, svc string
+	for _, suffix := range []string{"/info/refs", "/git-upload-pack"} {
+		if strings.HasSuffix(r.URL.Path, suffix) {
+			svc = suffix
+			repo = strings.TrimSuffix(r.URL.Path, suffix)
+			repo = strings.TrimPrefix(repo, "/")
+			break
+		}
+	}
+
+	dir := s.Dir(repo)
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		http.Error(w, "repository not found", http.StatusNotFound)
+		return
+	} else if err != nil {
+		http.Error(w, "failed to stat repo: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	start := time.Now()
+	defer func() {
+		s.Debug.Printf("git service svc=%s protocol=%s repo=%s duration=%v", svc, r.Header.Get("Git-Protocol"), repo, time.Since(start))
+	}()
+
+	args := append([]string{}, uploadPackArgs...)
+	switch svc {
+	case "/info/refs":
+		w.Header().Set("Content-Type", "application/x-git-upload-pack-advertisement")
+		_, _ = w.Write(packetWrite("# service=git-upload-pack\n"))
+		_, _ = w.Write([]byte("0000"))
+		args = append(args, "--advertise-refs")
+	case "/git-upload-pack":
+		w.Header().Set("Content-Type", "application/x-git-upload-pack-result")
+	default:
+		http.Error(w, "unexpected subpath (want /info/refs or /git-upload-pack) ", http.StatusInternalServerError)
+		return
+	}
+	args = append(args, dir)
+
+	body := r.Body
+	defer body.Close()
+
+	env := os.Environ()
+	if protocol := r.Header.Get("Git-Protocol"); protocol != "" {
+		env = append(env, "GIT_PROTOCOL="+protocol)
+	}
+
+	cmd := exec.CommandContext(r.Context(), "git", args...)
+	cmd.Env = env
+	cmd.Stdout = w
+	cmd.Stdin = body
+	if err := cmd.Run(); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+func packetWrite(str string) []byte {
+	s := strconv.FormatInt(int64(len(str)+4), 16)
+	if len(s)%4 != 0 {
+		s = strings.Repeat("0", 4-len(s)%4) + s
+	}
+	return []byte(s + str)
+}

--- a/internal/servegit/service_test.go
+++ b/internal/servegit/service_test.go
@@ -1,0 +1,108 @@
+package servegit
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGitServiceHandler(t *testing.T) {
+	root := tmpDir(t)
+	repo := filepath.Join(root, "testrepo")
+
+	// Setup a repo with a commit so we can add bad refs
+	runCmd(t, root, "git", "init", repo)
+	runCmd(t, repo, "sh", "-c", "echo hello world > hello.txt")
+	runCmd(t, repo, "git", "add", "hello.txt")
+	runCmd(t, repo, "git", "commit", "-m", "hello")
+
+	ts := httptest.NewServer(&gitServiceHandler{
+		Dir: func(s string) string {
+			return filepath.Join(root, s, ".git")
+		},
+		Debug: discardLogger,
+	})
+	defer ts.Close()
+
+	t.Run("404", func(t *testing.T) {
+		c := exec.Command("git", "clone", ts.URL+"/doesnotexist")
+		c.Dir = tmpDir(t)
+		b, err := c.CombinedOutput()
+		if !bytes.Contains(b, []byte("repository not found")) {
+			t.Fatal("expected clone to fail with repository not found", string(b), err)
+		}
+	})
+
+	cloneURL := ts.URL + "/testrepo"
+
+	t.Run("clonev1", func(t *testing.T) {
+		runCmd(t, tmpDir(t), "git", "-c", "protocol.version=1", "clone", cloneURL)
+	})
+
+	cloneV2 := []struct {
+		Name string
+		Args []string
+	}{{
+		"clonev2",
+		[]string{},
+	}, {
+		"shallow",
+		[]string{"--depth=1"},
+	}}
+
+	for _, tc := range cloneV2 {
+		t.Run(tc.Name, func(t *testing.T) {
+			args := []string{"-c", "protocol.version=2", "clone"}
+			args = append(args, tc.Args...)
+			args = append(args, cloneURL)
+
+			c := exec.Command("git", args...)
+			c.Dir = tmpDir(t)
+			c.Env = []string{
+				"GIT_TRACE_PACKET=1",
+			}
+			b, err := c.CombinedOutput()
+			if err != nil {
+				t.Fatalf("command failed: %s\nOutput: %s", err, b)
+			}
+
+			// This is the same test done by git's tests for checking if the
+			// server is using protocol v2.
+			if !bytes.Contains(b, []byte("git< version 2")) {
+				t.Fatalf("protocol v2 not used by server. Output:\n%s", b)
+			}
+		})
+	}
+}
+
+func runCmd(t *testing.T, dir string, cmd string, arg ...string) string {
+	t.Helper()
+	c := exec.Command(cmd, arg...)
+	c.Dir = dir
+	c.Env = []string{
+		"GIT_COMMITTER_NAME=a",
+		"GIT_COMMITTER_EMAIL=a@a.com",
+		"GIT_AUTHOR_NAME=a",
+		"GIT_AUTHOR_EMAIL=a@a.com",
+	}
+	b, err := c.CombinedOutput()
+	if err != nil {
+		t.Fatalf("%s %s failed: %s\nOutput: %s", cmd, strings.Join(arg, " "), err, b)
+	}
+	return string(b)
+}
+
+func tmpDir(t *testing.T) string {
+	t.Helper()
+	dir, err := ioutil.TempDir("", filepath.Base(t.Name()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	return dir
+}


### PR DESCRIPTION
This commit copy pastes the upload pack service we use in gitserver from
the Sourcegraph repo at commit d0d94c90. It is mostly copy paste, but we
remove prometheus metrics and "--strict" since we allow non-bare repos.

Previously we supported only git protocol v0. This is regarded as the
"dumb" protocol. We ran into issues of it being slow to update (requires
running git update-server-info). It also requires write access to the
files.

Git protocol v2 allows more efficient fetching and extra cool features
we may start to rely on.

Part of https://github.com/sourcegraph/sourcegraph/issues/12363
Part of https://github.com/sourcegraph/sourcegraph/issues/11707