### PR TITLE
campaigns: allow partial publishing of changesets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to `src-cli` are documented in this file.
 
 ### Added
 
+- The `published` flag in campaign specs may now be an array, which allows only specific changesets within a campaign to be published based on the repository name. [#294](https://github.com/sourcegraph/src-cli/pull/294)
+
 ### Changed
 
 - Error reporting by `src campaign [preview|apply]` has been improved and now includes more information about which step failed in which repository. [#325](https://github.com/sourcegraph/src-cli/pull/325)

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/olekukonko/tablewriter v0.0.4 // indirect
 	github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4
 	github.com/pkg/errors v0.9.1
-	github.com/sourcegraph/campaignutils v0.0.0-20200930010549-508f59a6ab8f
+	github.com/sourcegraph/campaignutils v0.0.0-20200930165749-a8777d33a817
 	github.com/sourcegraph/codeintelutils v0.0.0-20200824140252-1db3aed5cf58
 	github.com/sourcegraph/go-diff v0.6.0
 	github.com/sourcegraph/jsonx v0.0.0-20200629203448-1a936bd500cf

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/olekukonko/tablewriter v0.0.4 // indirect
 	github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4
 	github.com/pkg/errors v0.9.1
-	github.com/sourcegraph/campaignutils v0.0.0-20200930004700-7633103cfc7f
+	github.com/sourcegraph/campaignutils v0.0.0-20200930010549-508f59a6ab8f
 	github.com/sourcegraph/codeintelutils v0.0.0-20200824140252-1db3aed5cf58
 	github.com/sourcegraph/go-diff v0.6.0
 	github.com/sourcegraph/jsonx v0.0.0-20200629203448-1a936bd500cf

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/olekukonko/tablewriter v0.0.4 // indirect
 	github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4
 	github.com/pkg/errors v0.9.1
+	github.com/sourcegraph/campaignutils v0.0.0-20200930004700-7633103cfc7f
 	github.com/sourcegraph/codeintelutils v0.0.0-20200824140252-1db3aed5cf58
 	github.com/sourcegraph/go-diff v0.6.0
 	github.com/sourcegraph/jsonx v0.0.0-20200629203448-1a936bd500cf

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/efritz/pentimento v0.0.0-20190429011147-ade47d831101 h1:RylpU+KNJJNEJIk3o8gZ70uPTlutxaYnikKNPko39LA=
 github.com/efritz/pentimento v0.0.0-20190429011147-ade47d831101/go.mod h1:5ALWO82UZwfAtNRUtwzsWimcrcuYzyieTyyXOXrP6EQ=
+github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
+github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/google/go-cmp v0.4.1 h1:/exdXoGamhu5ONeUJH0deniYLWYvQwW66yvlfiiKTu0=
 github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
@@ -35,6 +37,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/shurcooL/go v0.0.0-20180423040247-9e1955d9fb6e/go.mod h1:TDJrrUr11Vxrven61rcy3hJMUqaf/CLWYhHNPmT14Lk=
 github.com/shurcooL/go-goon v0.0.0-20170922171312-37c2f522c041/go.mod h1:N5mDOmsrJOB+vfqUK+7DmDyjhSLIIBnXo9lvZJj3MWQ=
+github.com/sourcegraph/campaignutils v0.0.0-20200930004700-7633103cfc7f h1:99HEuBftdnPSmb8ykMm+PBQE8tOwXqasTLYfdknZ72I=
+github.com/sourcegraph/campaignutils v0.0.0-20200930004700-7633103cfc7f/go.mod h1:5P8k8KlKz78RZJ2EFk9k9ln/j/twj28z/+BvO5hHZJ8=
 github.com/sourcegraph/codeintelutils v0.0.0-20200824140252-1db3aed5cf58 h1:Ps+U1xoZP+Zoph39YfRB6Q846ghO8pgrAgp0MiObvPs=
 github.com/sourcegraph/codeintelutils v0.0.0-20200824140252-1db3aed5cf58/go.mod h1:HplI8gRslTrTUUsSYwu28hSOderix7m5dHNca7xBzeo=
 github.com/sourcegraph/go-diff v0.6.0 h1:WbN9e/jD8ujU+o0vd9IFN5AEwtfB0rn/zM/AANaClqQ=

--- a/go.sum
+++ b/go.sum
@@ -37,10 +37,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/shurcooL/go v0.0.0-20180423040247-9e1955d9fb6e/go.mod h1:TDJrrUr11Vxrven61rcy3hJMUqaf/CLWYhHNPmT14Lk=
 github.com/shurcooL/go-goon v0.0.0-20170922171312-37c2f522c041/go.mod h1:N5mDOmsrJOB+vfqUK+7DmDyjhSLIIBnXo9lvZJj3MWQ=
-github.com/sourcegraph/campaignutils v0.0.0-20200930004700-7633103cfc7f h1:99HEuBftdnPSmb8ykMm+PBQE8tOwXqasTLYfdknZ72I=
-github.com/sourcegraph/campaignutils v0.0.0-20200930004700-7633103cfc7f/go.mod h1:5P8k8KlKz78RZJ2EFk9k9ln/j/twj28z/+BvO5hHZJ8=
-github.com/sourcegraph/campaignutils v0.0.0-20200930010549-508f59a6ab8f h1:VOEPaxP5OzsOHfZx7Y1Kvz+D/1IQld8CUOY2S+KCHtk=
-github.com/sourcegraph/campaignutils v0.0.0-20200930010549-508f59a6ab8f/go.mod h1:5P8k8KlKz78RZJ2EFk9k9ln/j/twj28z/+BvO5hHZJ8=
+github.com/sourcegraph/campaignutils v0.0.0-20200930165749-a8777d33a817 h1:mdFA7I2rnfl8AV0m8iMb4uoQb3GRdjRsgRMREoNGEk4=
+github.com/sourcegraph/campaignutils v0.0.0-20200930165749-a8777d33a817/go.mod h1:5P8k8KlKz78RZJ2EFk9k9ln/j/twj28z/+BvO5hHZJ8=
 github.com/sourcegraph/codeintelutils v0.0.0-20200824140252-1db3aed5cf58 h1:Ps+U1xoZP+Zoph39YfRB6Q846ghO8pgrAgp0MiObvPs=
 github.com/sourcegraph/codeintelutils v0.0.0-20200824140252-1db3aed5cf58/go.mod h1:HplI8gRslTrTUUsSYwu28hSOderix7m5dHNca7xBzeo=
 github.com/sourcegraph/go-diff v0.6.0 h1:WbN9e/jD8ujU+o0vd9IFN5AEwtfB0rn/zM/AANaClqQ=

--- a/go.sum
+++ b/go.sum
@@ -39,6 +39,8 @@ github.com/shurcooL/go v0.0.0-20180423040247-9e1955d9fb6e/go.mod h1:TDJrrUr11Vxr
 github.com/shurcooL/go-goon v0.0.0-20170922171312-37c2f522c041/go.mod h1:N5mDOmsrJOB+vfqUK+7DmDyjhSLIIBnXo9lvZJj3MWQ=
 github.com/sourcegraph/campaignutils v0.0.0-20200930004700-7633103cfc7f h1:99HEuBftdnPSmb8ykMm+PBQE8tOwXqasTLYfdknZ72I=
 github.com/sourcegraph/campaignutils v0.0.0-20200930004700-7633103cfc7f/go.mod h1:5P8k8KlKz78RZJ2EFk9k9ln/j/twj28z/+BvO5hHZJ8=
+github.com/sourcegraph/campaignutils v0.0.0-20200930010549-508f59a6ab8f h1:VOEPaxP5OzsOHfZx7Y1Kvz+D/1IQld8CUOY2S+KCHtk=
+github.com/sourcegraph/campaignutils v0.0.0-20200930010549-508f59a6ab8f/go.mod h1:5P8k8KlKz78RZJ2EFk9k9ln/j/twj28z/+BvO5hHZJ8=
 github.com/sourcegraph/codeintelutils v0.0.0-20200824140252-1db3aed5cf58 h1:Ps+U1xoZP+Zoph39YfRB6Q846ghO8pgrAgp0MiObvPs=
 github.com/sourcegraph/codeintelutils v0.0.0-20200824140252-1db3aed5cf58/go.mod h1:HplI8gRslTrTUUsSYwu28hSOderix7m5dHNca7xBzeo=
 github.com/sourcegraph/go-diff v0.6.0 h1:WbN9e/jD8ujU+o0vd9IFN5AEwtfB0rn/zM/AANaClqQ=

--- a/internal/campaigns/campaign_spec.go
+++ b/internal/campaigns/campaign_spec.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
-	"github.com/sourcegraph/campaignutils/override"
+	"github.com/sourcegraph/campaignutils/overridable"
 	"github.com/sourcegraph/src-cli/schema"
 	"github.com/xeipuuv/gojsonschema"
 	"gopkg.in/yaml.v2"
@@ -41,7 +41,7 @@ type ChangesetTemplate struct {
 	Body      string                       `json:"body,omitempty" yaml:"body"`
 	Branch    string                       `json:"branch,omitempty" yaml:"branch"`
 	Commit    ExpandedGitCommitDescription `json:"commit,omitempty" yaml:"commit"`
-	Published override.Bool                `json:"published" yaml:"published"`
+	Published overridable.Bool             `json:"published" yaml:"published"`
 }
 
 type GitCommitAuthor struct {

--- a/internal/campaigns/campaign_spec.go
+++ b/internal/campaigns/campaign_spec.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
+	"github.com/sourcegraph/campaignutils/override"
 	"github.com/sourcegraph/src-cli/schema"
 	"github.com/xeipuuv/gojsonschema"
 	"gopkg.in/yaml.v2"
@@ -40,7 +41,7 @@ type ChangesetTemplate struct {
 	Body      string                       `json:"body,omitempty" yaml:"body"`
 	Branch    string                       `json:"branch,omitempty" yaml:"branch"`
 	Commit    ExpandedGitCommitDescription `json:"commit,omitempty" yaml:"commit"`
-	Published bool                         `json:"published" yaml:"published"`
+	Published override.Bool                `json:"published" yaml:"published"`
 }
 
 type GitCommitAuthor struct {

--- a/internal/campaigns/executor.go
+++ b/internal/campaigns/executor.go
@@ -294,6 +294,8 @@ func reachedTimeout(cmdCtx context.Context, err error) bool {
 }
 
 func createChangesetSpec(task *Task, diff string) *ChangesetSpec {
+	repo := task.Repository.Name
+
 	var authorName string
 	var authorEmail string
 
@@ -323,7 +325,7 @@ func createChangesetSpec(task *Task, diff string) *ChangesetSpec {
 					Diff:        string(diff),
 				},
 			},
-			Published: task.Template.Published,
+			Published: task.Template.Published.Value(repo),
 		},
 	}
 }

--- a/schema/campaign_spec.schema.json
+++ b/schema/campaign_spec.schema.json
@@ -153,9 +153,24 @@
           }
         },
         "published": {
-          "type": "boolean",
           "description": "Whether to publish the changeset. An unpublished changeset can be previewed on Sourcegraph by any person who can view the campaign, but its commit, branch, and pull request aren't created on the code host. A published changeset results in a commit, branch, and pull request being created on the code host.",
-          "$comment": "TODO(sqs): Come up with a way to specify that only a subset of changesets should be published. For example, making `published` an array with some include/exclude syntax items."
+          "oneOf": [
+            {
+              "type": "boolean",
+              "description": "A single flag to control the publishing state for the entire campaign."
+            },
+            {
+              "type": "array",
+              "description": "A list of repository patterns to match. In the event multiple patterns match, the last matching pattern in the list will be used.",
+              "items": {
+                "type": "object",
+                "description": "An object with one field: the key is the glob pattern to match against repository names; the value will be used as the published flag for matching repositories.",
+                "additionalProperties": { "type": "boolean" },
+                "minProperties": 1,
+                "maxProperties": 1
+              }
+            }
+          ]
         }
       }
     }

