### PR TITLE
Remove unused callback from Executor

### DIFF
--- a/cmd/src/campaigns_common.go
+++ b/cmd/src/campaigns_common.go
@@ -186,7 +186,7 @@ func campaignsExecute(ctx context.Context, out *output.Output, svc *campaigns.Se
 	} else {
 		opts.Parallelism = flags.parallelism
 	}
-	executor := svc.NewExecutor(opts, nil)
+	executor := svc.NewExecutor(opts)
 
 	if errs != nil {
 		return "", "", errs

--- a/internal/campaigns/executor_test.go
+++ b/internal/campaigns/executor_test.go
@@ -121,7 +121,7 @@ func TestExecutor_Integration(t *testing.T) {
 				opts.Timeout = 5 * time.Second
 			}
 
-			executor := newExecutor(opts, client, nil)
+			executor := newExecutor(opts, client)
 
 			template := &ChangesetTemplate{}
 			for _, r := range tc.repos {

--- a/internal/campaigns/service.go
+++ b/internal/campaigns/service.go
@@ -150,8 +150,8 @@ type ExecutorOpts struct {
 	CacheDir      string
 }
 
-func (svc *Service) NewExecutor(opts ExecutorOpts, update ExecutorUpdateCallback) Executor {
-	return newExecutor(opts, svc.client, update)
+func (svc *Service) NewExecutor(opts ExecutorOpts) Executor {
+	return newExecutor(opts, svc.client)
 }
 
 func (svc *Service) NewWorkspaceCreator(dir string, cleanArchives bool) *WorkspaceCreator {


### PR DESCRIPTION
This was used in the old architecture but has been replaced by the
TaskStatus callbacks.