### PR TITLE
Check that Docker and git are available when executing campaign spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to `src-cli` are documented in this file.
 
 - Error reporting by `src campaign [preview|apply]` has been improved and now includes more information about which step failed in which repository. [#325](https://github.com/sourcegraph/src-cli/pull/325)
 - The default behaviour of `src campaigns [preview|apply]` has been changed to retain downloaded archives of repositories for better performance across re-runs of the command. To use the old behaviour and delete the archives use the `-clean-archives` flag. Repository archives are also not stored in the directory for temp data (see `-tmp` flag) anymore but in the cache directory, which can be configured with the `-cache` flag. To manually delete archives between runs, delete the `*.zip` files in the `-cache` directory (see `src campaigns -help` for its default location).
+- `src campaign [preview|apply]` now check whether `git` and `docker` are available before trying to execute a campaign spec's steps. [#326](https://github.com/sourcegraph/src-cli/pull/326)
 
 ### Fixed
 


### PR DESCRIPTION
We had the check for git before, but lost it in the switch to the new
model.

The Docker check I added after running into a hard-to-decipher error
when trying to run `src campaigns apply` on a VM without Docker.

Here's what it looks like:

<img width="334" alt="screenshot_2020-09-22_16 37 30@2x" src="https://user-images.githubusercontent.com/1185253/93897247-228a5e00-fcf2-11ea-9549-6f26a5ab6e98.png">
