### PR TITLE
Show progress bar when downloading Docker images

### DIFF
--- a/cmd/src/campaigns_common.go
+++ b/cmd/src/campaigns_common.go
@@ -162,6 +162,18 @@ func campaignsExecute(ctx context.Context, out *output.Output, svc *campaigns.Se
 	}
 	campaignsCompletePending(pending, "Resolving namespace")
 
+	imageProgress := out.Progress([]output.ProgressBar{{
+		Label: "Preparing container images",
+		Max:   float64(len(campaignSpec.Steps)),
+	}}, nil)
+	err = svc.SetDockerImages(ctx, campaignSpec, func(step int) {
+		imageProgress.SetValue(0, float64(step))
+	})
+	if err != nil {
+		return "", "", err
+	}
+	imageProgress.Complete()
+
 	var progress output.Progress
 	specs, err := svc.ExecuteCampaignSpec(ctx, executor, campaignSpec, func(statuses []*campaigns.TaskStatus) {
 		if progress == nil {


### PR DESCRIPTION
Not sure whether that fits your vision for how you want to show progress, @LawnGnome, but since the image pulling should be done once for all steps and not for each task/repository, I think it makes sense to pull it out.

Also tried to follow your convention of not mixing `output` into the `Service` but providing a progress callback.

### Demo GIF

This uses some large images, so don't be surprised that it takes so long.

![screenshot_2020-08-28_13 45 10](https://user-images.githubusercontent.com/1185253/91557602-0be02980-e935-11ea-95ea-3a7faf2ecaac.gif)
