### PR TITLE
Follow-up to gzip encoding of request body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to `src-cli` are documented in this file.
 - `src campaign [preview|apply]` now check whether `git` and `docker` are available before trying to execute a campaign spec's steps. [#326](https://github.com/sourcegraph/src-cli/pull/326)
 - The progress bar displayed by `src campaign [preview|apply]` has been extended by status bars that show which steps are currently being executed for each repository. [#338](https://github.com/sourcegraph/src-cli/pull/338)
 - `src campaign [preview|apply]` now shows a warning when no changeset specs have been created.
+- Requests sent to Sourcegraph by the `src campaign` commands now use gzip compression for the body when talking to Sourcegraph 3.21.0 and later. [#336](https://github.com/sourcegraph/src-cli/pull/336) and [#343](https://github.com/sourcegraph/src-cli/pull/343)
 
 ### Fixed
 

--- a/cmd/src/campaigns_apply.go
+++ b/cmd/src/campaigns_apply.go
@@ -65,6 +65,10 @@ Examples:
 			Client:           cfg.apiClient(flags.api, flagSet.Output()),
 		})
 
+		if err := svc.DetermineFeatureFlags(ctx); err != nil {
+			return err
+		}
+
 		if err := doApply(ctx, out, svc, flags); err != nil {
 			printExecutionError(out, err)
 			return &exitCodeError{nil, 1}

--- a/cmd/src/campaigns_preview.go
+++ b/cmd/src/campaigns_preview.go
@@ -42,6 +42,10 @@ Examples:
 			Client:           cfg.apiClient(flags.api, flagSet.Output()),
 		})
 
