### PR TITLE
fix for crash when progress bars had a size of zero

### DIFF
--- a/internal/output/progress_tty.go
+++ b/internal/output/progress_tty.go
@@ -208,7 +208,11 @@ func (p *progressTTY) writeLine(bar *ProgressBar) {
 
 	// Unicode box drawing gives us eight possible bar widths, so we need to
 	// calculate both the bar width and then the final character, if any.
-	segments := int(math.Round((float64(8*barWidth) * value) / bar.Max))
+	var segments int
+	if bar.Max > 0 {
+		segments = int(math.Round((float64(8*barWidth) * value) / bar.Max))
+	}
+
 	fillWidth := segments / 8
 	remainder := segments % 8
 	if remainder == 0 {


### PR DESCRIPTION
If a progress bar was created with a size of zero (`bar.Max` was 0), then src-cli would crash in rendering. (This could happen if some engineering manager didn't know what they were doing when using campaigns and tried to create one with no repos found, for example.)

Instead, we just draw a zero-width bar if `bar.Max` is zero.