### PR TITLE
Allow setting temp dir used by campaigns through flag/env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to `src-cli` are documented in this file.
 ### Added
 
 - Campaigns specs now include an optional `author` property. (If not included, `src campaigns` generates default values for author name and email.) `src campaigns` now includes the name and email in all changeset specs that it generates.
+- The campaigns temp directory can now be overwritten by using the `-tmp` flag with `src campaigns [apply|preview]` or by setting `SRC_CAMPAIGNS_TMP_DIR`. The directory is used to, for example, store log files and unzipped repository archives when executing campaign specs.
 
 ### Changed
 

--- a/cmd/src/campaigns_apply.go
+++ b/cmd/src/campaigns_apply.go
@@ -25,7 +25,7 @@ Examples:
 `
 
 	flagSet := flag.NewFlagSet("apply", flag.ExitOnError)
-	flags := newCampaignsApplyFlags(flagSet, campaignsDefaultCacheDir())
+	flags := newCampaignsApplyFlags(flagSet, campaignsDefaultCacheDir(), campaignsDefaultTempDirPrefix())
 
 	doApply := func(ctx context.Context, out *output.Output, svc *campaigns.Service, flags *campaignsApplyFlags) error {
 		id, _, err := campaignsExecute(ctx, out, svc, flags)

--- a/cmd/src/campaigns_common.go
+++ b/cmd/src/campaigns_common.go
@@ -112,11 +112,15 @@ func campaignsDefaultTempDirPrefix() string {
 	if p != "" {
 		return p
 	}
-	// We use an explicit prefix for our temp directories, because otherwise Go
-	// would use $TMPDIR, which is set to `/var/folders` per default on macOS. But
-	// Docker for Mac doesn't have `/var/folders` in its default set of shared
-	// folders, but it does have `/tmp` in there.
-	return "/tmp"
+	// On macOS, we use an explicit prefix for our temp directories, because
+	// otherwise Go would use $TMPDIR, which is set to `/var/folders` per
+	// default on macOS. But Docker for Mac doesn't have `/var/folders` in its
+	// default set of shared folders, but it does have `/tmp` in there.
+	if runtime.GOOS == "darwin" {
+		return "/tmp"
+
+	}
+	return os.TempDir()
 }
 
 func campaignsOpenFileFlag(flag *string) (io.ReadCloser, error) {

--- a/cmd/src/campaigns_common.go
+++ b/cmd/src/campaigns_common.go
@@ -59,7 +59,7 @@ func newCampaignsApplyFlags(flagSet *flag.FlagSet, cacheDir, tempDir string) *ca
 	)
 	flagSet.StringVar(
 		&caf.tempDir, "tmp", tempDir,
-		"Directory for storing temporary data, such as repository archives when executing campaign specs or log files. Default is /tmp. Can also be set with environment variable SRC_CAMPAIGNS_TMP_DIR.",
+		"Directory for storing temporary data, such as repository archives when executing campaign specs or log files. Default is /tmp. Can also be set with environment variable SRC_CAMPAIGNS_TMP_DIR; if both are set, this flag will be used and not the environment variable.",
 	)
 	flagSet.StringVar(
 		&caf.file, "f", "",

--- a/cmd/src/campaigns_common.go
+++ b/cmd/src/campaigns_common.go
@@ -59,7 +59,7 @@ func newCampaignsApplyFlags(flagSet *flag.FlagSet, cacheDir, tempDir string) *ca
 	)
 	flagSet.StringVar(
 		&caf.tempDir, "tmp", tempDir,
-		"Directory for storing temporary data, such as repository archives when executing campaign specs or log files. Default is /tmp. Can also be set with environment variable SRC_CAMPAIGNS_TMP_DIR. .",
+		"Directory for storing temporary data, such as repository archives when executing campaign specs or log files. Default is /tmp. Can also be set with environment variable SRC_CAMPAIGNS_TMP_DIR.",
 	)
 	flagSet.StringVar(
 		&caf.file, "f", "",

--- a/cmd/src/campaigns_common.go
+++ b/cmd/src/campaigns_common.go
@@ -27,6 +27,7 @@ type campaignsApplyFlags struct {
 	api              *api.Flags
 	apply            bool
 	cacheDir         string
+	tempDir          string
 	clearCache       bool
 	file             string
 	keep             bool
@@ -35,7 +36,7 @@ type campaignsApplyFlags struct {
 	timeout          time.Duration
 }
 
-func newCampaignsApplyFlags(flagSet *flag.FlagSet, cacheDir string) *campaignsApplyFlags {
+func newCampaignsApplyFlags(flagSet *flag.FlagSet, cacheDir, tempDir string) *campaignsApplyFlags {
 	caf := &campaignsApplyFlags{
 		api: api.NewFlags(flagSet),
 	}
@@ -55,6 +56,10 @@ func newCampaignsApplyFlags(flagSet *flag.FlagSet, cacheDir string) *campaignsAp
 	flagSet.BoolVar(
 		&caf.clearCache, "clear-cache", false,
 		"If true, clears the cache and executes all steps anew.",
+	)
+	flagSet.StringVar(
+		&caf.tempDir, "tmp", tempDir,
+		"Directory for storing temporary data, such as repository archives when executing campaign specs or log files. Default is /tmp. Can also be set with environment variable SRC_CAMPAIGNS_TMP_DIR. .",
 	)
 	flagSet.StringVar(
 		&caf.file, "f", "",
@@ -99,6 +104,21 @@ func campaignsDefaultCacheDir() string {
 	return path.Join(uc, "sourcegraph", "campaigns")
 }
 
+// campaignsDefaultTempDirPrefix returns the prefix to be passed to ioutil.TempFile. If the
+// environment variable SRC_CAMPAIGNS_TMP_DIR is set, that is used as the
+// prefix. Otherwise we use "/tmp".
+func campaignsDefaultTempDirPrefix() string {
+	p := os.Getenv("SRC_CAMPAIGNS_TMP_DIR")
+	if p != "" {
+		return p
+	}
+	// We use an explicit prefix for our temp directories, because otherwise Go
+	// would use $TMPDIR, which is set to `/var/folders` per default on macOS. But
+	// Docker for Mac doesn't have `/var/folders` in its default set of shared
+	// folders, but it does have `/tmp` in there.
+	return "/tmp"
+}
+
 func campaignsOpenFileFlag(flag *string) (io.ReadCloser, error) {
 	if flag == nil || *flag == "" || *flag == "-" {
 		return os.Stdin, nil
@@ -134,6 +154,7 @@ func campaignsExecute(ctx context.Context, out *output.Output, svc *campaigns.Se
 		ClearCache: flags.clearCache,
 		KeepLogs:   flags.keep,
 		Timeout:    flags.timeout,
+		TempDir:    flags.tempDir,
 	}
 	if flags.parallelism <= 0 {
 		opts.Parallelism = runtime.GOMAXPROCS(0)

--- a/cmd/src/campaigns_preview.go
+++ b/cmd/src/campaigns_preview.go
@@ -25,7 +25,7 @@ Examples:
 `
 
 	flagSet := flag.NewFlagSet("preview", flag.ExitOnError)
