### PR TITLE
campaigns: allow user to set git commit author

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable changes to `src-cli` are documented in this file.
 
 ## Unreleased changes
 
+- Campaigns specs now include an optional `author` property. (If not included, `src campaigns` generates default values for author name and email.) `src campaigns` now includes the name and email in all changeset specs that it generates.
+
 ### Changed
 
 - The default branch for the `src-cli` project has been changed to `main`. [#262](https://github.com/sourcegraph/src-cli/pull/262)

--- a/internal/campaigns/campaign_spec.go
+++ b/internal/campaigns/campaign_spec.go
@@ -43,8 +43,14 @@ type ChangesetTemplate struct {
 	Published bool                         `json:"published" yaml:"published"`
 }
 
+type GitCommitAuthor struct {
+	Name  string `json:"name" yaml:"name"`
+	Email string `json:"email" yaml:"email"`
+}
+
 type ExpandedGitCommitDescription struct {
-	Message string `json:"message,omitempty" yaml:"message"`
+	Message string           `json:"message,omitempty" yaml:"message"`
+	Author  *GitCommitAuthor `json:"author,omitempty" yaml:"author"`
 }
 
 type ImportChangeset struct {

--- a/internal/campaigns/changeset_spec.go
+++ b/internal/campaigns/changeset_spec.go
@@ -26,6 +26,8 @@ type CreatedChangeset struct {
 }
 
 type GitCommitDescription struct {
-	Message string `json:"message"`
-	Diff    string `json:"diff"`
+	Message     string `json:"message"`
+	Diff        string `json:"diff"`
+	AuthorName  string `json:"authorName"`
+	AuthorEmail string `json:"authorEmail"`
 }

--- a/internal/campaigns/executor.go
+++ b/internal/campaigns/executor.go
@@ -255,6 +255,18 @@ func reachedTimeout(cmdCtx context.Context, err error) bool {
 }
 
 func createChangesetSpec(task *Task, diff string) *ChangesetSpec {
+	var authorName string
+	var authorEmail string
+
+	if task.Template.Commit.Author == nil {
+		// user did not provide author info, so use defaults
+		authorName = "Sourcegraph"
+		authorEmail = "campaigns@sourcegraph.com"
+	} else {
+		authorName = task.Template.Commit.Author.Name
+		authorEmail = task.Template.Commit.Author.Email
+	}
+
 	return &ChangesetSpec{
 		BaseRepository: task.Repository.ID,
 		CreatedChangeset: &CreatedChangeset{
@@ -266,8 +278,10 @@ func createChangesetSpec(task *Task, diff string) *ChangesetSpec {
 			Body:           task.Template.Body,
 			Commits: []GitCommitDescription{
 				{
-					Message: task.Template.Commit.Message,
-					Diff:    string(diff),
+					Message:     task.Template.Commit.Message,
+					AuthorName:  authorName,
+					AuthorEmail: authorEmail,
+					Diff:        string(diff),
 				},
 			},
 			Published: task.Template.Published,

--- a/schema/campaign_spec.schema.json
+++ b/schema/campaign_spec.schema.json
@@ -131,6 +131,24 @@
             "message": {
               "type": "string",
               "description": "The Git commit message."
+            },
+            "author": {
+              "title": "GitCommitAuthor",
+              "type": "object",
+              "description": "The author of the Git commit.",
+              "additionalProperties": false,
+              "required": ["name", "email"],
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "description": "The Git commit author name."
+                },
+                "email": {
+                  "type": "string",
+                  "format": "email",
+                  "description": "The Git commit author email."
+                }
+              }
             }
           }
         },

--- a/schema/campaign_spec_stringdata.go
+++ b/schema/campaign_spec_stringdata.go
@@ -37,9 +37,6 @@ const CampaignSpecJSON = `{
                 "type": "string",
                 "description": "A Sourcegraph search query that matches a set of repositories (and branches). If the query matches files, symbols, or some other object inside a repository, the object's repository is included.",
                 "examples": ["file:README.md"]
-              },
-              "changesetTemplate": {
-                "$ref": "#/definitions/changesetTemplate"
               }
             }
           },
@@ -118,24 +115,13 @@ const CampaignSpecJSON = `{
       }
     },
     "changesetTemplate": {
-      "$ref": "#/definitions/changesetTemplate"
-    }
-  },
-  "definitions": {
-    "changesetTemplate": {
       "type": "object",
       "description": "A template describing how to create (and update) changesets with the file changes produced by the command steps.",
       "additionalProperties": false,
       "required": ["title", "branch", "commit", "published"],
       "properties": {
-        "title": {
-          "type": "string",
-          "description": "The title of the changeset."
-        },
-        "body": {
-          "type": "string",
-          "description": "The body (description) of the changeset."
-        },
+        "title": { "type": "string", "description": "The title of the changeset." },
+        "body": { "type": "string", "description": "The body (description) of the changeset." },
         "branch": {
           "type": "string",
           "description": "The name of the Git branch to create or update on each repository with the changes."
@@ -150,6 +136,24 @@ const CampaignSpecJSON = `{
             "message": {
               "type": "string",
               "description": "The Git commit message."
+            },
+            "author": {
+              "title": "GitCommitAuthor",
+              "type": "object",
+              "description": "The author of the Git commit.",
+              "additionalProperties": false,
+              "required": ["name", "email"],
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "description": "The Git commit author name."
+                },
+                "email": {
+                  "type": "string",
+                  "format": "email",
+                  "description": "The Git commit author email."
+                }
+              }
             }
           }
         },


### PR DESCRIPTION
This is the src-cli side of the fix for [#12769](https://github.com/sourcegraph/sourcegraph/issues/12769). ([back-end PR](https://github.com/sourcegraph/sourcegraph/pull/13574))

It implements the first part of [RFC 229](https://docs.google.com/document/d/1kDkIFQK9hiezEJrG5TfoGvsBKFKF6B6eUcKejYoX2XI/edit#), so campaign specs can have changeset templates that now look like:

```
changesetTemplate:
  title: Hello World
  body: My first campaign
  branch: hello-world # Push the commit to this branch.
  commit:
    message: Append Hello World to all README.md files
    author:
      name: Chris Pine
      email: chrispine@sourcegraph.com
  published: true
```

Issues

- I don't know how to say "this version of src-cli goes with that version of the back-end".

Future work

- Consider: instead of just going with the default author, check for local git config and use that. (But does that behave in ways we don't like: if I create a campaign without specifying an author, then you modify the campaign spec on your machine and apply it... would it change the commit author? Would we want it to?)