### PR TITLE
api: refactor the low level cmd/src GraphQL functionality into a new api package

### DIFF
--- a/cmd/src/actions_scope_query.go
+++ b/cmd/src/actions_scope_query.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
+	"github.com/sourcegraph/src-cli/internal/api"
 	"github.com/sourcegraph/src-cli/internal/campaigns"
 )
 
@@ -35,6 +36,7 @@ Examples:
 	var (
 		fileFlag               = flagSet.String("f", "-", "The action file. If not given or '-' standard input is used. (Required)")
 		includeUnsupportedFlag = flagSet.Bool("include-unsupported", false, "When specified, also repos from unsupported codehosts are processed. Those can be created once the integration is done.")
+		apiFlags               = api.NewFlags(flagSet)
 	)
 
 	handler := func(args []string) error {
@@ -71,6 +73,7 @@ Examples:
 		}
 
 		ctx := context.Background()
+		client := cfg.apiClient(apiFlags, flagSet.Output())
 
 		if *verbose {
 			log.Printf("# scopeQuery in action definition: %s\n", action.ScopeQuery)
@@ -81,7 +84,7 @@ Examples:
 		}
 
 		logger := campaigns.NewActionLogger(*verbose, false)
-		repos, err := actionRepos(ctx, action.ScopeQuery, *includeUnsupportedFlag, logger)
+		repos, err := actionRepos(ctx, client, action.ScopeQuery, *includeUnsupportedFlag, logger)
 		if err != nil {
 			return err
 		}

--- a/cmd/src/api.go
+++ b/cmd/src/api.go
@@ -1,19 +1,17 @@
 package main
 
 import (
-	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
 	"io/ioutil"
-	"log"
-	"net/http"
 	"os"
 	"strings"
 
-	"github.com/kballard/go-shellquote"
 	"github.com/mattn/go-isatty"
+	"github.com/sourcegraph/src-cli/internal/api"
 )
 
 func init() {
@@ -53,7 +51,7 @@ Examples:
 	var (
 		queryFlag = flagSet.String("query", "", "GraphQL query to execute, e.g. 'query { currentUser { username } }' (stdin otherwise)")
 		varsFlag  = flagSet.String("vars", "", `GraphQL query variables to include as JSON string, e.g. '{"var": "val", "var2": "val2"}'`)
-		apiFlags  = newAPIFlags(flagSet)
+		apiFlags  = api.NewFlags(flagSet)
 	)
 
 	handler := func(args []string) error {
@@ -95,22 +93,17 @@ Examples:
 
 		// Perform the request.
 		var result interface{}
-		return (&apiRequest{
-			query:  query,
-			vars:   vars,
-			result: &result,
-			done: func() error {
-				// Print the formatted JSON.
-				f, err := marshalIndent(result)
-				if err != nil {
-					return err
-				}
-				fmt.Println(string(f))
-				return nil
-			},
-			flags:            apiFlags,
-			dontUnpackErrors: true,
-		}).do()
+		if ok, err := cfg.apiClient(apiFlags, flagSet.Output()).NewRequest(query, vars).DoRaw(context.Background(), &result); err != nil || !ok {
+			return err
+		}
+
+		// Print the formatted JSON.
+		f, err := marshalIndent(result)
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(f))
+		return nil
 	}
 
 	// Register the command.
@@ -119,218 +112,4 @@ Examples:
 		handler:   handler,
 		usageFunc: usageFunc,
 	})
