### PR TITLE
Show warning if 0 changeset specs have been created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to `src-cli` are documented in this file.
 - The default behaviour of `src campaigns [preview|apply]` has been changed to retain downloaded archives of repositories for better performance across re-runs of the command. To use the old behaviour and delete the archives use the `-clean-archives` flag. Repository archives are also not stored in the directory for temp data (see `-tmp` flag) anymore but in the cache directory, which can be configured with the `-cache` flag. To manually delete archives between runs, delete the `*.zip` files in the `-cache` directory (see `src campaigns -help` for its default location).
 - `src campaign [preview|apply]` now check whether `git` and `docker` are available before trying to execute a campaign spec's steps. [#326](https://github.com/sourcegraph/src-cli/pull/326)
 - The progress bar displayed by `src campaign [preview|apply]` has been extended by status bars that show which steps are currently being executed for each repository. [#338](https://github.com/sourcegraph/src-cli/pull/338)
+- `src campaign [preview|apply]` now shows a warning when no changeset specs have been created.
 
 ### Fixed
 

--- a/internal/output/emoji.go
+++ b/internal/output/emoji.go
@@ -3,6 +3,6 @@ package output
 // Standard emoji for use in output.
 const (
 	EmojiFailure = "❌"
-	EmojiWarning = "⚠️"
+	EmojiWarning = "❗️"
 	EmojiSuccess = "✅"
 )

--- a/internal/output/emoji.go
+++ b/internal/output/emoji.go
@@ -3,5 +3,6 @@ package output
 // Standard emoji for use in output.
 const (
 	EmojiFailure = "❌"
+	EmojiWarning = "⚠️"
 	EmojiSuccess = "✅"
 )


### PR DESCRIPTION
This fixes https://github.com/sourcegraph/sourcegraph/issues/14531 by showing a warning.

Please note that I think it should only ever be a warning, otherwise it'll be really hard to run `src campaign apply|preview` reliably in CI without some additional flags or something.