### PR TITLE
campaigns: experiment with per-repo templates

### DIFF
--- a/internal/campaigns/campaign_spec.go
+++ b/internal/campaigns/campaign_spec.go
@@ -53,9 +53,10 @@ type ImportChangeset struct {
 }
 
 type OnQueryOrRepository struct {
-	RepositoriesMatchingQuery string `json:"repositoriesMatchingQuery,omitempty" yaml:"repositoriesMatchingQuery"`
-	Repository                string `json:"repository,omitempty" yaml:"repository"`
-	Branch                    string `json:"branch,omitempty" yaml:"branch"`
+	RepositoriesMatchingQuery string             `json:"repositoriesMatchingQuery,omitempty" yaml:"repositoriesMatchingQuery"`
+	Repository                string             `json:"repository,omitempty" yaml:"repository"`
+	Branch                    string             `json:"branch,omitempty" yaml:"branch"`
+	ChangesetTemplate         *ChangesetTemplate `json:"changesetTemplate,omitempty" yaml:"changesetTemplate"`
 }
 
 type Step struct {

--- a/internal/campaigns/campaign_spec.go
+++ b/internal/campaigns/campaign_spec.go
@@ -1,8 +1,6 @@
 package campaigns
 
 import (
-	"fmt"
-
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/src-cli/schema"
@@ -27,12 +25,12 @@ import (
 //    pointers, which is ugly and inefficient.
 
 type CampaignSpec struct {
-	Name              string                `json:"name,omitempty" yaml:"name"`
-	Description       string                `json:"description,omitempty" yaml:"description"`
-	On                []OnQueryOrRepository `json:"on,omitempty" yaml:"on"`
-	Steps             []Step                `json:"steps,omitempty" yaml:"steps"`
-	ImportChangesets  []ImportChangeset     `json:"importChangesets,omitempty" yaml:"importChangesets"`
-	ChangesetTemplate *ChangesetTemplate    `json:"changesetTemplate,omitempty" yaml:"changesetTemplate"`
+	Name              string                        `json:"name,omitempty" yaml:"name"`
+	Description       string                        `json:"description,omitempty" yaml:"description"`
+	On                OnQueryOrRepositoryCollection `json:"on,omitempty" yaml:"on"`
+	Steps             []Step                        `json:"steps,omitempty" yaml:"steps"`
+	ImportChangesets  []ImportChangeset             `json:"importChangesets,omitempty" yaml:"importChangesets"`
+	ChangesetTemplate *ChangesetTemplate            `json:"changesetTemplate,omitempty" yaml:"changesetTemplate"`
 }
 
 type ChangesetTemplate struct {
@@ -50,13 +48,6 @@ type ExpandedGitCommitDescription struct {
 type ImportChangeset struct {
 	Repository  string        `json:"repository" yaml:"repository"`
 	ExternalIDs []interface{} `json:"externalIDs" yaml:"externalIDs"`
-}
-
-type OnQueryOrRepository struct {
-	RepositoriesMatchingQuery string             `json:"repositoriesMatchingQuery,omitempty" yaml:"repositoriesMatchingQuery"`
-	Repository                string             `json:"repository,omitempty" yaml:"repository"`
-	Branch                    string             `json:"branch,omitempty" yaml:"branch"`
-	ChangesetTemplate         *ChangesetTemplate `json:"changesetTemplate,omitempty" yaml:"changesetTemplate"`
 }
 
 type Step struct {
@@ -102,14 +93,4 @@ func (spec *CampaignSpec) Validate() error {
 		errs = multierror.Append(errs, errors.New(verr.String()))
 	}
 	return errs
-}
-
-func (on *OnQueryOrRepository) String() string {
-	if on.RepositoriesMatchingQuery != "" {
-		return on.RepositoriesMatchingQuery
-	} else if on.Repository != "" {
-		return "r:" + on.Repository
-	}
-
-	return fmt.Sprintf("%v", *on)
 }

--- a/internal/campaigns/on.go
+++ b/internal/campaigns/on.go
@@ -1,0 +1,63 @@
+package campaigns
+
+import "strings"
+
+type OnQueryOrRepository struct {
+	RepositoriesMatchingQuery string             `json:"repositoriesMatchingQuery,omitempty" yaml:"repositoriesMatchingQuery"`
+	Repository                string             `json:"repository,omitempty" yaml:"repository"`
+	Branch                    string             `json:"branch,omitempty" yaml:"branch"`
+	ChangesetTemplate         *ChangesetTemplate `json:"changesetTemplate,omitempty" yaml:"changesetTemplate"`
+}
+
+func (on *OnQueryOrRepository) String() string {
+	if on.isRepository() {
+		return on.Repository
+	} else {
+		return on.RepositoriesMatchingQuery
+	}
+}
+
+func (on *OnQueryOrRepository) isRepository() bool {
+	return on.Repository != ""
+}
+
+type OnQueryOrRepositoryCollection []OnQueryOrRepository
+
+func (coll OnQueryOrRepositoryCollection) Len() int {
+	return len(coll)
+}
+
+func (coll OnQueryOrRepositoryCollection) Less(i, j int) bool {
+	// The simple cases: if one or both of the OnQueryOrRepository instances
+	// are repositories, then those always "win" over queries.
+	if iIsRepo, jIsRepo := coll[i].isRepository(), coll[j].isRepository(); iIsRepo && jIsRepo {
+		// If the repositories are the same, then we'll prioritise the
+		// repository with a branch. If they both have branches, then we'll
+		// sort the branches lexicographically.
+		if coll[i].Repository == coll[j].Repository {
+			if iHasBranch, jHasBranch := coll[i].Branch != "", coll[j].Branch != ""; iHasBranch && jHasBranch {
+				return strings.Compare(coll[i].Branch, coll[j].Branch) < 0
+			} else if iHasBranch {
+				return true
+			} else if jHasBranch {
+				return false
+			}
+		}
+
+		// The fallback here is to just do a lexicographical comparison on the
+		// repo names. They should never conflict in practice anyway, since the
+		// same repo shouldn't ever be returned for disjoint repo names.
+		return strings.Compare(coll[i].Repository, coll[j].Repository) < 0
+	} else if iIsRepo {
+		return true
+	} else if jIsRepo {
+		return false
+	}
+
+	// We'll apply the Traefik rule here: the longer query "wins".
+	return len(coll[i].RepositoriesMatchingQuery) > len(coll[j].RepositoriesMatchingQuery)
+}
+
+func (coll OnQueryOrRepositoryCollection) Swap(i, j int) {
+	coll[i], coll[j] = coll[j], coll[i]
+}

--- a/internal/campaigns/on.go
+++ b/internal/campaigns/on.go
@@ -33,10 +33,11 @@ func (coll OnQueryOrRepositoryCollection) Less(i, j int) bool {
 	if iIsRepo, jIsRepo := coll[i].isRepository(), coll[j].isRepository(); iIsRepo && jIsRepo {
 		// If the repositories are the same, then we'll prioritise the
 		// repository with a branch. If they both have branches, then we'll
-		// sort the branches lexicographically.
+		// punt and let the first one win, provided the collection is sorted
+		// with sort.Stable().
 		if coll[i].Repository == coll[j].Repository {
 			if iHasBranch, jHasBranch := coll[i].Branch != "", coll[j].Branch != ""; iHasBranch && jHasBranch {
-				return strings.Compare(coll[i].Branch, coll[j].Branch) < 0
+				return false
 			} else if iHasBranch {
 				return true
 			} else if jHasBranch {

--- a/internal/campaigns/on_test.go
+++ b/internal/campaigns/on_test.go
@@ -1,0 +1,86 @@
+package campaigns
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestOn_SortInterface(t *testing.T) {
+	// Set up some standard OnQueryOrRepository variables to use in test cases.
+	ons := map[string]OnQueryOrRepository{
+		"repo A":      {Repository: "github.com/a/a"},
+		"repo B":      {Repository: "github.com/a/b"},
+		"repo B main": {Repository: "github.com/a/b", Branch: "main"},
+		"repo B xxx":  {Repository: "github.com/a/b", Branch: "xxx"},
+		"short query": {RepositoriesMatchingQuery: "f:README.md"},
+		"long query":  {RepositoriesMatchingQuery: "f:README.md r:a/b"},
+	}
+
+	for name, want := range map[string]OnQueryOrRepositoryCollection{
+		"one query only, Vasily": {
+			ons["short query"],
+		},
+		"one repo, one query": {
+			ons["repo A"], ons["short query"],
+		},
+		"two queries, same length": {
+			ons["short query"], ons["short query"],
+		},
+		"two queries, different lengths": {
+			ons["long query"], ons["short query"],
+		},
+		"two repos, no branches": {
+			ons["repo A"], ons["repo B"],
+		},
+		"two repos, one branch": {
+			ons["repo B main"], ons["repo B"],
+		},
+		"two repos, two branches": {
+			ons["repo B main"], ons["repo B xxx"],
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			// For each test case, we'll try the original order we're given,
+			// plus a reverse order, to ensure the sort function is actually
+			// doing something.
+			have := make(OnQueryOrRepositoryCollection, len(want))
+			copy(have, want)
+
+			sort.Sort(have)
+			if diff := cmp.Diff(have, want); diff != "" {
+				t.Error(diff)
+			}
+
+			// Reverse the slice.
+			for i, j := len(want)-1, 0; i >= 0; i-- {
+				have[j] = want[i]
+				j++
+			}
+
+			sort.Sort(have)
+			if diff := cmp.Diff(have, want); diff != "" {
+				t.Error(diff)
+			}
+		})
+	}
+}
+
+func TestOn_String(t *testing.T) {
+	for want, on := range map[string]OnQueryOrRepository{
+		"":               {},
+		"github.com/a/b": {Repository: "github.com/a/b", Branch: "main"},
+		"f:README.md":    {RepositoriesMatchingQuery: "f:README.md"},
+		"github.com/a/c": {
+			Repository:                "github.com/a/c",
+			RepositoriesMatchingQuery: "this is invalid, but let's test it anyway",
+		},
+	} {
+		t.Run(want, func(t *testing.T) {
+			if have := on.String(); have != want {
+				t.Errorf("have=%q want=%q", have, want)
+			}
+		})
+	}
+}

--- a/internal/campaigns/repository.go
+++ b/internal/campaigns/repository.go
@@ -1,0 +1,9 @@
+package campaigns
+
+import "github.com/sourcegraph/src-cli/internal/campaigns/graphql"
+
+type Repository struct {
+	*graphql.Repository
+
+	template *ChangesetTemplate
+}

--- a/internal/campaigns/service.go
+++ b/internal/campaigns/service.go
@@ -293,7 +293,7 @@ func (svc *Service) ResolveRepositories(ctx context.Context, spec *CampaignSpec)
 
 	// We'll sort the On slice so that we iterate over the repositories from
 	// most to least specific.
-	sort.Sort(spec.On)
+	sort.Stable(spec.On)
 
 	// TODO: this could be trivially parallelised in the future.
 	for _, on := range spec.On {

--- a/schema/campaign_spec.schema.json
+++ b/schema/campaign_spec.schema.json
@@ -32,6 +32,9 @@
                 "type": "string",
                 "description": "A Sourcegraph search query that matches a set of repositories (and branches). If the query matches files, symbols, or some other object inside a repository, the object's repository is included.",
                 "examples": ["file:README.md"]
+              },
+              "changesetTemplate": {
+                "$ref": "#/definitions/changesetTemplate"
               }
             }
           },
@@ -110,13 +113,24 @@
       }
     },
     "changesetTemplate": {
+      "$ref": "#/definitions/changesetTemplate"
+    }
+  },
+  "definitions": {
+    "changesetTemplate": {
       "type": "object",
       "description": "A template describing how to create (and update) changesets with the file changes produced by the command steps.",
       "additionalProperties": false,
       "required": ["title", "branch", "commit", "published"],
       "properties": {
-        "title": { "type": "string", "description": "The title of the changeset." },
-        "body": { "type": "string", "description": "The body (description) of the changeset." },
+        "title": {
+          "type": "string",
+          "description": "The title of the changeset."
+        },
+        "body": {
+          "type": "string",
+          "description": "The body (description) of the changeset."
+        },
         "branch": {
           "type": "string",
           "description": "The name of the Git branch to create or update on each repository with the changes."

--- a/schema/campaign_spec.schema.json
+++ b/schema/campaign_spec.schema.json
@@ -53,6 +53,9 @@
               "branch": {
                 "type": "string",
                 "description": "The branch on the repository to propose changes to. If unset, the repository's default branch is used."
+              },
+              "changesetTemplate": {
+                "$ref": "#/definitions/changesetTemplate"
               }
             }
           }

--- a/schema/campaign_spec_stringdata.go
+++ b/schema/campaign_spec_stringdata.go
@@ -58,6 +58,9 @@ const CampaignSpecJSON = `{
               "branch": {
                 "type": "string",
                 "description": "The branch on the repository to propose changes to. If unset, the repository's default branch is used."
+              },
+              "changesetTemplate": {
+                "$ref": "#/definitions/changesetTemplate"
               }
             }
           }


### PR DESCRIPTION
This is one possible approach to tackle sourcegraph/sourcegraph#13139, as described in [RFC 228](https://docs.google.com/document/d/1A-5cbYGz1p1UB1eAFsIgpK5XDkvS7ZNAVKMdtBm_WY0/edit?usp=sharing).

Basically, you can now replicate `changesetTemplate` in individual `OnQueryOrRepository` items. For example:

```yaml
name: hello-world
description: Add Hello World to READMEs

# Find all repositories that contain a README.md file.
on:
  - repositoriesMatchingQuery: file:README.md r:github.com/LawnGnome
    changesetTemplate:
      title: Hello Adam
      body: Your first campaign?
      branch: hello-world # Push the commit to this branch.
      commit:
        message: Append Hello World to all README.md files
      published: true
  - repositoriesMatchingQuery: file:README.md r:gitlab.sgdev.org

# In each repository, run this command. Each repository's resulting diff is captured.
steps:
  - run: echo Hello World | tee -a $(find -name README.md)
    container: alpine:3

# Describe the changeset (e.g., GitHub pull request) you want for each repository.
changesetTemplate:
  title: Hello World
  body: My first campaign!
  branch: hello-world # Push the commit to this branch.
  commit:
    message: Append Hello World to all README.md files
  published: false
```

In the event that a repo is matched by more than one `OnQueryOrRepository`, the precedence is roughly (more detail in the RFC):

1. `repository: exact repo` with a branch, with the tie breaker being the first item seen
2. `repository: exact repo` without a branch
3. `repositoriesMatchingQuery: search string`, with the tie breaker being the longer query
4. The campaign spec `changesetTemplate`