### PR TITLE
Add -n as an alias for -namespace

### DIFF
--- a/cmd/src/campaigns_common.go
+++ b/cmd/src/campaigns_common.go
@@ -68,6 +68,8 @@ func newCampaignsApplyFlags(flagSet *flag.FlagSet, cacheDir string) *campaignsAp
 		&caf.namespace, "namespace", "",
 		"The user of organization namespace to place the campaign within.",
 	)
+	flagSet.StringVar(&caf.namespace, "n", "", "Alias for -namespace.")
+
 	flagSet.IntVar(
 		&caf.parallelism, "j", 0,
 		"The maximum number of parallel jobs. (Default: GOMAXPROCS.)",


### PR DESCRIPTION
-namespace is quite long and I've wished for a shorter version multiple
times now.

Apparently, though, introducing an alias can be controversial if all you
have is single-dash flags like `-namespace` (vs. `--namespace`), since
`-namespace` could then be interpreted as `-n -a -m -e ...` etc.

Not sure whether that's an _actual_ concern though, since we do have
single-letter flags already (`-v` and `-j`, for example).