### PR TITLE
Properly have .log file extension for temp log files

### DIFF
--- a/internal/campaigns/log.go
+++ b/internal/campaigns/log.go
@@ -70,7 +70,7 @@ type TaskLogger struct {
 func newTaskLogger(task *Task, keep bool) (*TaskLogger, error) {
 	prefix := "changeset-" + task.Repository.Slug()
 
-	f, err := ioutil.TempFile(tempDirPrefix, prefix+".log")
+	f, err := ioutil.TempFile(tempDirPrefix, prefix+".*.log")
 	if err != nil {
 		return nil, errors.Wrapf(err, "creating temporary file with prefix %q", prefix)
 	}


### PR DESCRIPTION
Closes #308 

before, the file ending wouldn't be `.log`, causing some terminals to not know how to open that file when clicking on it (hence, always have to select my fav editor, because the ending will always be different and cannot be remembered.)

Before and after:

![image](https://user-images.githubusercontent.com/19534377/92946549-1cc18c80-f457-11ea-8402-345771fd6889.png)