--- a/schema/campaign_spec.schema.json
+++ b/schema/campaign_spec.schema.json
@@ -161,7 +161,7 @@
             },
             {
               "type": "array",
-              "description": "A list of repository patterns to match. In the event multiple patterns match, the last matching pattern in the list will be used.",
+              "description": "A list of glob patterns to match repository names. In the event multiple patterns match, the last matching pattern in the list will be used.",
               "items": {
                 "type": "object",
                 "description": "An object with one field: the key is the glob pattern to match against repository names; the value will be used as the published flag for matching repositories.",

--- a/schema/campaign_spec_stringdata.go
+++ b/schema/campaign_spec_stringdata.go
@@ -166,7 +166,7 @@ const CampaignSpecJSON = `{
             },
             {
               "type": "array",
-              "description": "A list of repository patterns to match. In the event multiple patterns match, the last matching pattern in the list will be used.",
+              "description": "A list of glob patterns to match repository names. In the event multiple patterns match, the last matching pattern in the list will be used.",
               "items": {
                 "type": "object",
                 "description": "An object with one field: the key is the glob pattern to match against repository names; the value will be used as the published flag for matching repositories.",

--- a/schema/campaign_spec_stringdata.go
+++ b/schema/campaign_spec_stringdata.go
@@ -158,9 +158,24 @@ const CampaignSpecJSON = `{
           }
         },
         "published": {
-          "type": "boolean",
           "description": "Whether to publish the changeset. An unpublished changeset can be previewed on Sourcegraph by any person who can view the campaign, but its commit, branch, and pull request aren't created on the code host. A published changeset results in a commit, branch, and pull request being created on the code host.",
-          "$comment": "TODO(sqs): Come up with a way to specify that only a subset of changesets should be published. For example, making ` + "`" + `published` + "`" + ` an array with some include/exclude syntax items."
+          "oneOf": [
+            {
+              "type": "boolean",
+              "description": "A single flag to control the publishing state for the entire campaign."
+            },
+            {
+              "type": "array",
+              "description": "A list of repository patterns to match. In the event multiple patterns match, the last matching pattern in the list will be used.",
+              "items": {
+                "type": "object",
+                "description": "An object with one field: the key is the glob pattern to match against repository names; the value will be used as the published flag for matching repositories.",
+                "additionalProperties": { "type": "boolean" },
+                "minProperties": 1,
+                "maxProperties": 1
+              }
+            }
+          ]
         }
       }
     }


