### PR TITLE
Add visual step for resolving repositories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ All notable changes to `src-cli` are documented in this file.
 
 - Repositories without a default branch are skipped when applying/previewing a campaign spec. [#312](https://github.com/sourcegraph/src-cli/pull/312)
 - Log files produced when applying/previewing a campaign spec now have the `.log` file extension for easier opening. [#315](https://github.com/sourcegraph/src-cli/pull/315)
-- If the `repositoriesMatchingQuery:` query in a campaign spec yields repositories on unsupported code hosts the process is no longer aborted, but the repositories simply skipped. [#314](https://github.com/sourcegraph/src-cli/pull/314)
+- Campaign specs that apply to unsupported repositories will no longer generate an error. Instead, those repositories will be skipped by default and the campaign will be applied to the supported repositories only. [#314](https://github.com/sourcegraph/src-cli/pull/314)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to `src-cli` are documented in this file.
 
 - Repositories without a default branch are skipped when applying/previewing a campaign spec. [#312](https://github.com/sourcegraph/src-cli/pull/312)
 - Log files produced when applying/previewing a campaign spec now have the `.log` file extension for easier opening. [#315](https://github.com/sourcegraph/src-cli/pull/315)
+- If the `repositoriesMatchingQuery:` query in a campaign spec yields repositories on unsupported code hosts the process is no longer aborted, but the repositories simply skipped. [#314](https://github.com/sourcegraph/src-cli/pull/314)
 
 ### Fixed
 

--- a/cmd/src/campaigns_common.go
+++ b/cmd/src/campaigns_common.go
@@ -176,16 +176,16 @@ func campaignsExecute(ctx context.Context, out *output.Output, svc *campaigns.Se
 	}
 	imageProgress.Complete()
 
-	pending = out.Pending(output.Line("", campaignsPendingColor, "Resolving repositories"))
+	pending = campaignsCreatePending(out, "Resolving repositories")
 	repos, err := svc.ResolveRepositories(ctx, campaignSpec)
 	if err != nil {
 		if _, ok := err.(campaigns.UnsupportedRepoSet); ok {
-			pending.Complete(output.Line(campaignsSuccessEmoji, campaignsSuccessColor, "Resolved repositories. Found unsupported codehosts."))
+			campaignsCompletePending(pending, "Resolved repositories. Found unsupported codehosts.")
 		} else {
 			return "", "", errors.Wrap(err, "resolving repositories")
 		}
 	} else {
-		pending.Complete(output.Line(campaignsSuccessEmoji, campaignsSuccessColor, "Resolved repositories."))
+		campaignsCompletePending(pending, "Resolved repositories.")
 	}
 	var progress output.Progress
 	specs, err := svc.ExecuteCampaignSpec(ctx, repos, executor, campaignSpec, func(statuses []*campaigns.TaskStatus) {

--- a/internal/campaigns/errors.go
+++ b/internal/campaigns/errors.go
@@ -7,12 +7,12 @@ import (
 	"github.com/sourcegraph/src-cli/internal/campaigns/graphql"
 )
 
-// unsupportedRepoSet provides a set to manage repositories that are on
+// UnsupportedRepoSet provides a set to manage repositories that are on
 // unsupported code hosts. This type implements error to allow it to be
 // returned directly as an error value if needed.
-type unsupportedRepoSet map[*graphql.Repository]struct{}
+type UnsupportedRepoSet map[*graphql.Repository]struct{}
 
-func (e unsupportedRepoSet) Error() string {
+func (e UnsupportedRepoSet) Error() string {
 	repos := []string{}
 	typeSet := map[string]struct{}{}
 	for repo := range e {
@@ -32,10 +32,10 @@ func (e unsupportedRepoSet) Error() string {
 	)
 }
 
-func (e unsupportedRepoSet) appendRepo(repo *graphql.Repository) {
+func (e UnsupportedRepoSet) appendRepo(repo *graphql.Repository) {
 	e[repo] = struct{}{}
 }
 
-func (e unsupportedRepoSet) hasUnsupported() bool {
+func (e UnsupportedRepoSet) hasUnsupported() bool {
 	return len(e) > 0
 }

--- a/internal/campaigns/service.go
+++ b/internal/campaigns/service.go
@@ -164,12 +164,7 @@ func (svc *Service) SetDockerImages(ctx context.Context, spec *CampaignSpec, pro
 	return nil
 }
 
-func (svc *Service) ExecuteCampaignSpec(ctx context.Context, x Executor, spec *CampaignSpec, progress func([]*TaskStatus)) ([]*ChangesetSpec, error) {
-	repos, err := svc.ResolveRepositories(ctx, spec)
-	if err != nil {
-		return nil, errors.Wrap(err, "resolving repositories")
-	}
-
+func (svc *Service) ExecuteCampaignSpec(ctx context.Context, repos []*graphql.Repository, x Executor, spec *CampaignSpec, progress func([]*TaskStatus)) ([]*ChangesetSpec, error) {
 	statuses := make([]*TaskStatus, 0, len(repos))
 	for _, repo := range repos {
 		ts := x.AddTask(repo, spec.Steps, spec.ChangesetTemplate)
@@ -289,7 +284,7 @@ func (svc *Service) ResolveNamespace(ctx context.Context, namespace string) (str
 func (svc *Service) ResolveRepositories(ctx context.Context, spec *CampaignSpec) ([]*graphql.Repository, error) {
 	final := []*graphql.Repository{}
 	seen := map[string]struct{}{}
-	unsupported := unsupportedRepoSet{}
+	unsupported := UnsupportedRepoSet{}
 
 	// TODO: this could be trivially parallelised in the future.
 	for _, on := range spec.On {
@@ -303,21 +298,23 @@ func (svc *Service) ResolveRepositories(ctx context.Context, spec *CampaignSpec)
 				if repo.DefaultBranch == nil {
 					continue
 				}
+				seen[repo.ID] = struct{}{}
 				switch st := strings.ToLower(repo.ExternalRepository.ServiceType); st {
 				case "github", "gitlab", "bitbucketserver":
-
 				default:
 					unsupported.appendRepo(repo)
+					if !svc.allowUnsupported {
+						continue
+					}
 				}
 
-				seen[repo.ID] = struct{}{}
 				final = append(final, repo)
 			}
 		}
 	}
 
 	if unsupported.hasUnsupported() && !svc.allowUnsupported {
-		return nil, unsupported
+		return final, unsupported
 	}
 
 	return final, nil


### PR DESCRIPTION
Also fixes unsupported repositories aborting the workflow. We now simply skip those and let the user know.

Since this step can take some time, I was always confused what src-cli does. It resolves repositories apparently.

Closes https://github.com/sourcegraph/src-cli/issues/310