### PR TITLE
src login command to help users configure authentication w/access token

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,26 +63,36 @@ chmod +x /usr/local/bin/src
 
 See [Sourcegraph CLI for Windows](WINDOWS.md).
 
-## Setup with your Sourcegraph instance
+## Log into your Sourcegraph instance
 
-### Via environment variables
+Run <code><strong>src login <i>SOURCEGRAPH-URL</i></strong></code> to authenticate `src` to access your Sourcegraph instance with your user credentials.
 
-Point `src` to your instance and access token using environment variables:
+<blockquote>
+
+**Examples**
+`src login https://sourcegraph.example.com`
+`src login https://sourcegraph.com`
+
+</blockquote>
+
+`src` consults the following environment variables:
+
+- `SRC_ENDPOINT`: the URL to your Sourcegraph instance (such as `https://sourcegraph.example.com`)
+- `SRC_ACCESS_TOKEN`: your Sourcegraph access token (on your Sourcegraph instance, click your user menu in the top right, then select **Settings > Access tokens** to create one)
+
+For convenience, you can export these environment variables in your shell profile. You can also inline them in a single command with:
 
 ```sh
-SRC_ENDPOINT=https://sourcegraph.example.com SRC_ACCESS_TOKEN="secret" src search 'foobar'
+SRC_ENDPOINT=https://sourcegraph.example.com SRC_ACCESS_TOKEN=my-token src search 'foo'
 ```
 
