### PR TITLE
output: fix Block newlines

### DIFF
--- a/cmd/src/campaigns_apply.go
+++ b/cmd/src/campaigns_apply.go
@@ -42,6 +42,8 @@ Examples:
 
 		out.Write("")
 		block := out.Block(output.Line(campaignsSuccessEmoji, campaignsSuccessColor, "Campaign applied!"))
+		defer block.Close()
+
 		block.Write("To view the campaign, go to:")
 		block.Writef("%s%s", cfg.Endpoint, campaign.URL)
 
@@ -63,6 +65,8 @@ Examples:
 		if err := doApply(ctx, out, svc, flags); err != nil {
 			out.Write("")
 			block := out.Block(output.Line("❌", output.StyleWarning, "Error"))
+			defer block.Close()
+
 			block.Write(err.Error())
 		}
 

--- a/cmd/src/campaigns_common.go
+++ b/cmd/src/campaigns_common.go
@@ -187,10 +187,14 @@ func campaignsExecute(ctx context.Context, out *output.Output, svc *campaigns.Se
 	}
 
 	if logFiles := executor.LogFiles(); len(logFiles) > 0 && flags.keep {
-		block := out.Block(output.Line("", campaignsSuccessColor, "Preserving log files:"))
-		for _, file := range logFiles {
-			block.Write(file)
-		}
+		func() {
+			block := out.Block(output.Line("", campaignsSuccessColor, "Preserving log files:"))
+			defer block.Close()
+
+			for _, file := range logFiles {
+				block.Write(file)
+			}
+		}()
 	}
 
 	progress = out.Progress([]output.ProgressBar{

--- a/cmd/src/campaigns_preview.go
+++ b/cmd/src/campaigns_preview.go
@@ -41,13 +41,17 @@ Examples:
 
 		_, url, err := campaignsExecute(ctx, out, svc, flags)
 		if err != nil {
-			out.Write("")
-			block := out.Block(output.Line("❌", output.StyleWarning, "Error"))
-			block.Write(err.Error())
+			func() {
+				out.Write("")
+				block := out.Block(output.Line("❌", output.StyleWarning, "Error"))
+				defer block.Close()
+				block.Write(err.Error())
+			}()
 		}
 
 		out.Write("")
 		block := out.Block(output.Line(campaignsSuccessEmoji, campaignsSuccessColor, "To preview or apply the campaign spec, go to:"))
+		defer block.Close()
 		block.Writef("%s%s", cfg.Endpoint, url)
 
 		return nil

--- a/cmd/src/campaigns_validate.go
+++ b/cmd/src/campaigns_validate.go
@@ -71,6 +71,7 @@ func campaignsValidateSpec(out *output.Output, spec *campaigns.CampaignSpec) err
 	if err := spec.Validate(); err != nil {
 		if merr, ok := err.(*multierror.Error); ok {
 			block := out.Block(output.Line("\u274c", output.StyleWarning, "Campaign spec failed validation."))
+			defer block.Close()
 
 			for i, err := range merr.Errors {
 				block.Writef("%d. %s", i+1, err)

--- a/internal/output/_examples/main.go
+++ b/internal/output/_examples/main.go
@@ -94,4 +94,5 @@ func main() {
 	out.Write("")
 	block := out.Block(output.Line(output.EmojiSuccess, output.StyleSuccess, "Done!"))
 	block.Write("Here is some additional information.\nIt even line wraps.")
+	block.Close()
 }

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -27,6 +27,12 @@ type Writer interface {
 	WriteLine(line FancyLine)
 }
 
+type Context interface {
+	Writer
+
+	Close()
+}
+
 // Output encapsulates a standard set of functionality for commands that need
 // to output human-readable data.
 //

--- a/internal/output/pending.go
+++ b/internal/output/pending.go
@@ -3,7 +3,7 @@ package output
 type Pending interface {
 	// Anything sent to the Writer methods will be displayed as a log message
 	// above the pending line.
-	Writer
+	Context
 
 	// Update and Updatef change the message shown after the spinner.
 	Update(s string)

--- a/internal/output/pending_simple.go
+++ b/internal/output/pending_simple.go
@@ -16,6 +16,7 @@ func (p *pendingSimple) Complete(message FancyLine) {
 	p.WriteLine(message)
 }
 
+func (p *pendingSimple) Close()   {}
 func (p *pendingSimple) Destroy() {}
 
 func newPendingSimple(message FancyLine, o *Output) *pendingSimple {

--- a/internal/output/pending_tty.go
+++ b/internal/output/pending_tty.go
@@ -98,6 +98,8 @@ func (p *pendingTTY) Complete(message FancyLine) {
 	p.write(message)
 }
 
+func (p *pendingTTY) Close() { p.Destroy() }
+
 func (p *pendingTTY) Destroy() {
 	p.spinner.stop()
 

--- a/internal/output/progress.go
+++ b/internal/output/progress.go
@@ -1,7 +1,7 @@
 package output
 
 type Progress interface {
-	Writer
+	Context
 
 	// Complete stops the set of progress bars and marks them all as completed.
 	Complete()

--- a/internal/output/progress_simple.go
+++ b/internal/output/progress_simple.go
@@ -17,6 +17,7 @@ func (p *progressSimple) Complete() {
 	writeBars(p.Output, p.bars)
 }
 
+func (p *progressSimple) Close()   { p.Destroy() }
 func (p *progressSimple) Destroy() { p.stop() }
 
 func (p *progressSimple) SetLabel(i int, label string) {
@@ -68,6 +69,8 @@ func writeBar(w Writer, bar *ProgressBar) {
 func writeBars(o *Output, bars []*ProgressBar) {
 	if len(bars) > 1 {
 		block := o.Block(Line("", StyleReset, "Progress:"))
+		defer block.Close()
+
 		for _, bar := range bars {
 			writeBar(block, bar)
 		}

--- a/internal/output/progress_tty.go
+++ b/internal/output/progress_tty.go
@@ -32,6 +32,8 @@ func (p *progressTTY) Complete() {
 	p.drawInSitu()
 }
 
+func (p *progressTTY) Close() { p.Destroy() }
+
 func (p *progressTTY) Destroy() {
 	p.spinner.stop()
 


### PR DESCRIPTION
A logic error in the indentedWriter implementation resulted in extra newlines, depending on which Block method was invoked. Adding a Close() method fixes this.

I promise some tests are coming soon.