### PR TITLE
campaigns: show the repos that are unsupported

### DIFF
--- a/internal/campaigns/errors.go
+++ b/internal/campaigns/errors.go
@@ -1,0 +1,41 @@
+package campaigns
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/sourcegraph/src-cli/internal/campaigns/graphql"
+)
+
+// unsupportedRepoSet provides a set to manage repositories that are on
+// unsupported code hosts. This type implements error to allow it to be
+// returned directly as an error value if needed.
+type unsupportedRepoSet map[*graphql.Repository]struct{}
+
+func (e unsupportedRepoSet) Error() string {
+	repos := []string{}
+	typeSet := map[string]struct{}{}
+	for repo := range e {
+		repos = append(repos, repo.Name)
+		typeSet[repo.ExternalRepository.ServiceType] = struct{}{}
+	}
+
+	types := []string{}
+	for t := range typeSet {
+		types = append(types, t)
+	}
+
+	return fmt.Sprintf(
+		"found repositories on unsupported code hosts: %s\nrepositories:\n\t%s",
+		strings.Join(types, ", "),
+		strings.Join(repos, ", "),
+	)
+}
+
+func (e unsupportedRepoSet) appendRepo(repo *graphql.Repository) {
+	e[repo] = struct{}{}
+}
+
+func (e unsupportedRepoSet) hasUnsupported() bool {
+	return len(e) > 0
+}

--- a/internal/campaigns/errors.go
+++ b/internal/campaigns/errors.go
@@ -28,7 +28,7 @@ func (e unsupportedRepoSet) Error() string {
 	return fmt.Sprintf(
 		"found repositories on unsupported code hosts: %s\nrepositories:\n\t%s",
 		strings.Join(types, ", "),
-		strings.Join(repos, ", "),
+		strings.Join(repos, "\n\t"),
 	)
 }
 


### PR DESCRIPTION
Previously, only the code host types were displayed when a campaign was previewed or applied with unsupported repos. This commit extends the error message to include the actual repos as well:

![image](https://user-images.githubusercontent.com/229984/91366145-ca763f80-e7b7-11ea-9fc3-057823c3f255.png)