### PR TITLE
Show execution progress immediately

### DIFF
--- a/internal/campaigns/service.go
+++ b/internal/campaigns/service.go
@@ -175,6 +175,8 @@ func (svc *Service) ExecuteCampaignSpec(ctx context.Context, repos []*graphql.Re
 	done := make(chan struct{})
 	if progress != nil {
 		go func() {
+			progress(statuses)
+
 			ticker := time.NewTicker(1 * time.Second)
 			defer ticker.Stop()
 


### PR DESCRIPTION
Tiny change but I think it makes a difference: instead of a 1s delay in
which we show nothing (and seem to hang) we show the spinner
immediately.