### PR DESCRIPTION
This is a prototype of the option being presented in [RFC 228](https://docs.google.com/document/d/1A-5cbYGz1p1UB1eAFsIgpK5XDkvS7ZNAVKMdtBm_WY0/edit?usp=sharing). It needs to be used in conjunction with sourcegraph/sourcegraph#13476.

Note that this PR adds a dependency on https://github.com/LawnGnome/campaign-schema for schema-related code shared between this PR and sourcegraph/sourcegraph#13476; my intention is to move this to https://github.com/sourcegraph/campaignutils if accepted.

An example of the type of campaign you could run with this is:

```yaml
name: hello-world
description: Add Hello World to READMEs
​
# Find all repositories that contain a README.md file.
on:
  - repositoriesMatchingQuery: file:README.md r:github.com/*
  - repositoriesMatchingQuery: file:README.md r:gitlab.sgdev.org
​
# In each repository, run this command. Each repository's resulting diff is captured.
steps:
  - run: echo Hello World | tee -a $(find -name README.md)
    container: alpine:3
​
# Describe the changeset (e.g., GitHub pull request) you want for each repository.
changesetTemplate:
  title:
    default: Hello World
    except:
      - github.com/sourcegraph/*: Hello Sourcegraph!
  body: My first campaign!
  branch: hello-world # Push the commit to this branch.
  commit:
    message: Append Hello World to all README.md files
  published:
    - github.com/LawnGnome/*: true
```