-Sourcegraph behind a custom auth proxy? See [auth proxy configuration](./AUTH_PROXY.md) docs.
-
-### Where to get an access token
-
-Visit your Sourcegraph instance (or https://sourcegraph.com), click your username in the top right to open the user menu, select **Settings**, and then select **Access tokens** in the left hand menu.
+Is your Sourcegraph instance behind a custom auth proxy? See [auth proxy configuration](./AUTH_PROXY.md) docs.
 
 ## Usage
 
 `src` provides different subcommands to interact with different parts of Sourcegraph:
 
+ - `src login` - authenticate to a Sourcegraph instance with your user credentials
  - `src search` - perform searches and get results in your terminal or as JSON
  - `src actions` - run [campaign actions](https://docs.sourcegraph.com/user/campaigns/actions) to generate patch sets
  - `src api` - run Sourcegraph GraphQL API requests

--- a/cmd/src/login.go
+++ b/cmd/src/login.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"strings"
+)
+
+func init() {
+	usage := `'src login' helps you authenticate 'src' to access a Sourcegraph instance with your user credentials.
+
+Usage:
+
+    src login SOURCEGRAPH_URL
+
+Examples:
+
+  Authenticate to a Sourcegraph instance at https://sourcegraph.example.com:
+
+    $ src login https://sourcegraph.example.com
+
+  Authenticate to Sourcegraph.com:
+
+    $ src login https://sourcegraph.com
+`
+
+	flagSet := flag.NewFlagSet("login", flag.ExitOnError)
+	usageFunc := func() {
+		fmt.Fprintln(flag.CommandLine.Output(), usage)
+	}
+
+	handler := func(args []string) error {
+		if err := flagSet.Parse(args); err != nil {
+			return err
+		}
+		if len(args) != 1 {
+			return &usageError{errors.New("expected exactly one argument: the Sourcegraph URL")}
+		}
+		endpointArg := args[0]
+		return loginCmd(context.Background(), cfg, endpointArg, os.Stdout)
+	}
+
+	commands = append(commands, &command{
+		flagSet:   flagSet,
+		handler:   handler,
+		usageFunc: usageFunc,
+	})
+}
+
+var exitCode1 = &exitCodeError{exitCode: 1}
+
+func loginCmd(ctx context.Context, cfg *config, endpointArg string, out io.Writer) error {
+	endpointArg = cleanEndpoint(endpointArg)
+
+	printProblem := func(problem string) {
+		fmt.Fprintf(out, "❌ Problem: %s\n", problem)
+	}
+
+	createAccessTokenMessage := fmt.Sprintf("\n"+`🛠  To fix: Create an access token at %s/user/settings/tokens, then set the following environment variables:
+
+   SRC_ENDPOINT=%s
+   SRC_ACCESS_TOKEN=(the access token you just created)
+
+   To verify that it's working, run this command again.
+`, endpointArg, endpointArg)
+
+	if cfg.ConfigFilePath != "" {
+		fmt.Fprintln(out)
+		fmt.Fprintf(out, "⚠️  Warning: Configuring src with a JSON file is deprecated. Please migrate to using the env vars SRC_ENDPOINT and SRC_ACCESS_TOKEN instead, and then remove %s. See https://github.com/sourcegraph/src-cli#readme for more information.\n", cfg.ConfigFilePath)
+	}
+
+	noToken := cfg.AccessToken == ""
+	endpointConflict := endpointArg != cfg.Endpoint
+	if noToken || endpointConflict {
+		fmt.Fprintln(out)
+		switch {
+		case noToken:
+			printProblem("No access token is configured.")
+		case endpointConflict:
+			printProblem(fmt.Sprintf("The configured endpoint is %s, not %s.", cfg.Endpoint, endpointArg))
+		}
+		fmt.Fprintln(out, createAccessTokenMessage)
+		return exitCode1
+	}
+
+	// See if the user is already authenticated.
+	query := `query CurrentUser { currentUser { username } }`
+	var result struct {
+		CurrentUser *struct{ Username string }
+	}
+	client := cfg.apiClient(nil, ioutil.Discard)
+	if _, err := client.NewRequest(query, nil).Do(ctx, &result); err != nil {
+		if strings.HasPrefix(err.Error(), "error: 401 Unauthorized") || strings.HasPrefix(err.Error(), "error: 403 Forbidden") {
+			printProblem("Invalid access token.")
+		} else {
+			printProblem(fmt.Sprintf("Error communicating with %s: %s", endpointArg, err))
+		}
+		fmt.Fprintln(out, createAccessTokenMessage)
+		fmt.Fprintln(out, "   (If you need to supply custom HTTP request headers, see information about SRC_HEADER_* env vars at https://github.com/sourcegraph/src-cli/blob/main/AUTH_PROXY.md.)")
+		return exitCode1
+	}
+
+	if result.CurrentUser == nil {
+		// This should never happen; we verified there is an access token, so there should always be
+		// a user.
+		printProblem(fmt.Sprintf("Unable to determine user on %s.", endpointArg))
+		return exitCode1
+	}
+	fmt.Fprintln(out)
+	fmt.Fprintf(out, "✔️  Authenticated as %s on %s\n", result.CurrentUser.Username, endpointArg)
+	fmt.Fprintln(out)
+	return nil
+}

--- a/cmd/src/login_test.go
+++ b/cmd/src/login_test.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestLogin(t *testing.T) {
+	check := func(t *testing.T, cfg *config, endpointArg string) (output string, err error) {
+		t.Helper()
+
+		var out bytes.Buffer
+		err = loginCmd(context.Background(), cfg, endpointArg, &out)
+		return strings.TrimSpace(out.String()), err
+	}
+
+	t.Run("different endpoint in config vs. arg", func(t *testing.T) {
+		out, err := check(t, &config{Endpoint: "https://example.com"}, "https://sourcegraph.example.com")
+		if err != exitCode1 {
+			t.Fatal(err)
+		}
+		wantOut := "❌ Problem: No access token is configured.\n\n🛠  To fix: Create an access token at https://sourcegraph.example.com/user/settings/tokens, then set the following environment variables:\n\n   SRC_ENDPOINT=https://sourcegraph.example.com\n   SRC_ACCESS_TOKEN=(the access token you just created)\n\n   To verify that it's working, run this command again."
+		if out != wantOut {
+			t.Errorf("got output %q, want %q", out, wantOut)
+		}
+	})
+
+	t.Run("no access token", func(t *testing.T) {
+		out, err := check(t, &config{Endpoint: "https://example.com"}, "https://sourcegraph.example.com")
+		if err != exitCode1 {
+			t.Fatal(err)
+		}
+		wantOut := "❌ Problem: No access token is configured.\n\n🛠  To fix: Create an access token at https://sourcegraph.example.com/user/settings/tokens, then set the following environment variables:\n\n   SRC_ENDPOINT=https://sourcegraph.example.com\n   SRC_ACCESS_TOKEN=(the access token you just created)\n\n   To verify that it's working, run this command again."
+		if out != wantOut {
+			t.Errorf("got output %q, want %q", out, wantOut)
+		}
+	})
+
+	t.Run("warning when using config file", func(t *testing.T) {
+		out, err := check(t, &config{Endpoint: "https://example.com", ConfigFilePath: "f"}, "https://example.com")
+		if err != exitCode1 {
+			t.Fatal(err)
+		}
+		wantOut := "⚠️  Warning: Configuring src with a JSON file is deprecated. Please migrate to using the env vars SRC_ENDPOINT and SRC_ACCESS_TOKEN instead, and then remove f. See https://github.com/sourcegraph/src-cli#readme for more information.\n\n❌ Problem: No access token is configured.\n\n🛠  To fix: Create an access token at https://example.com/user/settings/tokens, then set the following environment variables:\n\n   SRC_ENDPOINT=https://example.com\n   SRC_ACCESS_TOKEN=(the access token you just created)\n\n   To verify that it's working, run this command again."
+		if out != wantOut {
+			t.Errorf("got output %q, want %q", out, wantOut)
+		}
+	})
+
+	t.Run("invalid access token", func(t *testing.T) {
+		// Dummy HTTP server to return HTTP 401/403.
+		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "", http.StatusUnauthorized)
+		}))
+		defer s.Close()
+
+		endpoint := s.URL
+		out, err := check(t, &config{Endpoint: endpoint, AccessToken: "x"}, endpoint)
+		if err != exitCode1 {
+			t.Fatal(err)
+		}
+		wantOut := "❌ Problem: Invalid access token.\n\n🛠  To fix: Create an access token at $ENDPOINT/user/settings/tokens, then set the following environment variables:\n\n   SRC_ENDPOINT=$ENDPOINT\n   SRC_ACCESS_TOKEN=(the access token you just created)\n\n   To verify that it's working, run this command again.\n\n   (If you need to supply custom HTTP request headers, see information about SRC_HEADER_* env vars at https://github.com/sourcegraph/src-cli/blob/main/AUTH_PROXY.md.)"
+		wantOut = strings.Replace(wantOut, "$ENDPOINT", endpoint, -1)
+		if out != wantOut {
+			t.Errorf("got output %q, want %q", out, wantOut)
+		}
+	})
+
+	t.Run("valid", func(t *testing.T) {
+		// Dummy HTTP server to return JSON response with currentUser.
+		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprintln(w, `{"data":{"currentUser":{"username":"alice"}}}`)
+		}))
+		defer s.Close()
+
+		endpoint := s.URL
+		out, err := check(t, &config{Endpoint: endpoint, AccessToken: "x"}, endpoint)
+		if err != nil {
+			t.Fatal(err)
+		}
+		wantOut := "✔️  Authenticated as alice on $ENDPOINT"
+		wantOut = strings.Replace(wantOut, "$ENDPOINT", endpoint, -1)
+		if out != wantOut {
+			t.Errorf("got output %q, want %q", out, wantOut)
+		}
+	})
+}