+		if err := svc.DetermineFeatureFlags(ctx); err != nil {
+			return err
+		}
+
 		_, url, err := campaignsExecute(ctx, out, svc, flags)
 		if err != nil {
 			printExecutionError(out, err)

--- a/cmd/src/campaigns_repositories.go
+++ b/cmd/src/campaigns_repositories.go
@@ -49,6 +49,11 @@ Examples:
 		client := cfg.apiClient(apiFlags, flagSet.Output())
 
 		svc := campaigns.NewService(&campaigns.ServiceOpts{Client: client})
+
+		if err := svc.DetermineFeatureFlags(ctx); err != nil {
+			return err
+		}
+
 		spec, _, err := svc.ParseCampaignSpec(specFile)
 		if err != nil {
 			return errors.Wrap(err, "parsing campaign spec")

--- a/cmd/src/campaigns_validate.go
+++ b/cmd/src/campaigns_validate.go
@@ -39,6 +39,7 @@ Examples:
 		defer specFile.Close()
 
 		svc := campaigns.NewService(&campaigns.ServiceOpts{})
+
 		spec, _, err := svc.ParseCampaignSpec(specFile)
 		if err != nil {
 			return errors.Wrap(err, "parsing campaign spec")

--- a/cmd/src/config_get.go
+++ b/cmd/src/config_get.go
@@ -66,7 +66,9 @@ Examples:
 			ViewerSettings  *SettingsCascade
 			SettingsSubject *SettingsSubject
 		}
-		if ok, err := client.NewRequest(query, queryVars).Do(context.Background(), &result); err != nil || !ok {
+
+		ok, err := client.NewRequest(query, queryVars).Do(context.Background(), &result)
+		if err != nil || !ok {
 			return err
 		}
 

--- a/cmd/src/config_list.go
+++ b/cmd/src/config_list.go
@@ -73,7 +73,9 @@ Examples:
 			ViewerSettings  *SettingsCascade
 			SettingsSubject *SettingsSubject
 		}
-		if ok, err := client.NewRequest(query, queryVars).Do(context.Background(), &result); err != nil || !ok {
+
+		ok, err := client.NewRequest(query, queryVars).Do(context.Background(), &result)
+		if err != nil || !ok {
 			return err
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/sourcegraph/src-cli
 go 1.13
 
 require (
+	github.com/Masterminds/semver v1.5.0
 	github.com/dustin/go-humanize v1.0.0
 	github.com/efritz/pentimento v0.0.0-20190429011147-ade47d831101
 	github.com/google/go-cmp v0.5.2

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
+github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -10,12 +10,10 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
-	"regexp"
 	"strings"
 
-	"github.com/Masterminds/semver"
 	"github.com/hashicorp/go-multierror"
-	"github.com/jig/teereadcloser"
+	ioaux "github.com/jig/teereadcloser"
 	"github.com/kballard/go-shellquote"
 	"github.com/mattn/go-isatty"
 	"github.com/pkg/errors"
@@ -30,6 +28,13 @@ type Client interface {
 
 	// NewRequest creates a GraphQL request.
 	NewRequest(query string, vars map[string]interface{}) Request
+
+	// NewGzippedRequest creates a GraphQL request with gzip compression turned on.
+	NewGzippedRequest(query string, vars map[string]interface{}) Request
+
+	// NewGzippedQuery is a convenience wrapper around NewQuery with gzip
+	// compression turned on.
+	NewGzippedQuery(query string) Request
 
 	// NewHTTPRequest creates an http.Request for the Sourcegraph API.
 	//
@@ -56,8 +61,7 @@ type Request interface {
 
 // client is the internal concrete type implementing Client.
 type client struct {
-	opts         ClientOpts
-	supportsGzip *bool
+	opts ClientOpts
 }
 
 // request is the internal concrete type implementing Request.
@@ -65,6 +69,7 @@ type request struct {
 	client *client
 	query  string
 	vars   map[string]interface{}
+	gzip   bool
 }
 
 // ClientOpts encapsulates the options given to NewClient.
@@ -116,34 +121,23 @@ func (c *client) NewRequest(query string, vars map[string]interface{}) Request {
 	}
 }
 
+func (c *client) NewGzippedRequest(query string, vars map[string]interface{}) Request {
+	return &request{
+		client: c,
+		query:  query,
+		vars:   vars,
+		gzip:   true,
+	}
+}
+
+func (c *client) NewGzippedQuery(query string) Request {
+	return c.NewGzippedRequest(query, nil)
+}
+
 func (c *client) NewHTTPRequest(ctx context.Context, method, p string, body io.Reader) (*http.Request, error) {
-	if c.supportsGzip == nil {
-		// set to false, unless we have a new enough version
-		supportsGzip := false
-		c.supportsGzip = &supportsGzip
-
-		version, err := c.getSourcegraphVersion(ctx)
-
-		// ignore errors; we only care if the version is sufficently new
-		if err == nil {
-			supportsGzip, err = sourcegraphVersionCheck(version, ">= 3.21.0", "2020-10-12")
-			if err == nil {
-				c.supportsGzip = &supportsGzip
-			}
-		}
-	}
-
-	if *c.supportsGzip && body != nil {
-		body = codeintelutils.Gzip(body)
-	}
-
 	req, err := c.createHTTPRequest(ctx, method, p, body)
 	if err != nil {
 		return nil, err
-	}
-
-	if *c.supportsGzip {
-		req.Header.Set("Content-Encoding", "gzip")
 	}
 
 	return req, nil
@@ -201,10 +195,19 @@ func (r *request) do(ctx context.Context, result interface{}) (bool, error) {
 		return false, err
 	}
 
+	var bufBody io.Reader = bytes.NewBuffer(reqBody)
+	if r.gzip {
+		bufBody = codeintelutils.Gzip(bufBody)
+	}
+
 	// Create the HTTP request.
-	req, err := r.client.NewHTTPRequest(ctx, "POST", ".api/graphql", bytes.NewBuffer(reqBody))
+	req, err := r.client.NewHTTPRequest(ctx, "POST", ".api/graphql", bufBody)
 	if err != nil {
 		return false, err
+	}
+
+	if r.gzip {
+		req.Header.Set("Content-Encoding", "gzip")
 	}
 
 	// Perform the request.
@@ -302,58 +305,4 @@ func (r *request) curlCmd() (string, error) {
 	s += fmt.Sprintf("   %s \\\n", shellquote.Join("-d", string(data)))
 	s += fmt.Sprintf("   %s", shellquote.Join(r.client.opts.Endpoint+"/.api/graphql"))
 	return s, nil
-}
-
-const sourcegraphVersionQuery = `query SourcegraphVersion {
-	site {
-	  productVersion
-	}
-  }
-  `
-
-func (c *client) getSourcegraphVersion(ctx context.Context) (string, error) {
-	var sourcegraphVersion struct {
-		Data struct {
-			Site struct {
-				ProductVersion string
-			}
-		}
-	}
-
-	// Create the JSON object.
-	reqBody, err := json.Marshal(map[string]interface{}{
-		"query": sourcegraphVersionQuery,
-	})
-	if err != nil {
-		return "", err
-	}
-
-	// Create the HTTP request.
-	req, err := c.createHTTPRequest(ctx, "POST", ".api/graphql", bytes.NewBuffer(reqBody))
-	if err != nil {
-		return "", err
-	}
-
-	// Perform the request.
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return "", err
-	}
-	defer resp.Body.Close()
-
-	respBytes, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return "", err
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("checking sourcegraph backend version; got status code %d", resp.StatusCode)
-	}
-
-	err = json.Unmarshal(respBytes, &sourcegraphVersion)
-	if err != nil {
-		return "", err
-	}
-
-	return sourcegraphVersion.Data.Site.ProductVersion, err
 }

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -357,26 +357,3 @@ func (c *client) getSourcegraphVersion(ctx context.Context) (string, error) {
 
 	return sourcegraphVersion.Data.Site.ProductVersion, err
 }
-
-func sourcegraphVersionCheck(version, constraint, minDate string) (bool, error) {
-	if version == "dev" || version == "0.0.0+dev" {
-		return true, nil
-	}
-
-	buildDate := regexp.MustCompile(`^\d+_(\d{4}-\d{2}-\d{2})_[a-z0-9]{7}$`)
-	matches := buildDate.FindStringSubmatch(version)
-	if len(matches) > 1 {
-		return matches[1] >= minDate, nil
-	}
-
-	c, err := semver.NewConstraint(constraint)
-	if err != nil {
-		return false, nil
-	}
-
-	v, err := semver.NewVersion(version)
-	if err != nil {
-		return false, err
-	}
-	return c.Check(v), nil
-}

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -1,0 +1,74 @@
+package api
+
+import "testing"
+
+func TestSourcegraphVersionCheck(t *testing.T) {
+	for _, tc := range []struct {
+		currentVersion, constraint, minDate string
+		expected                            bool
+	}{
+		{
+			currentVersion: "3.12.6",
+			constraint:     ">= 3.12.6",
+			minDate:        "2020-01-19",
+			expected:       true,
+		},
+		{
+			currentVersion: "3.12.6-rc.1",
+			constraint:     ">= 3.12.6-0",
+			minDate:        "2020-01-19",
+			expected:       true,
+		},
+		{
+			currentVersion: "3.12.6",
+			constraint:     ">= 3.13",
+			minDate:        "2020-01-19",
+			expected:       false,
+		},
+		{
+			currentVersion: "3.13.0",
+			constraint:     ">= 3.13",
+			minDate:        "2020-01-19",
+			expected:       true,
+		},
+		{
+			currentVersion: "dev",
+			constraint:     ">= 3.13",
+			minDate:        "2020-01-19",
+			expected:       true,
+		},
+		{
+			currentVersion: "0.0.0+dev",
+			constraint:     ">= 3.13",
+			minDate:        "2020-01-19",
+			expected:       true,
+		},
+		{
+			currentVersion: "54959_2020-01-29_9258595",
+			minDate:        "2020-01-19",
+			constraint:     ">= 999.13",
+			expected:       true,
+		},
+		{
+			currentVersion: "54959_2020-01-29_9258595",
+			minDate:        "2020-01-30",
+			constraint:     ">= 999.13",
+			expected:       false,
+		},
+		{
+			currentVersion: "54959_2020-01-29_9258595",
+			minDate:        "2020-01-29",
+			constraint:     ">= 0.0",
+			expected:       true,
+		},
+	} {
+		actual, err := sourcegraphVersionCheck(tc.currentVersion, tc.constraint, tc.minDate)
+		if err != nil {
+			t.Errorf("err: %s", err)
+		}
+
+		if actual != tc.expected {
+			t.Errorf("wrong result. want=%t, got=%t (version=%q, constraint=%q)", tc.expected, actual, tc.currentVersion, tc.constraint)
+		}
+	}
+}

--- a/internal/api/version_check.go
+++ b/internal/api/version_check.go
@@ -1,0 +1,30 @@
+package api
+
+import (
+	"regexp"
+
+	"github.com/Masterminds/semver"
+)
+
+func CheckSourcegraphVersion(version, constraint, minDate string) (bool, error) {
+	if version == "dev" || version == "0.0.0+dev" {
+		return true, nil
+	}
+
+	buildDate := regexp.MustCompile(`^\d+_(\d{4}-\d{2}-\d{2})_[a-z0-9]{7}$`)
+	matches := buildDate.FindStringSubmatch(version)
+	if len(matches) > 1 {
+		return matches[1] >= minDate, nil
+	}
+
+	c, err := semver.NewConstraint(constraint)
+	if err != nil {
+		return false, nil
+	}
+
+	v, err := semver.NewVersion(version)
+	if err != nil {
+		return false, err
+	}
+	return c.Check(v), nil
+}

--- a/internal/api/version_check_test.go
+++ b/internal/api/version_check_test.go
@@ -2,7 +2,7 @@ package api
 
 import "testing"
 
-func TestSourcegraphVersionCheck(t *testing.T) {
+func TestCheckSourcegraphVersion(t *testing.T) {
 	for _, tc := range []struct {
 		currentVersion, constraint, minDate string
 		expected                            bool
@@ -62,7 +62,7 @@ func TestSourcegraphVersionCheck(t *testing.T) {
 			expected:       true,
 		},
 	} {
-		actual, err := sourcegraphVersionCheck(tc.currentVersion, tc.constraint, tc.minDate)
+		actual, err := CheckSourcegraphVersion(tc.currentVersion, tc.constraint, tc.minDate)
 		if err != nil {
 			t.Errorf("err: %s", err)
 		}

--- a/internal/campaigns/service.go
+++ b/internal/campaigns/service.go
@@ -17,8 +17,9 @@ import (
 )
 
 type Service struct {
-	allowUnsupported bool
-	client           api.Client
+	allowUnsupported   bool
+	client             api.Client
+	useGzipCompression bool
 }
 
 type ServiceOpts struct {
@@ -37,6 +38,57 @@ func NewService(opts *ServiceOpts) *Service {
 	}
 }
 
+const sourcegraphVersionQuery = `query SourcegraphVersion {
+	site {
+	  productVersion
+	}
+  }
+  `
+
+// getSourcegraphVersion queries the Sourcegraph GraphQL API to get the
+// current version of the Sourcegraph instance.
+func (svc *Service) getSourcegraphVersion(ctx context.Context) (string, error) {
+	var result struct {
+		Data struct {
+			Site struct {
+				ProductVersion string
+			}
+		}
+	}
+
+	ok, err := svc.client.NewQuery(sourcegraphVersionQuery).Do(ctx, &result)
+	if err != nil || !ok {
+		return "", err
+	}
+
+	return result.Data.Site.ProductVersion, err
+}
+
+// DetermineFeatureFlags fetches the version of the configured Sourcegraph
+// instance and then sets flags on the Service itself to use features available
+// in that version, e.g. gzip compression.
+func (svc *Service) DetermineFeatureFlags(ctx context.Context) error {
+	version, err := svc.getSourcegraphVersion(ctx)
+	if err != nil {
+		return errors.Wrap(err, "failed to query Sourcegraph version to check for available features")
+	}
+
+	supportsGzip, err := api.CheckSourcegraphVersion(version, ">= 3.21.0", "2020-10-12")
+	if err != nil {
+		return errors.Wrap(err, "version returned by Sourcegraph instance is invalid")
+	}
+	svc.useGzipCompression = supportsGzip
+
+	return nil
+}
+
+func (svc *Service) newRequest(query string, vars map[string]interface{}) api.Request {
+	if svc.useGzipCompression {
+		return svc.client.NewGzippedRequest(query, vars)
+	}
+	return svc.client.NewRequest(query, vars)
+}
+
 type CampaignSpecID string
 type ChangesetSpecID string
 
@@ -52,7 +104,7 @@ func (svc *Service) ApplyCampaign(ctx context.Context, spec CampaignSpecID) (*gr
 	var result struct {
 		Campaign *graphql.Campaign `json:"applyCampaign"`
 	}
-	if ok, err := svc.client.NewRequest(applyCampaignMutation, map[string]interface{}{
+	if ok, err := svc.newRequest(applyCampaignMutation, map[string]interface{}{
 		"campaignSpec": spec,
 	}).Do(ctx, &result); err != nil || !ok {
 		return nil, err
@@ -120,7 +172,7 @@ func (svc *Service) CreateChangesetSpec(ctx context.Context, spec *ChangesetSpec
 			ID string
 		}
 	}
-	if ok, err := svc.client.NewRequest(createChangesetSpecMutation, map[string]interface{}{
+	if ok, err := svc.newRequest(createChangesetSpecMutation, map[string]interface{}{
 		"spec": string(raw),
 	}).Do(ctx, &result); err != nil || !ok {
 		return "", err

--- a/internal/campaigns/service.go
+++ b/internal/campaigns/service.go
@@ -49,10 +49,8 @@ const sourcegraphVersionQuery = `query SourcegraphVersion {
 // current version of the Sourcegraph instance.
 func (svc *Service) getSourcegraphVersion(ctx context.Context) (string, error) {
 	var result struct {
-		Data struct {
-			Site struct {
-				ProductVersion string
-			}
+		Site struct {
+			ProductVersion string
 		}
 	}
 
@@ -61,7 +59,7 @@ func (svc *Service) getSourcegraphVersion(ctx context.Context) (string, error) {
 		return "", err
 	}
 
-	return result.Data.Site.ProductVersion, err
+	return result.Site.ProductVersion, err
 }
 
 // DetermineFeatureFlags fetches the version of the configured Sourcegraph
@@ -75,7 +73,7 @@ func (svc *Service) DetermineFeatureFlags(ctx context.Context) error {
 
 	supportsGzip, err := api.CheckSourcegraphVersion(version, ">= 3.21.0", "2020-10-12")
 	if err != nil {
-		return errors.Wrap(err, "version returned by Sourcegraph instance is invalid")
+		return errors.Wrap(err, "failed to check version returned by Sourcegraph")
 	}
 	svc.useGzipCompression = supportsGzip
 


### PR DESCRIPTION
This is a follow-up to https://github.com/sourcegraph/src-cli/pull/336 and addresses this comment https://github.com/sourcegraph/src-cli/pull/336#discussion_r503788437 and the broken build (see https://github.com/sourcegraph/src-cli/pull/336#issuecomment-707605116) by

- making gzip compression for GraphQL requests an opt-in feature of the `api.Client` (vs. trying to encode every request)
- making the `gzip: bool` flag a property of the `api.Request` struct to fix the data race
- pulling the version/feature-flag check out of the `api.Client` and moving it into the `campaigns.Service` where it's used to determine whether gzip compression should be used or not
- adding back the the unit tests that came with the original implementation of the `sourcegraphVersionCheck` function
- reusing the existing GraphQL-request logic in `campaigns.Service` to query the version
- adding a changelog