-	flags := newCampaignsApplyFlags(flagSet, campaignsDefaultCacheDir())
+	flags := newCampaignsApplyFlags(flagSet, campaignsDefaultCacheDir(), campaignsDefaultTempDirPrefix())
 
 	handler := func(args []string) error {
 		if err := flagSet.Parse(args); err != nil {

--- a/internal/campaigns/log.go
+++ b/internal/campaigns/log.go
@@ -14,17 +14,18 @@ import (
 )
 
 type LogManager struct {
+	dir      string
 	keepLogs bool
 
 	tasks sync.Map
 }
 
-func NewLogManager(keepLogs bool) *LogManager {
-	return &LogManager{keepLogs: keepLogs}
+func NewLogManager(dir string, keepLogs bool) *LogManager {
+	return &LogManager{dir: dir, keepLogs: keepLogs}
 }
 
 func (lm *LogManager) AddTask(task *Task) (*TaskLogger, error) {
-	tl, err := newTaskLogger(task, lm.keepLogs)
+	tl, err := newTaskLogger(task, lm.keepLogs, lm.dir)
 	if err != nil {
 		return nil, err
 	}
@@ -67,10 +68,10 @@ type TaskLogger struct {
 	keep    bool
 }
 
-func newTaskLogger(task *Task, keep bool) (*TaskLogger, error) {
+func newTaskLogger(task *Task, keep bool, dir string) (*TaskLogger, error) {
 	prefix := "changeset-" + task.Repository.Slug()
 
-	f, err := ioutil.TempFile(tempDirPrefix, prefix+".*.log")
+	f, err := ioutil.TempFile(dir, prefix+".*.log")
 	if err != nil {
 		return nil, errors.Wrapf(err, "creating temporary file with prefix %q", prefix)
 	}

--- a/internal/campaigns/service.go
+++ b/internal/campaigns/service.go
@@ -145,6 +145,7 @@ type ExecutorOpts struct {
 	ClearCache    bool
 	KeepLogs      bool
 	VerboseLogger bool
+	TempDir       string
 }
 
 func (svc *Service) NewExecutor(opts ExecutorOpts, update ExecutorUpdateCallback) Executor {


### PR DESCRIPTION
This addresses a customer report in which `src campaigns apply` couldn't
be run in CI because the docker-in-docker setup prohibits mounting
`/tmp` into containers.

It also fixes parts of
https://github.com/sourcegraph/src-cli/issues/316, since the temporary
directory is also where the logs are stored, but we might want to split
those locations up (in case a user wants to keep logs but not inside the
temporary directory).