### PR TITLE
api: add Client.NewHTTPRequest

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -1,4 +1,4 @@
-// Package api provides a basic client library for the Sourcegraph GraphQL API.
+// Package api provides a basic client library for the Sourcegraph API.
 package api
 
 import (
@@ -10,6 +10,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"path"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/kballard/go-shellquote"
@@ -25,6 +26,12 @@ type Client interface {
 
 	// NewRequest creates a GraphQL request.
 	NewRequest(query string, vars map[string]interface{}) Request
+
+	// NewHTTPRequest creates an http.Request for the Sourcegraph API.
+	//
+	// path is joined against the API route. For example on Sourcegraph.com this
+	// will result the URL: https://sourcegraph.com/.api/path.
+	NewHTTPRequest(ctx context.Context, method, path string, body io.Reader) (*http.Request, error)
 }
 
 // Request instances represent GraphQL requests.
@@ -104,8 +111,21 @@ func (c *client) NewRequest(query string, vars map[string]interface{}) Request {
 	}
 }
 
-func (c *client) url() string {
-	return c.opts.Endpoint + "/.api/graphql"
+func (c *client) NewHTTPRequest(ctx context.Context, method, p string, body io.Reader) (*http.Request, error) {
+	req, err := http.NewRequestWithContext(ctx, method, c.opts.Endpoint+path.Join("/.api", p), body)
+	if err != nil {
+		return nil, err
+	}
+	if c.opts.AccessToken != "" {
+		req.Header.Set("Authorization", "token "+c.opts.AccessToken)
+	}
+	if *c.opts.Flags.trace {
+		req.Header.Set("X-Sourcegraph-Should-Trace", "true")
+	}
+	for k, v := range c.opts.AdditionalHeaders {
+		req.Header.Set(k, v)
+	}
+	return req, nil
 }
 
 func (r *request) do(ctx context.Context, result interface{}) (bool, error) {
@@ -128,18 +148,9 @@ func (r *request) do(ctx context.Context, result interface{}) (bool, error) {
 	}
 
 	// Create the HTTP request.
-	req, err := http.NewRequestWithContext(ctx, "POST", r.client.url(), nil)
+	req, err := r.client.NewHTTPRequest(ctx, "POST", "graphql", nil)
 	if err != nil {
 		return false, err
-	}
-	if r.client.opts.AccessToken != "" {
-		req.Header.Set("Authorization", "token "+r.client.opts.AccessToken)
-	}
-	if *r.client.opts.Flags.trace {
-		req.Header.Set("X-Sourcegraph-Should-Trace", "true")
-	}
-	for k, v := range r.client.opts.AdditionalHeaders {
-		req.Header.Set(k, v)
 	}
 	req.Body = ioutil.NopCloser(&buf)
 
@@ -225,6 +236,6 @@ func (r *request) curlCmd() (string, error) {
 		s += fmt.Sprintf("   %s \\\n", shellquote.Join("-H", k+": "+v))
 	}
 	s += fmt.Sprintf("   %s \\\n", shellquote.Join("-d", string(data)))
-	s += fmt.Sprintf("   %s", shellquote.Join(r.client.url()))
+	s += fmt.Sprintf("   %s", shellquote.Join(r.client.opts.Endpoint+"/.api/graphql"))
 	return s, nil
 }


### PR DESCRIPTION
I want to make authenticated requests against the Sourcegraph API which
are not via GraphQL. In particular I am experimenting with Server Sent
Events endpoint. This commit adds NewHTTPRequest to the Client
interface, which allows access to an authenticated http.Request. This
will then be used to communicate with the non-GraphQL endpoint.

I have no idea if this fits your vision for the api package. After a little thought this seemed like the cleanest way to achieve this access, but I'm not a big fan of expanding interfaces.

Side-note: We could avoid adding to both interface and impl if this package returned a Client struct (but still kept the Request interface). The call sites could then use an interface for Client to make them testable.