### PR TITLE
Fix regression and clean up log files again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ All notable changes to `src-cli` are documented in this file.
 
 ### Fixed
 
+- Log files created by `src campaigns [preview|apply]` are deleted again after successful execution. This was a regression and is not new behaviour. If steps failed to execute or the `-keep-logs` flag is set the log files are not cleaned up.
+
 ## 3.21.0
 
 ### Added

--- a/internal/campaigns/log.go
+++ b/internal/campaigns/log.go
@@ -90,6 +90,11 @@ func (tl *TaskLogger) Close() error {
 	if tl.errored || tl.keep {
 		return nil
 	}
+
+	if err := os.Remove(tl.f.Name()); err != nil {
+		return errors.Wrapf(err, "cleaning up log file %s", tl.f.Name())
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
While looking into how we store ZIP files I realised that log files are
not cleaned up. That's not a big issue, since `/tmp` is cleaned up by
the OS, but it's still a regression and not what we intended.

Digging deeper I ended up starting at the previous for much too long
before realising that the cleanup code was simply missing :)