### PR TITLE
Fix display of status bars when 0 repositories have been matched

### DIFF
--- a/cmd/src/campaign_progress_printer.go
+++ b/cmd/src/campaign_progress_printer.go
@@ -38,8 +38,13 @@ type campaignProgressPrinter struct {
 }
 
 func (p *campaignProgressPrinter) initProgressBar(statuses []*campaigns.TaskStatus) {
-	statusBars := []*output.StatusBar{}
-	for i := 0; i < p.numParallelism; i++ {
+	numStatusBars := p.numParallelism
+	if len(statuses) < numStatusBars {
+		numStatusBars = len(statuses)
+	}
+
+	statusBars := make([]*output.StatusBar, 0, numStatusBars)
+	for i := 0; i < numStatusBars; i++ {
 		statusBars = append(statusBars, output.NewStatusBarWithLabel("Starting worker..."))
 	}
 
@@ -56,6 +61,10 @@ func (p *campaignProgressPrinter) Complete() {
 }
 
 func (p *campaignProgressPrinter) PrintStatuses(statuses []*campaigns.TaskStatus) {
+	if len(statuses) == 0 {
+		return
+	}
+
 	if p.progress == nil {
 		p.initProgressBar(statuses)
 	}


### PR DESCRIPTION
This fixes https://github.com/sourcegraph/sourcegraph/issues/14559 by
not printing a progress bar when 0 repositories have been matched.

#### Before

<img width="900" alt="screenshot_2020-10-12_12 27 11@2x" src="https://user-images.githubusercontent.com/1185253/95741134-04c76d80-0c8e-11eb-9dbf-822463f14256.png">

#### After

<img width="900" alt="screenshot_2020-10-12_12 27 28@2x" src="https://user-images.githubusercontent.com/1185253/95741151-0e50d580-0c8e-11eb-8c82-65d731c10084.png">

