### PR TITLE
servegit: list flag to list found repositories

### DIFF
--- a/internal/servegit/serve_test.go
+++ b/internal/servegit/serve_test.go
@@ -175,11 +175,14 @@ func TestIgnoreGitSubmodules(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	repos := (&Serve{
+	repos, err := (&Serve{
 		Info:  testLogger(t),
 		Debug: discardLogger,
 		Root:  root,
-	}).repos()
+	}).Repos()
+	if err != nil {
+		t.Fatal(err)
+	}
 	if len(repos) != 0 {
 		t.Fatalf("expected no repos, got %v", repos)
 	}


### PR DESCRIPTION
This is useful functionality when setting up serve-git to understand
what it does.

Part of https://github.com/sourcegraph/sourcegraph/issues/12363