### PR TITLE
doc: update changelog before release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ All notable changes to `src-cli` are documented in this file.
 ### Added
 
 - The `published` flag in campaign specs may now be an array, which allows only specific changesets within a campaign to be published based on the repository name. [#294](https://github.com/sourcegraph/src-cli/pull/294)
-- A new `src campaign new` command creates a campaign spec YAML file with common values prefilled to make it easier to create a new campaign. [#339](https://github.com/sourcegraph/src-cli/pull/339)
+- The new `src campaign new` command creates a campaign spec YAML file with common values prefilled to make it easier to create a new campaign. [#339](https://github.com/sourcegraph/src-cli/pull/339)
+- The new [`src validate` command](https://docs.sourcegraph.com/admin/validation) provides a way to quickly check that a Sourcegraph instance is functioning as expected after a fresh install or update. [#200](https://github.com/sourcegraph/src-cli/pull/200)
 
 ### Changed
 


### PR DESCRIPTION
This covers the changelog we need for #200, and also makes the wording consistent between entries.