### PR TITLE
Retain repository archives across executions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to `src-cli` are documented in this file.
 ### Changed
 
 - Error reporting by `src campaign [preview|apply]` has been improved and now includes more information about which step failed in which repository. [#325](https://github.com/sourcegraph/src-cli/pull/325)
+- The default behaviour of `src campaigns [preview|apply]` has been changed to retain downloaded archives of repositories for better performance across re-runs of the command. To use the old behaviour and delete the archives use the `-clean-archives` flag. Repository archives are also not stored in the directory for temp data (see `-tmp` flag) anymore but in the cache directory, which can be configured with the `-cache` flag. To manually delete archives between runs, delete the `*.zip` files in the `-cache` directory (see `src campaigns -help` for its default location).
 
 ### Fixed
 

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,7 @@ github.com/efritz/pentimento v0.0.0-20190429011147-ade47d831101 h1:RylpU+KNJJNEJ
 github.com/efritz/pentimento v0.0.0-20190429011147-ade47d831101/go.mod h1:5ALWO82UZwfAtNRUtwzsWimcrcuYzyieTyyXOXrP6EQ=
 github.com/google/go-cmp v0.4.1 h1:/exdXoGamhu5ONeUJH0deniYLWYvQwW66yvlfiiKTu0=
 github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
@@ -34,8 +35,6 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/shurcooL/go v0.0.0-20180423040247-9e1955d9fb6e/go.mod h1:TDJrrUr11Vxrven61rcy3hJMUqaf/CLWYhHNPmT14Lk=
 github.com/shurcooL/go-goon v0.0.0-20170922171312-37c2f522c041/go.mod h1:N5mDOmsrJOB+vfqUK+7DmDyjhSLIIBnXo9lvZJj3MWQ=
-github.com/sourcegraph/codeintelutils v0.0.0-20200706141440-54ddac67b5b6 h1:91WE5oskxcHBJIiK8GeUDqGQJWaUBiI0LBfvRxAcDX4=
-github.com/sourcegraph/codeintelutils v0.0.0-20200706141440-54ddac67b5b6/go.mod h1:HplI8gRslTrTUUsSYwu28hSOderix7m5dHNca7xBzeo=
 github.com/sourcegraph/codeintelutils v0.0.0-20200824140252-1db3aed5cf58 h1:Ps+U1xoZP+Zoph39YfRB6Q846ghO8pgrAgp0MiObvPs=
 github.com/sourcegraph/codeintelutils v0.0.0-20200824140252-1db3aed5cf58/go.mod h1:HplI8gRslTrTUUsSYwu28hSOderix7m5dHNca7xBzeo=
 github.com/sourcegraph/go-diff v0.6.0 h1:WbN9e/jD8ujU+o0vd9IFN5AEwtfB0rn/zM/AANaClqQ=

--- a/internal/campaigns/archive_fetcher.go
+++ b/internal/campaigns/archive_fetcher.go
@@ -1,0 +1,164 @@
+package campaigns
+
+import (
+	"archive/zip"
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/sourcegraph/src-cli/internal/api"
+	"github.com/sourcegraph/src-cli/internal/campaigns/graphql"
+)
+
+type WorkspaceCreator struct {
+	dir    string
+	client api.Client
+
+	deleteZips bool
+}
+
+func (wc *WorkspaceCreator) Create(ctx context.Context, repo *graphql.Repository) (string, error) {
+	path := localRepositoryZipArchivePath(wc.dir, repo)
+
+	exists, err := fileExists(path)
+	if err != nil {
+		return "", err
+	}
+
+	if !exists {
+		if err := fetchRepositoryArchive(ctx, wc.client, repo, path); err != nil {
+			return "", errors.Wrap(err, "fetching ZIP archive")
+		}
+	}
+
+	if wc.deleteZips {
+		defer os.Remove(path)
+	}
+
+	prefix := "workspace-" + repo.Slug()
+	workspace, err := unzipToTempDir(ctx, path, wc.dir, prefix)
+	if err != nil {
+		return "", errors.Wrap(err, "unzipping the ZIP archive")
+	}
+
+	return workspace, nil
+}
+
+func fileExists(path string) (bool, error) {
+	_, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+func unzipToTempDir(ctx context.Context, zipFile, tempDir, tempFilePrefix string) (string, error) {
+	volumeDir, err := ioutil.TempDir(tempDir, tempFilePrefix)
+	if err != nil {
+		return "", err
+	}
+	return volumeDir, unzip(zipFile, volumeDir)
+}
+
+func fetchRepositoryArchive(ctx context.Context, client api.Client, repo *graphql.Repository, dest string) error {
+	req, err := client.NewHTTPRequest(ctx, "GET", repositoryZipArchivePath(repo), nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Accept", "application/zip")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unable to fetch archive (HTTP %d from %s)", resp.StatusCode, req.URL.String())
+	}
+
+	f, err := os.Create(dest)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	if _, err := io.Copy(f, resp.Body); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func repositoryZipArchivePath(repo *graphql.Repository) string {
+	return path.Join("", repo.Name+"@"+repo.DefaultBranch.Name, "-", "raw")
+}
+
+func localRepositoryZipArchivePath(dir string, repo *graphql.Repository) string {
+	ref := repo.DefaultBranch.Target.OID
+	return filepath.Join(dir, fmt.Sprintf("%s-%s.zip", repo.Slug(), ref))
+}
+
+func unzip(zipFile, dest string) error {
+	r, err := zip.OpenReader(zipFile)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	outputBase := filepath.Clean(dest) + string(os.PathSeparator)
+
+	for _, f := range r.File {
+		fpath := filepath.Join(dest, f.Name)
+
+		// Check for ZipSlip. More Info: https://snyk.io/research/zip-slip-vulnerability#go
+		if !strings.HasPrefix(fpath, outputBase) {
+			return fmt.Errorf("%s: illegal file path", fpath)
+		}
+
+		if f.FileInfo().IsDir() {
+			if err := os.MkdirAll(fpath, os.ModePerm); err != nil {
+				return err
+			}
+			continue
+		}
+
+		if err := os.MkdirAll(filepath.Dir(fpath), os.ModePerm); err != nil {
+			return err
+		}
+
+		outFile, err := os.OpenFile(fpath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode())
+		if err != nil {
+			return err
+		}
+
+		rc, err := f.Open()
+		if err != nil {
+			outFile.Close()
+			return err
+		}
+
+		_, err = io.Copy(outFile, rc)
+		rc.Close()
+		cerr := outFile.Close()
+		// Now we have safely closed everything that needs it, and can check errors
+		if err != nil {
+			return errors.Wrapf(err, "copying %q failed", f.Name)
+		}
+		if cerr != nil {
+			return errors.Wrap(err, "closing output file failed")
+		}
+
+	}
+
+	return nil
+}

--- a/internal/campaigns/executor.go
+++ b/internal/campaigns/executor.go
@@ -70,6 +70,7 @@ type executor struct {
 	cache   ExecutionCache
 	client  api.Client
 	logger  *LogManager
+	creator *WorkspaceCreator
 	tasks   sync.Map
 	tempDir string
 
@@ -86,6 +87,7 @@ func newExecutor(opts ExecutorOpts, client api.Client, update ExecutorUpdateCall
 	return &executor{
 		ExecutorOpts:  opts,
 		cache:         opts.Cache,
+		creator:       opts.Creator,
 		client:        client,
 		doneEnqueuing: make(chan struct{}),
 		logger:        NewLogManager(opts.TempDir, opts.KeepLogs),
@@ -218,7 +220,7 @@ func (x *executor) do(ctx context.Context, task *Task) (err error) {
 	defer cancel()
 
 	// Actually execute the steps.
-	diff, err := runSteps(runCtx, x.client, task.Repository, task.Steps, log, x.tempDir)
+	diff, err := runSteps(runCtx, x.creator, task.Repository, task.Steps, log, x.tempDir)
 	if err != nil {
 		if reachedTimeout(runCtx, err) {
 			err = &errTimeoutReached{timeout: x.Timeout}

--- a/internal/campaigns/run_steps.go
+++ b/internal/campaigns/run_steps.go
@@ -1,38 +1,25 @@
 package campaigns
 
 import (
-	"archive/zip"
 	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"io/ioutil"
-	"net/http"
 	"os"
 	"os/exec"
-	"path"
-	"path/filepath"
 	"strings"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
-	"github.com/sourcegraph/src-cli/internal/api"
 	"github.com/sourcegraph/src-cli/internal/campaigns/graphql"
 )
 
-func runSteps(ctx context.Context, client api.Client, repo *graphql.Repository, steps []Step, logger *TaskLogger, tempDir string) ([]byte, error) {
-	zipFile, err := fetchRepositoryArchive(ctx, client, repo, tempDir)
+func runSteps(ctx context.Context, wc *WorkspaceCreator, repo *graphql.Repository, steps []Step, logger *TaskLogger, tempDir string) ([]byte, error) {
+	volumeDir, err := wc.Create(ctx, repo)
 	if err != nil {
-		return nil, errors.Wrap(err, "Fetching ZIP archive failed")
-	}
-	defer os.Remove(zipFile.Name())
-
-	prefix := "changeset-" + repo.Slug()
-	volumeDir, err := unzipToTempDir(ctx, zipFile.Name(), tempDir, prefix)
-	if err != nil {
-		return nil, errors.Wrap(err, "Unzipping the ZIP archive failed")
+		return nil, errors.Wrap(err, "creating workspace")
 	}
 	defer os.RemoveAll(volumeDir)
 
@@ -72,7 +59,7 @@ func runSteps(ctx context.Context, client api.Client, repo *graphql.Repository, 
 	for i, step := range steps {
 		logger.Logf("[Step %d] docker run %s %q", i+1, step.Container, step.Run)
 
-		cidFile, err := ioutil.TempFile(tempDir, prefix+"-container-id")
+		cidFile, err := ioutil.TempFile(tempDir, repo.Slug()+"-container-id")
 		if err != nil {
 			return nil, errors.Wrap(err, "Creating a CID file failed")
 		}
@@ -167,101 +154,6 @@ func runSteps(ctx context.Context, client api.Client, repo *graphql.Repository, 
 	}
 
 	return diffOut, err
-}
-
-func unzipToTempDir(ctx context.Context, zipFile, tempDir, tempFilePrefix string) (string, error) {
-	volumeDir, err := ioutil.TempDir(tempDir, tempFilePrefix)
-	if err != nil {
-		return "", err
-	}
-	return volumeDir, unzip(zipFile, volumeDir)
-}
-
-func fetchRepositoryArchive(ctx context.Context, client api.Client, repo *graphql.Repository, tempDir string) (*os.File, error) {
-	req, err := client.NewHTTPRequest(ctx, "GET", repositoryZipArchivePath(repo), nil)
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("Accept", "application/zip")
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unable to fetch archive (HTTP %d from %s)", resp.StatusCode, req.URL.String())
-	}
-
-	f, err := ioutil.TempFile(tempDir, strings.Replace(repo.Name, "/", "-", -1)+".zip")
-	if err != nil {
-		return nil, err
-	}
-	defer f.Close()
-
-	if _, err := io.Copy(f, resp.Body); err != nil {
-		return nil, err
-	}
-	return f, nil
-}
-
-func repositoryZipArchivePath(repo *graphql.Repository) string {
-	return path.Join("", repo.Name+"@"+repo.DefaultBranch.Name, "-", "raw")
-}
-
-func unzip(zipFile, dest string) error {
-	r, err := zip.OpenReader(zipFile)
-	if err != nil {
-		return err
-	}
-	defer r.Close()
-
-	outputBase := filepath.Clean(dest) + string(os.PathSeparator)
-
-	for _, f := range r.File {
-		fpath := filepath.Join(dest, f.Name)
-
-		// Check for ZipSlip. More Info: https://snyk.io/research/zip-slip-vulnerability#go
-		if !strings.HasPrefix(fpath, outputBase) {
-			return fmt.Errorf("%s: illegal file path", fpath)
-		}
-
-		if f.FileInfo().IsDir() {
-			if err := os.MkdirAll(fpath, os.ModePerm); err != nil {
-				return err
-			}
-			continue
-		}
-
-		if err := os.MkdirAll(filepath.Dir(fpath), os.ModePerm); err != nil {
-			return err
-		}
-
-		outFile, err := os.OpenFile(fpath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode())
-		if err != nil {
-			return err
-		}
-
-		rc, err := f.Open()
-		if err != nil {
-			outFile.Close()
-			return err
-		}
-
-		_, err = io.Copy(outFile, rc)
-		rc.Close()
-		cerr := outFile.Close()
-		// Now we have safely closed everything that needs it, and can check errors
-		if err != nil {
-			return errors.Wrapf(err, "copying %q failed", f.Name)
-		}
-		if cerr != nil {
-			return errors.Wrap(err, "closing output file failed")
-		}
-
-	}
-
-	return nil
 }
 
 func probeImageForShell(ctx context.Context, image string) (shell, tempfile string, err error) {

--- a/internal/campaigns/run_steps.go
+++ b/internal/campaigns/run_steps.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"os/exec"

--- a/internal/campaigns/service.go
+++ b/internal/campaigns/service.go
@@ -139,6 +139,7 @@ func (svc *Service) NewExecutionCache(dir string) ExecutionCache {
 
 type ExecutorOpts struct {
 	Cache       ExecutionCache
+	Creator     *WorkspaceCreator
 	Parallelism int
 	Timeout     time.Duration
 
@@ -146,10 +147,15 @@ type ExecutorOpts struct {
 	KeepLogs      bool
 	VerboseLogger bool
 	TempDir       string
+	CacheDir      string
 }
 
 func (svc *Service) NewExecutor(opts ExecutorOpts, update ExecutorUpdateCallback) Executor {
 	return newExecutor(opts, svc.client, update)
+}
+
+func (svc *Service) NewWorkspaceCreator(dir string, cleanArchives bool) *WorkspaceCreator {
+	return &WorkspaceCreator{dir: dir, client: svc.client, deleteZips: cleanArchives}
 }
 
 func (svc *Service) SetDockerImages(ctx context.Context, spec *CampaignSpec, progress func(i int)) error {


### PR DESCRIPTION
Copying from the CHANGELOG:

- The default behaviour of `src campaigns [preview|apply]` has been changed to retain downloaded archives of repositories for better performance across re-runs of the command.
- To use the old behaviour and delete the archives use the `-clean-archives` flag.
- Repository archives are also not stored in the directory for temp data (see `-tmp` flag) anymore but in the cache directory, which can be configured with the `-cache` flag. To manually delete archives between runs, delete the `*.zip` files in the `-cache` directory (see `src campaigns -help` for its default location)

I'm still not sure whether this is the best way to achieve the goal of
"do not delete the same zip file over and over again", because it's easy
ot have the cache fill up: if you run campaigns multiple times and the
base ref of the repository changes you get a new zip every time.

While I keep thinking about this and hacking on it: opinions?