-}
-
-// gqlURL returns the URL to the GraphQL endpoint for the given Sourcegraph
-// instance.
-func gqlURL(endpoint string) string {
-	return endpoint + "/.api/graphql"
-}
-
-// curlCmd returns the curl command to perform the given GraphQL query. Bash-only.
-func curlCmd(endpoint, accessToken string, additionalHeaders map[string]string, query string, vars map[string]interface{}) (string, error) {
-	data, err := json.Marshal(map[string]interface{}{
-		"query":     query,
-		"variables": vars,
-	})
-	if err != nil {
-		return "", err
-	}
-
-	s := "curl \\\n"
-	if accessToken != "" {
-		s += fmt.Sprintf("   %s \\\n", shellquote.Join("-H", "Authorization: token "+accessToken))
-	}
-	for k, v := range additionalHeaders {
-		s += fmt.Sprintf("   %s \\\n", shellquote.Join("-H", k+": "+v))
-	}
-	s += fmt.Sprintf("   %s \\\n", shellquote.Join("-d", string(data)))
-	s += fmt.Sprintf("   %s", shellquote.Join(gqlURL(endpoint)))
-	return s, nil
-}
-
-// apiRequest represents a GraphQL API request.
-type apiRequest struct {
-	query  string                 // the GraphQL query
-	vars   map[string]interface{} // the GraphQL query variables
-	result interface{}            // where to store the result
-	done   func() error           // a function to invoke for handling the response. If nil, flags like -get-curl are ignored.
-	flags  *apiFlags              // the API flags previously created via newAPIFlags
-
-	// If true, errors will not be unpacked.
-	//
-	// Consider a GraphQL response like:
-	//
-	// 	{"data": {...}, "errors": ["something went really wrong"]}
-	//
-	// 'error unpacking' refers to how we will check if there are any `errors`
-	// present in the response (if there are, we will report them on the command
-	// line separately AND exit with a proper error code), and if there are no
-	// errors `result` will contain only the `{...}` object.
-	//
-	// When true, the entire response object is stored in `result` -- as if you
-	// ran the curl query yourself.
-	dontUnpackErrors bool
-}
-
-// do performs the API request. If a.flags specify something like -get-curl
-// then it is handled immediately and a.done is not invoked. Otherwise, once
-// the request is finished a.done is invoked to handle the response (which is
-// stored in a.result).
-func (a *apiRequest) do() error {
-	if a.done != nil {
-		// Handle the get-curl flag now.
-		if *a.flags.getCurl {
-			curl, err := curlCmd(cfg.Endpoint, cfg.AccessToken, cfg.AdditionalHeaders, a.query, a.vars)
-			if err != nil {
-				return err
-			}
-			fmt.Println(curl)
-			return nil
-		}
-	} else {
-		a.done = func() error { return nil }
-	}
-
-	// Create the JSON object.
-	var buf bytes.Buffer
-	if err := json.NewEncoder(&buf).Encode(map[string]interface{}{
-		"query":     a.query,
-		"variables": a.vars,
-	}); err != nil {
-		return err
-	}
-
-	// Create the HTTP request.
-	req, err := http.NewRequest("POST", gqlURL(cfg.Endpoint), nil)
-	if err != nil {
-		return err
-	}
-	if cfg.AccessToken != "" {
-		req.Header.Set("Authorization", "token "+cfg.AccessToken)
-	}
-	if *a.flags.trace {
-		req.Header.Set("X-Sourcegraph-Should-Trace", "true")
-	}
-	for k, v := range cfg.AdditionalHeaders {
-		req.Header.Set(k, v)
-	}
-	req.Body = ioutil.NopCloser(&buf)
-
-	// Perform the request.
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	// Check trace header before we potentially early exit
-	if *a.flags.trace {
-		log.Printf("x-trace: %s", resp.Header.Get("x-trace"))
-	}
-
-	// Our request may have failed before the reaching GraphQL endpoint, so
-	// confirm the status code. You can test this easily with e.g. an invalid
-	// endpoint like -endpoint=https://google.com
-	if resp.StatusCode != http.StatusOK {
-		if resp.StatusCode == http.StatusUnauthorized && isatty.IsCygwinTerminal(os.Stdout.Fd()) {
-			fmt.Println("You may need to specify or update your access token to use this endpoint.")
-			fmt.Println("See https://github.com/sourcegraph/src-cli#authentication")
-			fmt.Println("")
-		}
-		body, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			return err
-		}
-		return fmt.Errorf("error: %s\n\n%s", resp.Status, body)
-	}
-
-	// Decode the response.
-	var result struct {
-		Data   interface{} `json:"data,omitempty"`
-		Errors interface{} `json:"errors,omitempty"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return err
-	}
-
-	// Handle the case of not unpacking errors.
-	if a.dontUnpackErrors {
-		if err := jsonCopy(a.result, result); err != nil {
-			return err
-		}
-		if err := a.done(); err != nil {
-			return err
-		}
-		if result.Errors != nil {
-			return &exitCodeError{error: nil, exitCode: graphqlErrorsExitCode}
-		}
-		return nil
-	}
-
-	// Handle the case of unpacking errors.
-	if result.Errors != nil {
-		return &exitCodeError{
-			error:    fmt.Errorf("GraphQL errors:\n%s", &graphqlError{result.Errors}),
-			exitCode: graphqlErrorsExitCode,
-		}
-	}
-	if err := jsonCopy(a.result, result.Data); err != nil {
-		return err
-	}
-	return a.done()
-}
-
-// apiFlags represents generic API flags available in all commands that perform
-// API requests. e.g. the ability to turn any CLI command into a curl command.
-type apiFlags struct {
-	getCurl *bool
-	trace   *bool
-}
-
-// newAPIFlags creates the API flags. It should be invoked once at flag setup
-// time.
-func newAPIFlags(flagSet *flag.FlagSet) *apiFlags {
-	return &apiFlags{
-		getCurl: flagSet.Bool("get-curl", false, "Print the curl command for executing this query and exit (WARNING: includes printing your access token!)"),
-		trace:   flagSet.Bool("trace", false, "Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing"),
-	}
-}
-
-// jsonCopy is a cheaty method of copying an already-decoded JSON (src)
-// response into its destination (dst) that would usually be passed to e.g.
-// json.Unmarshal.
-//
-// We could do this with reflection, obviously, but it would be much more
-// complex and JSON re-marshaling should be cheap enough anyway. Can improve in
-// the future.
-func jsonCopy(dst, src interface{}) error {
-	data, err := json.Marshal(src)
-	if err != nil {
-		return err
-	}
-	return json.NewDecoder(bytes.NewReader(data)).Decode(dst)
-}
-
-type graphqlError struct {
-	Errors interface{}
-}
-
-func (g *graphqlError) Error() string {
-	j, _ := marshalIndent(g.Errors)
-	return string(j)
-}
-
-func nullInt(n int) *int {
-	if n == -1 {
-		return nil
-	}
-	return &n
-}
-
-func nullString(s string) *string {
-	if s == "" {
-		return nil
-	}
-	return &s
 }

--- a/cmd/src/format.go
+++ b/cmd/src/format.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/url"
@@ -106,7 +107,7 @@ func parseTemplate(text string) (*template.Template, error) {
 
 			// Hacky to do this in a formatting helper, but better than
 			// globally querying the version and only using it here for now.
-			version, err := getSourcegraphVersion()
+			version, err := getSourcegraphVersion(context.Background(), cfg.apiClient(nil, os.Stdout))
 			if err != nil {
 				// We ignore the error and return what we have
 				return buf.String()

--- a/cmd/src/main.go
+++ b/cmd/src/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"flag"
+	"io"
 	"io/ioutil"
 	"log"
 	"os"
@@ -11,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	"github.com/sourcegraph/src-cli/internal/api"
 )
 
 const usageText = `src is a tool that provides access to Sourcegraph instances.
@@ -74,6 +76,17 @@ type config struct {
 	Endpoint          string            `json:"endpoint"`
 	AccessToken       string            `json:"accessToken"`
 	AdditionalHeaders map[string]string `json:"additionalHeaders"`
+}
+
+// apiClient returns an api.Client built from the configuration.
+func (c *config) apiClient(flags *api.Flags, out io.Writer) api.Client {
+	return api.NewClient(api.ClientOpts{
+		Endpoint:          c.Endpoint,
+		AccessToken:       c.AccessToken,
+		AdditionalHeaders: c.AdditionalHeaders,
+		Flags:             flags,
+		Out:               out,
+	})
 }
 
 // readConfig reads the config file from the given path.

--- a/cmd/src/repos_delete.go
+++ b/cmd/src/repos_delete.go
@@ -1,16 +1,18 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
+	"github.com/sourcegraph/src-cli/internal/api"
 )
 
 func init() {
 	flagSet := flag.NewFlagSet("delete", flag.ExitOnError)
-	apiFlags := newAPIFlags(flagSet)
+	apiFlags := api.NewFlags(flagSet)
 
 	printUsage := func() {
 		fmt.Fprintf(flag.CommandLine.Output(), "Usage of 'src repos %s'\n", flagSet.Name())
@@ -27,8 +29,8 @@ Examples:
 		fmt.Fprint(flag.CommandLine.Output(), examples)
 	}
 
-	deleteRepository := func(repoName string) error {
-		repoID, err := fetchRepositoryID(repoName)
+	deleteRepository := func(ctx context.Context, client api.Client, repoName string) error {
+		repoID, err := fetchRepositoryID(ctx, client, repoName)
 		if err != nil {
 			return err
 		}
@@ -39,25 +41,25 @@ Examples:
 			}
 		}`
 		var result struct{}
-		return (&apiRequest{
-			query: query,
-			vars: map[string]interface{}{
-				"repoID": repoID,
-			},
-			result: &result,
-			done: func() error {
-				fmt.Fprintf(flag.CommandLine.Output(), "Repository %q deleted\n", repoName)
-				return nil
-			},
-			flags: apiFlags,
-		}).do()
+		if ok, err := client.NewRequest(query, map[string]interface{}{
+			"repoID": repoID,
+		}).Do(ctx, &result); err != nil || !ok {
+			return err
+		}
+
+		fmt.Fprintf(flag.CommandLine.Output(), "Repository %q deleted\n", repoName)
+		return nil
 	}
 
 	deleteRepositories := func(args []string) error {
 		flagSet.Parse(args)
+
+		ctx := context.Background()
+		client := cfg.apiClient(apiFlags, flagSet.Output())
+
 		var errs *multierror.Error
 		for _, repoName := range flagSet.Args() {
-			err := deleteRepository(repoName)
+			err := deleteRepository(ctx, client, repoName)
 			if err != nil {
 				err = errors.Wrapf(err, "Failed to delete repository %q", repoName)
 				errs = multierror.Append(errs, err)

--- a/cmd/src/users_create.go
+++ b/cmd/src/users_create.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
+
+	"github.com/sourcegraph/src-cli/internal/api"
 )
 
 func init() {
@@ -25,11 +28,13 @@ Examples:
 		usernameFlag         = flagSet.String("username", "", `The new user's username. (required)`)
 		emailFlag            = flagSet.String("email", "", `The new user's email address. (required)`)
 		resetPasswordURLFlag = flagSet.Bool("reset-password-url", false, `Print the reset password URL to manually send to the new user.`)
-		apiFlags             = newAPIFlags(flagSet)
+		apiFlags             = api.NewFlags(flagSet)
 	)
 
 	handler := func(args []string) error {
 		flagSet.Parse(args)
+
+		client := cfg.apiClient(apiFlags, flagSet.Output())
 
 		query := `mutation CreateUser(
   $username: String!,
@@ -48,23 +53,19 @@ Examples:
 				ResetPasswordURL string
 			}
 		}
-		return (&apiRequest{
-			query: query,
-			vars: map[string]interface{}{
-				"username": *usernameFlag,
-				"email":    *emailFlag,
-			},
-			result: &result,
-			done: func() error {
-				fmt.Printf("User %q created.\n", *usernameFlag)
-				if *resetPasswordURLFlag && result.CreateUser.ResetPasswordURL != "" {
-					fmt.Println()
-					fmt.Printf("\tReset pasword URL: %s\n", result.CreateUser.ResetPasswordURL)
-				}
-				return nil
-			},
-			flags: apiFlags,
-		}).do()
+		if ok, err := client.NewRequest(query, map[string]interface{}{
+			"username": *usernameFlag,
+			"email":    *emailFlag,
+		}).Do(context.Background(), &result); err != nil || !ok {
+			return err
+		}
+
+		fmt.Printf("User %q created.\n", *usernameFlag)
+		if *resetPasswordURLFlag && result.CreateUser.ResetPasswordURL != "" {
+			fmt.Println()
+			fmt.Printf("\tReset pasword URL: %s\n", result.CreateUser.ResetPasswordURL)
+		}
+		return nil
 	}
 
 	// Register the command.

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -1,0 +1,230 @@
+// Package api provides a basic client library for the Sourcegraph GraphQL API.
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/kballard/go-shellquote"
+	"github.com/mattn/go-isatty"
+	"github.com/pkg/errors"
+)
+
+// Client instances provide methods to create API requests.
+type Client interface {
+	// NewQuery is a convenience method to create a GraphQL request without
+	// variables.
+	NewQuery(query string) Request
+
+	// NewRequest creates a GraphQL request.
+	NewRequest(query string, vars map[string]interface{}) Request
+}
+
+// Request instances represent GraphQL requests.
+type Request interface {
+	// Do actions the request. Normally, this means that the request is
+	// transmitted and the response is unmarshalled into result.
+	//
+	// If no data was available to be unmarshalled — for example, due to the
+	// -get-curl flag being set — then ok will return false.
+	Do(ctx context.Context, result interface{}) (ok bool, err error)
+
+	// DoRaw has the same behaviour as Do, with one exception: the result will
+	// not be unwrapped, and will include the GraphQL errors. Therefore the
+	// structure that is provided as the result should have top level Data and
+	// Errors keys for the GraphQL wrapper to be unmarshalled into.
+	DoRaw(ctx context.Context, result interface{}) (ok bool, err error)
+}
+
+// client is the internal concrete type implementing Client.
+type client struct {
+	opts ClientOpts
+}
+
+// request is the internal concrete type implementing Request.
+type request struct {
+	client *client
+	query  string
+	vars   map[string]interface{}
+}
+
+// ClientOpts encapsulates the options given to NewClient.
+type ClientOpts struct {
+	Endpoint          string
+	AccessToken       string
+	AdditionalHeaders map[string]string
+
+	// Flags are the standard API client flags provided by NewFlags. If nil,
+	// default values will be used.
+	Flags *Flags
+
+	// Out is the writer that will be used when outputting diagnostics, such as
+	// curl commands when -get-curl is enabled.
+	Out io.Writer
+}
+
+// NewClient creates a new API client.
+func NewClient(opts ClientOpts) Client {
+	if opts.Out == nil {
+		panic("unexpected nil out option")
+	}
+
+	flags := opts.Flags
+	if flags == nil {
+		flags = defaultFlags()
+	}
+
+	return &client{
+		opts: ClientOpts{
+			Endpoint:          opts.Endpoint,
+			AccessToken:       opts.AccessToken,
+			AdditionalHeaders: opts.AdditionalHeaders,
+			Flags:             flags,
+			Out:               opts.Out,
+		},
+	}
+}
+
+func (c *client) NewQuery(query string) Request {
+	return c.NewRequest(query, nil)
+}
+
+func (c *client) NewRequest(query string, vars map[string]interface{}) Request {
+	return &request{
+		client: c,
+		query:  query,
+		vars:   vars,
+	}
+}
+
+func (c *client) url() string {
+	return c.opts.Endpoint + "/.api/graphql"
+}
+
+func (r *request) do(ctx context.Context, result interface{}) (bool, error) {
+	if *r.client.opts.Flags.getCurl {
+		curl, err := r.curlCmd()
+		if err != nil {
+			return false, err
+		}
+		r.client.opts.Out.Write([]byte(curl + "\n"))
+		return false, nil
+	}
+
+	// Create the JSON object.
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(map[string]interface{}{
+		"query":     r.query,
+		"variables": r.vars,
+	}); err != nil {
+		return false, err
+	}
+
+	// Create the HTTP request.
+	req, err := http.NewRequestWithContext(ctx, "POST", r.client.url(), nil)
+	if err != nil {
+		return false, err
+	}
+	if r.client.opts.AccessToken != "" {
+		req.Header.Set("Authorization", "token "+r.client.opts.AccessToken)
+	}
+	if *r.client.opts.Flags.trace {
+		req.Header.Set("X-Sourcegraph-Should-Trace", "true")
+	}
+	for k, v := range r.client.opts.AdditionalHeaders {
+		req.Header.Set(k, v)
+	}
+	req.Body = ioutil.NopCloser(&buf)
+
+	// Perform the request.
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return false, err
+	}
+	defer resp.Body.Close()
+
+	// Check trace header before we potentially early exit
+	if *r.client.opts.Flags.trace {
+		r.client.opts.Out.Write([]byte(fmt.Sprintf("x-trace: %s\n", resp.Header.Get("x-trace"))))
+	}
+
+	// Our request may have failed before reaching the GraphQL endpoint, so
+	// confirm the status code. You can test this easily with e.g. an invalid
+	// endpoint like -endpoint=https://google.com
+	if resp.StatusCode != http.StatusOK {
+		if resp.StatusCode == http.StatusUnauthorized && isatty.IsCygwinTerminal(os.Stdout.Fd()) {
+			fmt.Println("You may need to specify or update your access token to use this endpoint.")
+			fmt.Println("See https://github.com/sourcegraph/src-cli#authentication")
+			fmt.Println("")
+		}
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return false, err
+		}
+		return false, fmt.Errorf("error: %s\n\n%s", resp.Status, body)
+	}
+
+	// Decode the response.
+	if err := json.NewDecoder(resp.Body).Decode(result); err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+func (r *request) Do(ctx context.Context, result interface{}) (bool, error) {
+	raw := rawResult{Data: result}
+	ok, err := r.do(ctx, &raw)
+	if err != nil {
+		return false, err
+	} else if !ok {
+		return false, nil
+	}
+
+	// Handle the case of unpacking errors.
+	if raw.Errors != nil {
+		var errs *multierror.Error
+		for _, err := range raw.Errors {
+			errs = multierror.Append(errs, &graphqlError{err})
+		}
+		return false, errors.Wrap(errs, "GraphQL errors")
+	}
+	return true, nil
+}
+
+func (r *request) DoRaw(ctx context.Context, result interface{}) (bool, error) {
+	return r.do(ctx, result)
+}
+
+type rawResult struct {
+	Data   interface{}   `json:"data,omitempty"`
+	Errors []interface{} `json:"errors,omitempty"`
+}
+
+func (r *request) curlCmd() (string, error) {
+	data, err := json.Marshal(map[string]interface{}{
+		"query":     r.query,
+		"variables": r.vars,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	s := "curl \\\n"
+	if r.client.opts.AccessToken != "" {
+		s += fmt.Sprintf("   %s \\\n", shellquote.Join("-H", "Authorization: token "+r.client.opts.AccessToken))
+	}
+	for k, v := range r.client.opts.AdditionalHeaders {
+		s += fmt.Sprintf("   %s \\\n", shellquote.Join("-H", k+": "+v))
+	}
+	s += fmt.Sprintf("   %s \\\n", shellquote.Join("-d", string(data)))
+	s += fmt.Sprintf("   %s", shellquote.Join(r.client.url()))
+	return s, nil
+}

--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -1,0 +1,11 @@
+package api
+
+import "encoding/json"
+
+// graphqlError wraps a raw JSON error returned from a GraphQL endpoint.
+type graphqlError struct{ v interface{} }
+
+func (g *graphqlError) Error() string {
+	j, _ := json.MarshalIndent(g.v, "", "  ")
+	return string(j)
+}

--- a/internal/api/flags.go
+++ b/internal/api/flags.go
@@ -1,0 +1,27 @@
+package api
+
+import "flag"
+
+// Flags encapsulates the standard flags that should be added to all commands
+// that issue API requests.
+type Flags struct {
+	getCurl *bool
+	trace   *bool
+}
+
+// NewFlags instantiates a new Flags structure and attaches flags to the given
+// flag set.
+func NewFlags(flagSet *flag.FlagSet) *Flags {
+	return &Flags{
+		getCurl: flagSet.Bool("get-curl", false, "Print the curl command for executing this query and exit (WARNING: includes printing your access token!)"),
+		trace:   flagSet.Bool("trace", false, "Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing"),
+	}
+}
+
+func defaultFlags() *Flags {
+	d := false
+	return &Flags{
+		getCurl: &d,
+		trace:   &d,
+	}
+}

--- a/internal/api/nullable.go
+++ b/internal/api/nullable.go
@@ -1,0 +1,19 @@
+package api
+
+// NullInt returns a nullable int for use in a GraphQL variable, where -1 is
+// treated as a nil value.
+func NullInt(n int) *int {
+	if n == -1 {
+		return nil
+	}
+	return &n
+}
+
+// NullString returns a nullable string for use in a GraphQL variable, where ""
+// is treated as a nil value.
+func NullString(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}


### PR DESCRIPTION
This PR moves the `apiRequest` type and its associated functions in `cmd/src` out into a new `internal/api` package.

### Why?

I'm working on https://github.com/sourcegraph/sourcegraph/issues/12333, and want to keep as much of the business logic of interacting with the campaign backend out of `cmd/src` as possible: ideally, I want `cmd/src` to be the "view" layer — handling flags and managing output — and have `internal/campaigns` be the service layer that implements all the actual logic. I believe this separation will allow for better testing and code quality. (And, if I'm honest, this is also partly because I was starting to have to be _very_ careful about prefixing identifiers in `cmd/src`, and that was making for seriously unwieldy type and variable names.)

In order to do this, `internal/campaigns` has to be able to issue GraphQL requests. Just making `apiRequest` and friends public doesn't totally address this: it sets up potential circular dependencies, and `apiRequest` is tied to global state via its use of `cfg`, which makes it hard to reason about, and to mock for future testing purposes as I work on https://github.com/sourcegraph/sourcegraph/issues/12333.

### What's changed

I haven't significantly changed the internals of issuing GraphQL requests: the code in `api.Request`'s methods will look extremely familiar to anyone who's looked at `apiRequest.do()` previously.

There are a handful of specific changes that I think are improvements, but are open to discussion (just like everything else, of course):

1. There's no longer a concept of a `done` field: the request `Do` methods instead return a `bool, error` tuple that indicate whether the result was filled out (with the case where it's _not_ being when `-get-curl` is enabled). This means that functions that make GraphQL requests that previously used `done` are now written in a more top-down, procedural way, which I think is easier to read, but at the expense of a slightly more complicated `if` statement to check if `err != nil || !ok` in many cases.

2. `dontUnpackErrors` has been replaced with a parallel set of `Do` methods: one does the normal default unwrapping of the GraphQL response, and one doesn't. I think this is clearer, but this is certainly a matter of taste.

3. Contexts are now propagated consistently through the API package, although I haven't done any work to really take advantage of that thus far.

### What does this allow in the future

1. We can now test the API implementation more easily than when it lived in `cmd/src`, since it no longer relies on global state.

2. As `Client` and `Request` are interfaces, we can easily mock GraphQL requests in other tests within `src-cli`; I expect to add such a helper as I work on https://github.com/sourcegraph/sourcegraph/issues/12333.

3. This gives us some options for figuring out what context behaviour we think should be the default when executing `src` commands: we could now start looking at providing consistent options for timeouts and signal handling.

cc: @chrispine