### PR TITLE
api: add a standard -dump-requests flag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
 	github.com/google/go-cmp v0.4.1
 	github.com/hashicorp/go-multierror v1.1.0
+	github.com/jig/teereadcloser v0.0.0-20181016160506-953720c48e05
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/mattn/go-colorable v0.1.6 // indirect
 	github.com/mattn/go-isatty v0.0.12

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/U
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-multierror v1.1.0 h1:B9UzwGQJehnUY1yNrnwREHc3fGbC2xefo8g4TbElacI=
 github.com/hashicorp/go-multierror v1.1.0/go.mod h1:spPvp8C1qA32ftKqdAHm4hHTbPw+vmowP0z+KUhOZdA=
+github.com/jig/teereadcloser v0.0.0-20181016160506-953720c48e05 h1:dSwwtWuwMyarzsbVWOq4QJ8xVy9wgcNomvWyGtrKe+E=
+github.com/jig/teereadcloser v0.0.0-20181016160506-953720c48e05/go.mod h1:sRUFlj+HCejvoCRpuhU0EYnNw5FG+YJpz8UFfCf0F2U=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=

--- a/internal/api/flags.go
+++ b/internal/api/flags.go
@@ -5,6 +5,7 @@ import "flag"
 // Flags encapsulates the standard flags that should be added to all commands
 // that issue API requests.
 type Flags struct {
+	dump    *bool
 	getCurl *bool
 	trace   *bool
 }
@@ -13,6 +14,7 @@ type Flags struct {
 // flag set.
 func NewFlags(flagSet *flag.FlagSet) *Flags {
 	return &Flags{
+		dump:    flagSet.Bool("dump-requests", false, "Log GraphQL requests and responses to stdout"),
 		getCurl: flagSet.Bool("get-curl", false, "Print the curl command for executing this query and exit (WARNING: includes printing your access token!)"),
 		trace:   flagSet.Bool("trace", false, "Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing"),
 	}
@@ -21,6 +23,7 @@ func NewFlags(flagSet *flag.FlagSet) *Flags {
 func defaultFlags() *Flags {
 	d := false
 	return &Flags{
+		dump:    &d,
 		getCurl: &d,
 		trace:   &d,
 	}


### PR DESCRIPTION
This flag dumps the request and response out to stdout for any request issued via the internal/api package. This is probably only useful to people developing src-cli, but it's also pretty lightweight.

The output is very basic right now, but that's mostly because we have lots of implementation details stuck unexported in `cmd/src` that would be useful for colouring. If we land this and #268, then I'll likely rework this to use the new `Output` type.