### PR TITLE
Migrate to main as the default branch name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 <!--
 ###################################### READ ME ###########################################
-### This changelog should always be read on `master` branch. Its contents on version   ###
+### This changelog should always be read on `main` branch. Its contents on version     ###
 ### branches do not necessarily reflect the changes that have gone into that branch.   ###
 ##########################################################################################
 -->
@@ -16,6 +16,8 @@ All notable changes to `src-cli` are documented in this file.
 - When used with Sourcegraph 3.18 or later, campaigns can now be created on GitLab. [#231](https://github.com/sourcegraph/src-cli/pull/231)
 
 ### Changed
+
+- The default branch for the `src-cli` project has been changed to `main`. [#262](https://github.com/sourcegraph/src-cli/pull/262)
 
 ### Fixed
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -9,11 +9,11 @@ go install ./cmd/src
 
 ## Releasing
 
-1.  If this is a non-patch release, update the changelog. Add a new section `## $MAJOR.MINOR` to [`CHANGELOG.md`](https://github.com/sourcegraph/src-cli/blob/master/CHANGELOG.md#unreleased) immediately under `## Unreleased changes`. Add new empty `Added`, `Changed`, `Fixed`, and `Removed` sections under `## Unreleased changes`.
+1.  If this is a non-patch release, update the changelog. Add a new section `## $MAJOR.MINOR` to [`CHANGELOG.md`](https://github.com/sourcegraph/src-cli/blob/main/CHANGELOG.md#unreleased) immediately under `## Unreleased changes`. Add new empty `Added`, `Changed`, `Fixed`, and `Removed` sections under `## Unreleased changes`.
 1.  Find the latest version (either via the releases tab on GitHub or via git tags) to determine which version you are releasing.
 2.  `VERSION=9.9.9 ./release.sh` (replace `9.9.9` with the version you are releasing)
 3.  Travis will automatically perform the release. Once it has finished, **confirm that the curl commands fetch the latest version above**.
-4.  Update the `MinimumVersion` constant in the [src-cli package](https://github.com/sourcegraph/sourcegraph/tree/master/internal/src-cli/consts.go).
+4.  Update the `MinimumVersion` constant in the [src-cli package](https://github.com/sourcegraph/sourcegraph/tree/main/internal/src-cli/consts.go).
 
 ### Patch releases
 


### PR DESCRIPTION
This brings `src-cli` into line with our other important repositories. I don't believe we have any other hardcoded references to `src-cli`'s `master` branch across our organisation, [based on this search](https://sourcegraph.com/search?q=r:github.com/sourcegraph/.*+src-cli.*master&patternType=regexp).

Process wise, here's how I intend to proceed after approval:

1. Merge this PR.
2. Push `master` to `main`.
3. Update the default branch in the repo settings to `main`.
4. Edit open PRs to be against `main` instead of `master`.

If I've missed anything, I'd definitely appreciate a heads up! :smiley: 