### PR TITLE
do not crash if termbox fails to init

### DIFF
--- a/internal/output/capabilities.go
+++ b/internal/output/capabilities.go
@@ -23,11 +23,11 @@ func detectCapabilities() capabilities {
 	// Pulling in termbox is probably overkill, but finding a pure Go library
 	// that could just provide terminfo was surprisingly hard. At least termbox
 	// is widely used.
-	if err := termbox.Init(); err != nil {
-		panic(err)
+	w, h := 80, 25
+	if err := termbox.Init(); err == nil {
+		w, h = termbox.Size()
+		termbox.Close()
 	}
-	w, h := termbox.Size()
-	termbox.Close()
 
 	atty := isatty.IsTerminal(os.Stdout.Fd())
 


### PR DESCRIPTION
I'd like to debug in VS Code, but termbox fails to init in that environment for some reason. Since all we want is the size, how about if we fall back to a reasonable default (80x25) in that case?