### PR TITLE
Handle interrupt signal in src campaigns apply|preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to `src-cli` are documented in this file.
 ### Fixed
 
 - Log files created by `src campaigns [preview|apply]` are deleted again after successful execution. This was a regression and is not new behaviour. If steps failed to execute or the `-keep-logs` flag is set the log files are not cleaned up.
+- `src campaign [preview|apply]` now correctly handle the interrupt signal (emitted in a terminal with Ctrl-C) and abort execution of campaign steps, cleaning up running Docker containers.
 
 ## 3.21.0
 

--- a/cmd/src/campaigns_apply.go
+++ b/cmd/src/campaigns_apply.go
@@ -56,7 +56,10 @@ Examples:
 		}
 
 		out := output.NewOutput(flagSet.Output(), output.OutputOpts{Verbose: *verbose})
-		ctx := context.Background()
+
+		ctx, cancel := contextCancelOnInterrupt(context.Background())
+		defer cancel()
+
 		svc := campaigns.NewService(&campaigns.ServiceOpts{
 			AllowUnsupported: flags.allowUnsupported,
 			Client:           cfg.apiClient(flags.api, flagSet.Output()),

--- a/cmd/src/campaigns_preview.go
+++ b/cmd/src/campaigns_preview.go
@@ -33,7 +33,10 @@ Examples:
 		}
 
 		out := output.NewOutput(flagSet.Output(), output.OutputOpts{Verbose: *verbose})
-		ctx := context.Background()
+
+		ctx, cancel := contextCancelOnInterrupt(context.Background())
+		defer cancel()
+
 		svc := campaigns.NewService(&campaigns.ServiceOpts{
 			AllowUnsupported: flags.allowUnsupported,
 			Client:           cfg.apiClient(flags.api, flagSet.Output()),

--- a/internal/campaigns/run_steps.go
+++ b/internal/campaigns/run_steps.go
@@ -215,6 +215,8 @@ type stepFailedErr struct {
 	Err error
 }
 
+func (e stepFailedErr) Cause() error { return e.Err }
+
 func (e stepFailedErr) Error() string {
 	var out strings.Builder
 


### PR DESCRIPTION
Before this change Docker containers kept on running after the interrupt signal was sent to the process and killing it. This was a slight regression, since it was previously fixed by #169.

What this commit does is bring back the behaviour of #169 and also makes sure that we print the correct error message when we canceled a running step.

It also makes sure that we don't enqueue more tasks/steps after being canceled: that's the code in `(*executor).Start()` that aborts the `Range` call if the context has been cancelled/timed-out and aborts execution of a task if the goroutine already blocked on `x.par.Acquire()`.