### PR TITLE
Retain original input for campaign spec

### DIFF
--- a/cmd/src/campaigns_common.go
+++ b/cmd/src/campaigns_common.go
@@ -145,7 +145,7 @@ func campaignsExecute(ctx context.Context, out *output.Output, svc *campaigns.Se
 	}
 
 	pending := campaignsCreatePending(out, "Parsing campaign spec")
-	campaignSpec, err := svc.ParseCampaignSpec(specFile)
+	campaignSpec, rawSpec, err := svc.ParseCampaignSpec(specFile)
 	if err != nil {
 		return "", "", errors.Wrap(err, "parsing campaign spec")
 	}
@@ -212,7 +212,7 @@ func campaignsExecute(ctx context.Context, out *output.Output, svc *campaigns.Se
 	progress.Complete()
 
 	pending = campaignsCreatePending(out, "Creating campaign spec on Sourcegraph")
-	id, url, err := svc.CreateCampaignSpec(ctx, namespace, campaignSpec, ids)
+	id, url, err := svc.CreateCampaignSpec(ctx, namespace, rawSpec, ids)
 	if err != nil {
 		return "", "", err
 	}

--- a/cmd/src/campaigns_repositories.go
+++ b/cmd/src/campaigns_repositories.go
@@ -49,7 +49,7 @@ Examples:
 		client := cfg.apiClient(apiFlags, flagSet.Output())
 
 		svc := campaigns.NewService(&campaigns.ServiceOpts{Client: client})
-		spec, err := svc.ParseCampaignSpec(specFile)
+		spec, _, err := svc.ParseCampaignSpec(specFile)
 		if err != nil {
 			return errors.Wrap(err, "parsing campaign spec")
 		}

--- a/cmd/src/campaigns_validate.go
+++ b/cmd/src/campaigns_validate.go
@@ -39,7 +39,7 @@ Examples:
 		defer specFile.Close()
 
 		svc := campaigns.NewService(&campaigns.ServiceOpts{})
-		spec, err := svc.ParseCampaignSpec(specFile)
+		spec, _, err := svc.ParseCampaignSpec(specFile)
 		if err != nil {
 			return errors.Wrap(err, "parsing campaign spec")
 		}

--- a/internal/campaigns/service.go
+++ b/internal/campaigns/service.go
@@ -77,12 +77,7 @@ mutation CreateCampaignSpec(
 }
 `
 
-func (svc *Service) CreateCampaignSpec(ctx context.Context, namespace string, spec *CampaignSpec, ids []ChangesetSpecID) (CampaignSpecID, string, error) {
-	raw, err := json.Marshal(spec)
-	if err != nil {
-		return "", "", errors.Wrap(err, "marshalling campaign spec JSON")
-	}
-
+func (svc *Service) CreateCampaignSpec(ctx context.Context, namespace, spec string, ids []ChangesetSpecID) (CampaignSpecID, string, error) {
 	var result struct {
 		CreateCampaignSpec struct {
 			ID       string
@@ -91,7 +86,7 @@ func (svc *Service) CreateCampaignSpec(ctx context.Context, namespace string, sp
 	}
 	if ok, err := svc.client.NewRequest(createCampaignSpecMutation, map[string]interface{}{
 		"namespace":      namespace,
-		"spec":           string(raw),
+		"spec":           spec,
 		"changesetSpecs": ids,
 	}).Do(ctx, &result); err != nil || !ok {
 		return "", "", err
@@ -239,17 +234,17 @@ func (svc *Service) ExecuteCampaignSpec(ctx context.Context, x Executor, spec *C
 	return specs, nil
 }
 
-func (svc *Service) ParseCampaignSpec(in io.Reader) (*CampaignSpec, error) {
+func (svc *Service) ParseCampaignSpec(in io.Reader) (*CampaignSpec, string, error) {
 	data, err := ioutil.ReadAll(in)
 	if err != nil {
-		return nil, errors.Wrap(err, "reading campaign spec")
+		return nil, "", errors.Wrap(err, "reading campaign spec")
 	}
 
 	spec, err := ParseCampaignSpec(data)
 	if err != nil {
-		return nil, errors.Wrap(err, "parsing campaign spec")
+		return nil, "", errors.Wrap(err, "parsing campaign spec")
 	}
-	return spec, nil
+	return spec, string(data), nil
 }
 
 const namespaceQuery = `


### PR DESCRIPTION
Currently, the spec sent to the server is created by json marshalling the CampaignSpec struct.
That, however makes us lose the original formatting, comments and yaml format, if used.
Since we want to show the spec that this campaign was created from in the UI, we need to retain the _original_ input.

@LawnGnome I'd like your review here, as I might be missing a point where the struct is modified, but the raw spec isn't.

Works on https://github.com/sourcegraph/sourcegraph/issues/13210