--- a/cmd/src/main_test.go
+++ b/cmd/src/main_test.go
@@ -154,6 +154,13 @@ func TestReadConfig(t *testing.T) {
 			setEnv("SRC_ACCESS_TOKEN", test.envToken)
 			setEnv("SRC_ENDPOINT", test.envEndpoint)
 
+			tmpDir, err := ioutil.TempDir("", "")
+			if err != nil {
+				t.Fatal(err)
+			}
+			testHomeDir = tmpDir
+			t.Cleanup(func() { os.RemoveAll(tmpDir) })
+
 			if test.flagEndpoint != "" {
 				val := test.flagEndpoint
 				endpoint = &val
@@ -168,11 +175,6 @@ func TestReadConfig(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				tmpDir, err := ioutil.TempDir("", "")
-				if err != nil {
-					t.Fatal(err)
-				}
-				t.Cleanup(func() { os.RemoveAll(tmpDir) })
 				filePath := filepath.Join(tmpDir, "config.json")
 				err = ioutil.WriteFile(filePath, data, 0600)
 				if err != nil {
@@ -180,11 +182,11 @@ func TestReadConfig(t *testing.T) {
 				}
 				*configPath = filePath
 			}
-      
+
 			if err := os.Setenv("SRC_HEADER_FOO", test.envFooHeader); err != nil {
 				t.Fatal(err)
 			}
-      
+
 			config, err := readConfig()
 			if diff := cmp.Diff(test.want, config); diff != "" {
 				t.Errorf("config: %v", diff)

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -187,7 +187,7 @@ func (r *request) do(ctx context.Context, result interface{}) (bool, error) {
 	if resp.StatusCode != http.StatusOK {
 		if resp.StatusCode == http.StatusUnauthorized && isatty.IsCygwinTerminal(os.Stdout.Fd()) {
 			fmt.Println("You may need to specify or update your access token to use this endpoint.")
-			fmt.Println("See https://github.com/sourcegraph/src-cli#authentication")
+			fmt.Println("See https://github.com/sourcegraph/src-cli#readme")
 			fmt.Println("")
 		}
 		body, err := ioutil.ReadAll(resp.Body)


### PR DESCRIPTION
You can run `src login https://sourcegraph.example.com` to verify that your `src` is authenticated to access that Sourcegraph instance. If not, it'll show you friendly steps to help you get it set up.

This will simplify all of our docs and in-product text that relies on users using the CLI. The steps to get them to the right state will be just:

1. Install the Sourcegraph CLI (`src`) at https://github.com/sourcegraph/src-cli [or link to releases]
1. Run `src login SOURCEGRAPH_URL` [and we can even fill in `SOURCEGRAPH_URL` in in-product text]

Here is a screenshot of what it looks like in various states:

![image](https://user-images.githubusercontent.com/1976/93046268-41139980-f60e-11ea-98e9-5e3ace2b7160.png)
![image](https://user-images.githubusercontent.com/1976/93164388-37516b00-f6ce-11ea-946d-995a6de1a374.png)

README section:

![image](https://user-images.githubusercontent.com/1976/93164790-3ff67100-f6cf-11ea-92b3-674161c508d7.png)

