### PR TITLE
PROTOTYPE: Add support for templated campaign specs

### DIFF
--- a/internal/campaigns/executor_test.go
+++ b/internal/campaigns/executor_test.go
@@ -109,7 +109,7 @@ func TestExecutor_Integration(t *testing.T) {
 			},
 			steps: []Step{
 				{Run: `go fmt main.go`, Container: "doesntmatter:13"},
-				{Run: `touch modified-${{ modified_files }}.md`, Container: "alpine:13"},
+				{Run: `touch modified-${{ .PreviousStep.ModifiedFiles }}.md`, Container: "alpine:13"},
 			},
 			wantFilesChanged: map[string][]string{
 				srcCLIRepo.ID: []string{"main.go", "modified-main.go.md"},

--- a/internal/campaigns/executor_test.go
+++ b/internal/campaigns/executor_test.go
@@ -171,7 +171,6 @@ func TestExecutor_Integration(t *testing.T) {
 					t.Fatalf("wrong number of commits. want=%d, have=%d", want, have)
 				}
 
-				t.Logf("diff=%s\n", spec.Commits[0].Diff)
 				fileDiffs, err := diff.ParseMultiFileDiff([]byte(spec.Commits[0].Diff))
 				if err != nil {
 					t.Fatalf("failed to parse diff: %s", err)

--- a/internal/campaigns/graphql/repository.go
+++ b/internal/campaigns/graphql/repository.go
@@ -46,21 +46,13 @@ func (r *Repository) Slug() string {
 	return strings.ReplaceAll(r.Name, "/", "-")
 }
 
-func (r *Repository) FileMatchPaths() string {
-	files := []string{}
-	for f := range r.FileMatches {
-		files = append(files, f)
-	}
-	return strings.Join(files, " ")
-}
-
-type fileMatchPathList []string
-
-func (f fileMatchPathList) String() string { return strings.Join(f, " ") }
-
-func (r *Repository) FileMatchPathList() (list fileMatchPathList) {
+func (r *Repository) SearchResultPaths() (list fileMatchPathList) {
 	for f := range r.FileMatches {
 		list = append(list, f)
 	}
 	return list
 }
+
+type fileMatchPathList []string
+
+func (f fileMatchPathList) String() string { return strings.Join(f, " ") }

--- a/internal/campaigns/graphql/repository.go
+++ b/internal/campaigns/graphql/repository.go
@@ -1,6 +1,9 @@
 package graphql
 
-import "strings"
+import (
+	"sort"
+	"strings"
+)
 
 const RepositoryFieldsFragment = `
 fragment repositoryFields on Repository {
@@ -47,10 +50,12 @@ func (r *Repository) Slug() string {
 }
 
 func (r *Repository) SearchResultPaths() (list fileMatchPathList) {
+	var files []string
 	for f := range r.FileMatches {
-		list = append(list, f)
+		files = append(files, f)
 	}
-	return list
+	sort.Strings(files)
+	return fileMatchPathList(files)
 }
 
 type fileMatchPathList []string

--- a/internal/campaigns/graphql/repository.go
+++ b/internal/campaigns/graphql/repository.go
@@ -30,6 +30,8 @@ type Repository struct {
 	URL                string
 	ExternalRepository struct{ ServiceType string }
 	DefaultBranch      *Branch
+
+	FileMatches map[string]bool
 }
 
 func (r *Repository) BaseRef() string {
@@ -42,4 +44,23 @@ func (r *Repository) Rev() string {
 
 func (r *Repository) Slug() string {
 	return strings.ReplaceAll(r.Name, "/", "-")
+}
+
+func (r *Repository) FileMatchPaths() string {
+	files := []string{}
+	for f := range r.FileMatches {
+		files = append(files, f)
+	}
+	return strings.Join(files, " ")
+}
+
+type fileMatchPathList []string
+
+func (f fileMatchPathList) String() string { return strings.Join(f, " ") }
+
+func (r *Repository) FileMatchPathList() (list fileMatchPathList) {
+	for f := range r.FileMatches {
+		list = append(list, f)
+	}
+	return list
 }

--- a/internal/campaigns/run_steps.go
+++ b/internal/campaigns/run_steps.go
@@ -191,7 +191,10 @@ func parseStepRun(stepCtx StepContext, run string) (*template.Template, error) {
 	t := template.New("step-run").Delims("${{", "}}")
 
 	funcMap := template.FuncMap{
-		"repository_name": func() string { return stepCtx.Repository.Name },
+		"repository_name":    func() string { return stepCtx.Repository.Name },
+		"search_results":     stepCtx.Repository.FileMatchPathList,
+		"search_result_list": stepCtx.Repository.FileMatchPathList,
+		"join":               func(sl []string, sep string) string { return strings.Join(sl, sep) },
 	}
 
 	funcMap["modified_files"] = stepCtx.PreviousStep.ModifiedFiles

--- a/internal/campaigns/run_steps.go
+++ b/internal/campaigns/run_steps.go
@@ -101,7 +101,7 @@ func runSteps(ctx context.Context, wc *WorkspaceCreator, repo *graphql.Repositor
 			stepContext.PreviousStep = results[i-1]
 		}
 
-		tmpl, err := parseStepRun(stepContext, step.Run)
+		tmpl, err := parseStepRun(step.Run)
 		if err != nil {
 			return nil, errors.Wrap(err, "parsing step run")
 		}
@@ -190,7 +190,7 @@ func runSteps(ctx context.Context, wc *WorkspaceCreator, repo *graphql.Repositor
 	return diffOut, err
 }
 
-func parseStepRun(stepCtx StepContext, run string) (*template.Template, error) {
+func parseStepRun(run string) (*template.Template, error) {
 	return template.New("step-run").Delims("${{", "}}").Parse(run)
 }
 

--- a/internal/campaigns/run_steps.go
+++ b/internal/campaigns/run_steps.go
@@ -188,20 +188,7 @@ func runSteps(ctx context.Context, wc *WorkspaceCreator, repo *graphql.Repositor
 }
 
 func parseStepRun(stepCtx StepContext, run string) (*template.Template, error) {
-	t := template.New("step-run").Delims("${{", "}}")
-
-	funcMap := template.FuncMap{
-		"repository_name":    func() string { return stepCtx.Repository.Name },
-		"search_results":     stepCtx.Repository.FileMatchPathList,
-		"search_result_list": stepCtx.Repository.FileMatchPathList,
-		"join":               func(sl []string, sep string) string { return strings.Join(sl, sep) },
-	}
-
-	funcMap["modified_files"] = stepCtx.PreviousStep.ModifiedFiles
-
-	t.Funcs(funcMap)
-
-	return t.Parse(run)
+	return template.New("step-run").Delims("${{", "}}").Parse(run)
 }
 
 type StepContext struct {

--- a/internal/campaigns/run_steps_test.go
+++ b/internal/campaigns/run_steps_test.go
@@ -77,7 +77,7 @@ func TestParseStepRun(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		parsed, err := parseStepRun(tc.stepCtx, tc.run)
+		parsed, err := parseStepRun(tc.run)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/campaigns/run_steps_test.go
+++ b/internal/campaigns/run_steps_test.go
@@ -60,6 +60,20 @@ func TestParseStepRun(t *testing.T) {
 			run:  `${{ modified_files }} ${{ repository_name }}`,
 			want: ` github.com/sourcegraph/src-cli`,
 		},
+		{
+			stepCtx: StepContext{
+				Repository: &graphql.Repository{
+					Name: "github.com/sourcegraph/src-cli",
+					FileMatches: map[string]bool{
+						"README.md": true,
+						"main.go":   true,
+					},
+				},
+			},
+
+			run:  `${{ search_results }}`,
+			want: `README.md main.go`,
+		},
 	}
 
 	for _, tc := range tests {

--- a/internal/campaigns/run_steps_test.go
+++ b/internal/campaigns/run_steps_test.go
@@ -1,0 +1,80 @@
+package campaigns
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/sourcegraph/src-cli/internal/campaigns/graphql"
+)
+
+func TestParseGitStatus(t *testing.T) {
+	const input = `M  README.md
+M  another_file.go
+A  new_file.txt
+A  barfoo/new_file.txt
+D  to_be_deleted.txt
+`
+	parsed, err := parseGitStatus([]byte(input))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := StepChanges{
+		Modified: []string{"README.md", "another_file.go"},
+		Added:    []string{"new_file.txt", "barfoo/new_file.txt"},
+		Deleted:  []string{"to_be_deleted.txt"},
+	}
+
+	if !cmp.Equal(want, parsed) {
+		t.Fatalf("wrong output:\n%s", cmp.Diff(want, parsed))
+	}
+}
+
+func TestParseStepRun(t *testing.T) {
+	tests := []struct {
+		stepCtx StepContext
+		run     string
+		want    string
+	}{
+		{
+			stepCtx: StepContext{
+				Repository: &graphql.Repository{Name: "github.com/sourcegraph/src-cli"},
+				PreviousStep: StepResult{
+					Changes: StepChanges{
+						Modified: []string{"go.mod"},
+						Added:    []string{"main.go.swp"},
+						Deleted:  []string{".DS_Store"},
+					},
+				},
+			},
+
+			run:  `${{ modified_files }} ${{ repository_name }}`,
+			want: `go.mod github.com/sourcegraph/src-cli`,
+		},
+		{
+			stepCtx: StepContext{
+				Repository: &graphql.Repository{Name: "github.com/sourcegraph/src-cli"},
+			},
+
+			run:  `${{ modified_files }} ${{ repository_name }}`,
+			want: ` github.com/sourcegraph/src-cli`,
+		},
+	}
+
+	for _, tc := range tests {
+		parsed, err := parseStepRun(tc.stepCtx, tc.run)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var out bytes.Buffer
+		if err := parsed.Execute(&out, tc.stepCtx); err != nil {
+			t.Fatalf("executing template failed: %s", err)
+		}
+
+		if out.String() != tc.want {
+			t.Fatalf("wrong output:\n%s", cmp.Diff(tc.want, out.String()))
+		}
+	}
+}

--- a/internal/campaigns/run_steps_test.go
+++ b/internal/campaigns/run_steps_test.go
@@ -49,7 +49,7 @@ func TestParseStepRun(t *testing.T) {
 				},
 			},
 
-			run:  `${{ modified_files }} ${{ repository_name }}`,
+			run:  `${{ .PreviousStep.ModifiedFiles }} ${{ .Repository.Name }}`,
 			want: `go.mod github.com/sourcegraph/src-cli`,
 		},
 		{
@@ -57,7 +57,7 @@ func TestParseStepRun(t *testing.T) {
 				Repository: &graphql.Repository{Name: "github.com/sourcegraph/src-cli"},
 			},
 
-			run:  `${{ modified_files }} ${{ repository_name }}`,
+			run:  `${{ .PreviousStep.ModifiedFiles }} ${{ .Repository.Name }}`,
 			want: ` github.com/sourcegraph/src-cli`,
 		},
 		{
@@ -71,7 +71,7 @@ func TestParseStepRun(t *testing.T) {
 				},
 			},
 
-			run:  `${{ search_results }}`,
+			run:  `${{ .Repository.SearchResultPaths }}`,
 			want: `README.md main.go`,
 		},
 	}


### PR DESCRIPTION
**NOTE FOR REVIEWERS**: This is a prototype and should be treated as such, which means: let's review idea/design/feasibility instead of concrete implementation details (but if you do have concrete feedback on the implementation, feel free to leave it as such).

---

This is a prototype to add **templating** to the `steps` definitions in a campaign spec YAML file.

It's similar to the templating allowed in [GitHub Actions](https://docs.github.com/en/free-pro-team@latest/actions/reference/context-and-expression-syntax-for-github-actions).

Here is an excerpt from a campaign spec that uses templating. It runs comby _only over the search results_ found in the repository by the `repositoriesMatchingQuery` (that's the `${{ .Repository.SearchResultPaths }}` in the spec) and then runs `goimports` _only over the files modified by comby_ (the `${{ .PreviousStep.ModifiedFiles }}`):

```yaml
name: templated-campaign
description: Use templates

on:
  - repositoriesMatchingQuery: lang:go fmt.Sprintf("%d", :[v]) patterntype:structural -file:vendor count:10

steps:
  - run: comby -in-place 'fmt.Sprintf("%d", :[v])' 'strconv.Itoa(:[v])' ${{ .Repository.SearchResultPaths }}
    container: comby/comby
  - run: goimports -w ${{ .PreviousStep.ModifiedFiles }}
    container: unibeautify/goimports

changesetTemplate:
  # [... changesetTemplate is unchanged ...]
```

### Screenshot

![image](https://user-images.githubusercontent.com/1185253/96448285-6f8b2280-1213-11eb-82ce-9b4e20e7beca.png)


### Details

This is a tested prototype that works. Executing campaigns like this is _much_ faster because comby only has to look at and touch the files it needs to modify, same goes for goimports.

What else is available in the templates? [This is the definition of `StepContext`](https://github.com/sourcegraph/src-cli/blob/4022b92bc73a13c0011c94cea9f630c023629d04/internal/campaigns/run_steps.go#L197-L214), which is passed into the `step.run` string before executing a step.

That means a user can access:

* `${{ .Repository.SearchResultPaths }}`
* `${{ .Repository.Name }}` and [the other fields and methods on `*graphql.Repository`](https://github.com/sourcegraph/src-cli/blob/4022b92bc73a13c0011c94cea9f630c023629d04/internal/campaigns/graphql/repository.go#L27-L58)
* `${{ .PreviousStep.ModifiedFiles }}`
* `${{ .PreviousStep.AddedFiles }}`
* `${{ .PreviousStep.DeletedFiles }}`

### Drawbacks

- there are no shortened aliases available as variables (`${{ search_result_paths }}` for example). Why? Because I couldn't come up with a consistent naming scheme that allows us to have a hierarchy too (like `previous_step.modified_files` etc.). That doesn't mean we shouldn't do it though, since I don't like the `.Foobar` syntax of Go's templating system.
  - **Edit**: I managed to get lower_case names + field access working (see [here](https://gist.github.com/mrnugget/774812fe534fb019a80ad9be2c364a57)), which means we could use that instead.
- it might not be clear to the user that they have access to _file paths_ since they're defining `*repositories*MatchingQuery` in their campaign spec. There might be a better way to define this.
- with a large number of files and search results the rendered commands might become _very long_ and thus hard to debug

