### PR TITLE
campaigns: improve error output

### DIFF
--- a/cmd/src/campaigns_apply.go
+++ b/cmd/src/campaigns_apply.go
@@ -65,9 +65,9 @@ Examples:
 		if err := doApply(ctx, out, svc, flags); err != nil {
 			out.Write("")
 			block := out.Block(output.Line("❌", output.StyleWarning, "Error"))
-			defer block.Close()
-
 			block.Write(err.Error())
+			block.Close()
+			out.Write("")
 		}
 
 		return nil

--- a/cmd/src/campaigns_preview.go
+++ b/cmd/src/campaigns_preview.go
@@ -41,12 +41,12 @@ Examples:
 
 		_, url, err := campaignsExecute(ctx, out, svc, flags)
 		if err != nil {
-			func() {
-				out.Write("")
-				block := out.Block(output.Line("❌", output.StyleWarning, "Error"))
-				defer block.Close()
-				block.Write(err.Error())
-			}()
+			out.Write("")
+			block := out.Block(output.Line("❌", output.StyleWarning, "Error"))
+			block.Write(err.Error())
+			block.Close()
+			out.Write("")
+			return &exitCodeError{nil, 1}
 		}
 
 		out.Write("")


### PR DESCRIPTION
This enforces a newline separation above and below the error block, and ensures that the preview command doesn't erroneously print a preview URL after an error.