### PR TITLE
campaigns: split apply into two subcommands

### DIFF
--- a/cmd/src/campaigns.go
+++ b/cmd/src/campaigns.go
@@ -3,10 +3,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io"
-	"os"
-
-	"github.com/pkg/errors"
 )
 
 var campaignsCommands commander
@@ -21,6 +17,7 @@ Usage:
 The commands are:
 
 	apply                 applies a campaign spec to create or update a campaign
+	preview               creates a campaign spec to be previewed or applied
 	repos,repositories    queries the exact repositories that a campaign spec
 	                      will apply to
 	validate              validates a campaign spec
@@ -42,16 +39,4 @@ Use "src campaigns [command] -h" for more information about a command.
 		handler:   handler,
 		usageFunc: func() { fmt.Println(usage) },
 	})
-}
-
-func campaignsOpenFileFlag(flag *string) (io.ReadCloser, error) {
-	if flag == nil || *flag == "" || *flag == "-" {
-		return os.Stdin, nil
-	}
-
-	file, err := os.Open(*flag)
-	if err != nil {
-		return nil, errors.Wrapf(err, "cannot open file %q", *flag)
-	}
-	return file, nil
 }

--- a/cmd/src/campaigns_apply.go
+++ b/cmd/src/campaigns_apply.go
@@ -11,8 +11,8 @@ import (
 
 func init() {
 	usage := `
-'src campaigns apply' is used to apply a campaign on a Sourcegraph instance,
-creating it if necessary.
+'src campaigns apply' is used to apply a campaign spec on a Sourcegraph instance,
+creating or updating the described campaign if necessary.
 
 Usage:
 
@@ -20,7 +20,7 @@ Usage:
 
 Examples:
 
-    $ src campagins apply -f campaign.spec.yaml -namespace myorg -apply
+    $ src campagins apply -f campaign.spec.yaml -namespace myorg
 
 `
 

--- a/cmd/src/campaigns_apply.go
+++ b/cmd/src/campaigns_apply.go
@@ -11,8 +11,8 @@ import (
 
 func init() {
 	usage := `
-'src campaigns apply' is used to apply a campaign spec on a Sourcegraph instance,
-creating or updating the described campaign if necessary.
+'src campaigns apply' is used to apply a campaign spec on a Sourcegraph
+instance, creating or updating the described campaign if necessary.
 
 Usage:
 

--- a/cmd/src/campaigns_common.go
+++ b/cmd/src/campaigns_common.go
@@ -1,0 +1,218 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"io"
+	"os"
+	"path"
+	"runtime"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/pkg/errors"
+	"github.com/sourcegraph/src-cli/internal/api"
+	"github.com/sourcegraph/src-cli/internal/campaigns"
+	"github.com/sourcegraph/src-cli/internal/output"
+)
+
+var (
+	campaignsPendingColor = output.StylePending
+	campaignsSuccessColor = output.StyleSuccess
+	campaignsSuccessEmoji = output.EmojiSuccess
+)
+
+type campaignsApplyFlags struct {
+	allowUnsupported bool
+	api              *api.Flags
+	apply            bool
+	cacheDir         string
+	clearCache       bool
+	file             string
+	keep             bool
+	namespace        string
+	parallelism      int
+	timeout          time.Duration
+}
+
+func newCampaignsApplyFlags(flagSet *flag.FlagSet, cacheDir string) *campaignsApplyFlags {
+	caf := &campaignsApplyFlags{
+		api: api.NewFlags(flagSet),
+	}
+
+	flagSet.BoolVar(
+		&caf.allowUnsupported, "allow-unsupported", false,
+		"Allow unsupported code hosts.",
+	)
+	flagSet.BoolVar(
+		&caf.apply, "apply", false,
+		"Ignored.",
+	)
+	flagSet.StringVar(
+		&caf.cacheDir, "cache", cacheDir,
+		"Directory for caching results.",
+	)
+	flagSet.BoolVar(
+		&caf.clearCache, "clear-cache", false,
+		"If true, clears the cache and executes all steps anew.",
+	)
+	flagSet.StringVar(
+		&caf.file, "f", "",
+		"The campaign spec file to read.",
+	)
+	flagSet.BoolVar(
+		&caf.keep, "keep-logs", false,
+		"Retain logs after executing steps.",
+	)
+	flagSet.StringVar(
+		&caf.namespace, "namespace", "",
+		"The user of organization namespace to place the campaign within.",
+	)
+	flagSet.IntVar(
+		&caf.parallelism, "j", 0,
+		"The maximum number of parallel jobs. (Default: GOMAXPROCS.)",
+	)
+	flagSet.DurationVar(
+		&caf.timeout, "timeout", 60*time.Minute,
+		"The maximum duration a single set of campaign steps can take.",
+	)
+
+	return caf
+}
+
+func campaignsCreatePending(out *output.Output, message string) output.Pending {
+	return out.Pending(output.Line("", campaignsPendingColor, message))
+}
+
+func campaignsCompletePending(p output.Pending, message string) {
+	p.Complete(output.Line(campaignsSuccessEmoji, campaignsSuccessColor, message))
+}
+
+func campaignsDefaultCacheDir() string {
+	uc, err := os.UserCacheDir()
+	if err != nil {
+		return ""
+	}
+
+	return path.Join(uc, "sourcegraph", "campaigns")
+}
+
+func campaignsOpenFileFlag(flag *string) (io.ReadCloser, error) {
+	if flag == nil || *flag == "" || *flag == "-" {
+		return os.Stdin, nil
+	}
+
+	file, err := os.Open(*flag)
+	if err != nil {
+		return nil, errors.Wrapf(err, "cannot open file %q", *flag)
+	}
+	return file, nil
+}
+
+// campaignsExecute performs all the steps required to upload the campaign spec
+// to Sourcegraph, including execution as needed. The return values are the
+// spec ID, spec URL, and error.
+func campaignsExecute(ctx context.Context, out *output.Output, svc *campaigns.Service, flags *campaignsApplyFlags) (campaigns.CampaignSpecID, string, error) {
+	// Parse flags and build up our service options.
+	var errs *multierror.Error
+
+	specFile, err := campaignsOpenFileFlag(&flags.file)
+	if err != nil {
+		errs = multierror.Append(errs, err)
+	} else {
+		defer specFile.Close()
+	}
+
+	if flags.namespace == "" {
+		errs = multierror.Append(errs, &usageError{errors.New("a namespace must be provided with -namespace")})
+	}
+
+	opts := campaigns.ExecutorOpts{
+		Cache:      svc.NewExecutionCache(flags.cacheDir),
+		ClearCache: flags.clearCache,
+		KeepLogs:   flags.keep,
+		Timeout:    flags.timeout,
+	}
+	if flags.parallelism <= 0 {
+		opts.Parallelism = runtime.GOMAXPROCS(0)
+	} else {
+		opts.Parallelism = flags.parallelism
+	}
+	executor := svc.NewExecutor(opts, nil)
+
+	if errs != nil {
+		return "", "", errs
+	}
+
+	pending := campaignsCreatePending(out, "Parsing campaign spec")
+	campaignSpec, err := svc.ParseCampaignSpec(specFile)
+	if err != nil {
+		return "", "", errors.Wrap(err, "parsing campaign spec")
+	}
+
+	if err := campaignsValidateSpec(out, campaignSpec); err != nil {
+		return "", "", err
+	}
+	campaignsCompletePending(pending, "Parsing campaign spec")
+
+	pending = campaignsCreatePending(out, "Resolving namespace")
+	namespace, err := svc.ResolveNamespace(ctx, flags.namespace)
+	if err != nil {
+		return "", "", err
+	}
+	campaignsCompletePending(pending, "Resolving namespace")
+
+	var progress output.Progress
+	specs, err := svc.ExecuteCampaignSpec(ctx, executor, campaignSpec, func(statuses []*campaigns.TaskStatus) {
+		if progress == nil {
+			progress = out.Progress([]output.ProgressBar{{
+				Label: "Executing steps",
+				Max:   float64(len(statuses)),
+			}}, nil)
+		}
+
+		complete := 0
+		for _, ts := range statuses {
+			if !ts.FinishedAt.IsZero() {
+				complete += 1
+			}
+		}
+		progress.SetValue(0, float64(complete))
+	})
+	if err != nil {
+		return "", "", err
+	}
+	if progress != nil {
+		progress.Complete()
+	}
+
+	if logFiles := executor.LogFiles(); len(logFiles) > 0 && flags.keep {
+		block := out.Block(output.Line("", campaignsSuccessColor, "Preserving log files:"))
+		for _, file := range logFiles {
+			block.Write(file)
+		}
+	}
+
+	progress = out.Progress([]output.ProgressBar{
+		{Label: "Sending changeset specs", Max: float64(len(specs))},
+	}, nil)
+	ids := make([]campaigns.ChangesetSpecID, len(specs))
+	for i, spec := range specs {
+		id, err := svc.CreateChangesetSpec(ctx, spec)
+		if err != nil {
+			return "", "", err
+		}
+		ids[i] = id
+		progress.SetValue(0, float64(i+1))
+	}
+	progress.Complete()
+
+	pending = campaignsCreatePending(out, "Creating campaign spec on Sourcegraph")
+	id, url, err := svc.CreateCampaignSpec(ctx, namespace, campaignSpec, ids)
+	if err != nil {
+		return "", "", err
+	}
+	campaignsCompletePending(pending, "Creating campaign spec on Sourcegraph")
+
+	return id, url, nil
+}

--- a/cmd/src/campaigns_preview.go
+++ b/cmd/src/campaigns_preview.go
@@ -11,8 +11,8 @@ import (
 
 func init() {
 	usage := `
-'src campaigns preview' is executes the steps in a campaign spec and uploads it to a Sourcegraph
-instance, ready to be previewed and applied.
+'src campaigns preview' is executes the steps in a campaign spec and uploads it
+to a Sourcegraph instance, ready to be previewed and applied.
 
 Usage:
 

--- a/cmd/src/campaigns_preview.go
+++ b/cmd/src/campaigns_preview.go
@@ -11,7 +11,7 @@ import (
 
 func init() {
 	usage := `
-'src campaigns preview' is used to create a campaign spec on a Sourcegraph
+'src campaigns preview' is executes the steps in a campaign spec and uploads it to a Sourcegraph
 instance, ready to be previewed and applied.
 
 Usage:

--- a/cmd/src/campaigns_preview.go
+++ b/cmd/src/campaigns_preview.go
@@ -11,42 +11,21 @@ import (
 
 func init() {
 	usage := `
-'src campaigns apply' is used to apply a campaign on a Sourcegraph instance,
-creating it if necessary.
+'src campaigns preview' is used to create a campaign spec on a Sourcegraph
+instance, ready to be previewed and applied.
 
 Usage:
 
-    src campaigns apply -f FILE -namespace NAMESPACE [command options]
+    src campaigns preview -f FILE -namespace NAMESPACE [command options]
 
 Examples:
 
-    $ src campagins apply -f campaign.spec.yaml -namespace myorg -apply
+    $ src campaigns preview -f campaign.spec.yaml -namespace myuser
 
 `
 
-	flagSet := flag.NewFlagSet("apply", flag.ExitOnError)
+	flagSet := flag.NewFlagSet("preview", flag.ExitOnError)
 	flags := newCampaignsApplyFlags(flagSet, campaignsDefaultCacheDir())
-
-	doApply := func(ctx context.Context, out *output.Output, svc *campaigns.Service, flags *campaignsApplyFlags) error {
-		id, _, err := campaignsExecute(ctx, out, svc, flags)
-		if err != nil {
-			return err
-		}
-
-		pending := campaignsCreatePending(out, "Applying campaign spec")
-		campaign, err := svc.ApplyCampaign(ctx, id)
-		if err != nil {
-			return err
-		}
-		campaignsCompletePending(pending, "Applying campaign spec")
-
-		out.Write("")
-		block := out.Block(output.Line(campaignsSuccessEmoji, campaignsSuccessColor, "Campaign applied!"))
-		block.Write("To view the campaign, go to:")
-		block.Writef("%s%s", cfg.Endpoint, campaign.URL)
-
-		return nil
-	}
 
 	handler := func(args []string) error {
 		if err := flagSet.Parse(args); err != nil {
@@ -60,11 +39,16 @@ Examples:
 			Client:           cfg.apiClient(flags.api, flagSet.Output()),
 		})
 
-		if err := doApply(ctx, out, svc, flags); err != nil {
+		_, url, err := campaignsExecute(ctx, out, svc, flags)
+		if err != nil {
 			out.Write("")
 			block := out.Block(output.Line("❌", output.StyleWarning, "Error"))
 			block.Write(err.Error())
 		}
+
+		out.Write("")
+		block := out.Block(output.Line(campaignsSuccessEmoji, campaignsSuccessColor, "To preview or apply the campaign spec, go to:"))
+		block.Writef("%s%s", cfg.Endpoint, url)
 
 		return nil
 	}


### PR DESCRIPTION
This fixes #275 by splitting off a new `src campaigns preview` from `src campaigns apply`, and making the `-apply` flag meaningless.