### PR TITLE
Add draft option support for publish in changeset template

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/olekukonko/tablewriter v0.0.4 // indirect
 	github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4
 	github.com/pkg/errors v0.9.1
-	github.com/sourcegraph/campaignutils v0.0.0-20200930165749-a8777d33a817
+	github.com/sourcegraph/campaignutils v0.0.0-20201014123437-b528d0e91e0c
 	github.com/sourcegraph/codeintelutils v0.0.0-20200824140252-1db3aed5cf58
 	github.com/sourcegraph/go-diff v0.6.0
 	github.com/sourcegraph/jsonx v0.0.0-20200629203448-1a936bd500cf
@@ -32,5 +32,3 @@ require (
 )
 
 replace github.com/gosuri/uilive v0.0.4 => github.com/mrnugget/uilive v0.0.4-fix-escape
-
-replace github.com/sourcegraph/campaignutils => /Users/erik/Code/sourcegraph/campaignutils

--- a/go.mod
+++ b/go.mod
@@ -32,3 +32,5 @@ require (
 )
 
 replace github.com/gosuri/uilive v0.0.4 => github.com/mrnugget/uilive v0.0.4-fix-escape
+
+replace github.com/sourcegraph/campaignutils => /Users/erik/Code/sourcegraph/campaignutils

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/olekukonko/tablewriter v0.0.4 // indirect
 	github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4
 	github.com/pkg/errors v0.9.1
-	github.com/sourcegraph/campaignutils v0.0.0-20201014123437-b528d0e91e0c
+	github.com/sourcegraph/campaignutils v0.0.0-20201014140011-721315691938
 	github.com/sourcegraph/codeintelutils v0.0.0-20200824140252-1db3aed5cf58
 	github.com/sourcegraph/go-diff v0.6.0
 	github.com/sourcegraph/jsonx v0.0.0-20200629203448-1a936bd500cf

--- a/go.sum
+++ b/go.sum
@@ -48,10 +48,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/shurcooL/go v0.0.0-20180423040247-9e1955d9fb6e/go.mod h1:TDJrrUr11Vxrven61rcy3hJMUqaf/CLWYhHNPmT14Lk=
 github.com/shurcooL/go-goon v0.0.0-20170922171312-37c2f522c041/go.mod h1:N5mDOmsrJOB+vfqUK+7DmDyjhSLIIBnXo9lvZJj3MWQ=
-github.com/sourcegraph/campaignutils v0.0.0-20200930165749-a8777d33a817 h1:mdFA7I2rnfl8AV0m8iMb4uoQb3GRdjRsgRMREoNGEk4=
-github.com/sourcegraph/campaignutils v0.0.0-20200930165749-a8777d33a817/go.mod h1:5P8k8KlKz78RZJ2EFk9k9ln/j/twj28z/+BvO5hHZJ8=
-github.com/sourcegraph/campaignutils v0.0.0-20201014123437-b528d0e91e0c h1:ZJMGX3/ZxzkY0TJzm5nbfBQeg0RM+hcAz2lp+/15Q5o=
-github.com/sourcegraph/campaignutils v0.0.0-20201014123437-b528d0e91e0c/go.mod h1:5P8k8KlKz78RZJ2EFk9k9ln/j/twj28z/+BvO5hHZJ8=
+github.com/sourcegraph/campaignutils v0.0.0-20201014140011-721315691938 h1:h5gOw7sMlYFSQFNdFPXNHJ4dtD0nlgClmL8SGAzlNM4=
+github.com/sourcegraph/campaignutils v0.0.0-20201014140011-721315691938/go.mod h1:5P8k8KlKz78RZJ2EFk9k9ln/j/twj28z/+BvO5hHZJ8=
 github.com/sourcegraph/codeintelutils v0.0.0-20200824140252-1db3aed5cf58 h1:Ps+U1xoZP+Zoph39YfRB6Q846ghO8pgrAgp0MiObvPs=
 github.com/sourcegraph/codeintelutils v0.0.0-20200824140252-1db3aed5cf58/go.mod h1:HplI8gRslTrTUUsSYwu28hSOderix7m5dHNca7xBzeo=
 github.com/sourcegraph/go-diff v0.6.0 h1:WbN9e/jD8ujU+o0vd9IFN5AEwtfB0rn/zM/AANaClqQ=

--- a/go.sum
+++ b/go.sum
@@ -50,6 +50,8 @@ github.com/shurcooL/go v0.0.0-20180423040247-9e1955d9fb6e/go.mod h1:TDJrrUr11Vxr
 github.com/shurcooL/go-goon v0.0.0-20170922171312-37c2f522c041/go.mod h1:N5mDOmsrJOB+vfqUK+7DmDyjhSLIIBnXo9lvZJj3MWQ=
 github.com/sourcegraph/campaignutils v0.0.0-20200930165749-a8777d33a817 h1:mdFA7I2rnfl8AV0m8iMb4uoQb3GRdjRsgRMREoNGEk4=
 github.com/sourcegraph/campaignutils v0.0.0-20200930165749-a8777d33a817/go.mod h1:5P8k8KlKz78RZJ2EFk9k9ln/j/twj28z/+BvO5hHZJ8=
+github.com/sourcegraph/campaignutils v0.0.0-20201014123437-b528d0e91e0c h1:ZJMGX3/ZxzkY0TJzm5nbfBQeg0RM+hcAz2lp+/15Q5o=
+github.com/sourcegraph/campaignutils v0.0.0-20201014123437-b528d0e91e0c/go.mod h1:5P8k8KlKz78RZJ2EFk9k9ln/j/twj28z/+BvO5hHZJ8=
 github.com/sourcegraph/codeintelutils v0.0.0-20200824140252-1db3aed5cf58 h1:Ps+U1xoZP+Zoph39YfRB6Q846ghO8pgrAgp0MiObvPs=
 github.com/sourcegraph/codeintelutils v0.0.0-20200824140252-1db3aed5cf58/go.mod h1:HplI8gRslTrTUUsSYwu28hSOderix7m5dHNca7xBzeo=
 github.com/sourcegraph/go-diff v0.6.0 h1:WbN9e/jD8ujU+o0vd9IFN5AEwtfB0rn/zM/AANaClqQ=

--- a/internal/campaigns/campaign_spec.go
+++ b/internal/campaigns/campaign_spec.go
@@ -41,7 +41,7 @@ type ChangesetTemplate struct {
 	Body      string                       `json:"body,omitempty" yaml:"body"`
 	Branch    string                       `json:"branch,omitempty" yaml:"branch"`
 	Commit    ExpandedGitCommitDescription `json:"commit,omitempty" yaml:"commit"`
-	Published overridable.Bool             `json:"published" yaml:"published"`
+	Published overridable.BoolOrString     `json:"published" yaml:"published"`
 }
 
 type GitCommitAuthor struct {

--- a/internal/campaigns/changeset_spec.go
+++ b/internal/campaigns/changeset_spec.go
@@ -22,7 +22,7 @@ type CreatedChangeset struct {
 	Title          string                 `json:"title"`
 	Body           string                 `json:"body"`
 	Commits        []GitCommitDescription `json:"commits"`
-	Published      bool                   `json:"published"`
+	Published      interface{}            `json:"published"`
 }
 
 type GitCommitDescription struct {

--- a/schema/campaign_spec.schema.json
+++ b/schema/campaign_spec.schema.json
@@ -156,7 +156,7 @@
           "description": "Whether to publish the changeset. An unpublished changeset can be previewed on Sourcegraph by any person who can view the campaign, but its commit, branch, and pull request aren't created on the code host. A published changeset results in a commit, branch, and pull request being created on the code host.",
           "oneOf": [
             {
-              "type": "boolean",
+              "oneOf": [{ "type": "boolean" }, { "type": "string", "pattern": "^draft$" }],
               "description": "A single flag to control the publishing state for the entire campaign."
             },
             {
@@ -165,7 +165,7 @@
               "items": {
                 "type": "object",
                 "description": "An object with one field: the key is the glob pattern to match against repository names; the value will be used as the published flag for matching repositories.",
-                "additionalProperties": { "type": "boolean" },
+                "additionalProperties": { "oneOf": [{ "type": "boolean" }, { "type": "string", "pattern": "^draft$" }] },
                 "minProperties": 1,
                 "maxProperties": 1
               }

--- a/schema/campaign_spec_stringdata.go
+++ b/schema/campaign_spec_stringdata.go
@@ -161,7 +161,7 @@ const CampaignSpecJSON = `{
           "description": "Whether to publish the changeset. An unpublished changeset can be previewed on Sourcegraph by any person who can view the campaign, but its commit, branch, and pull request aren't created on the code host. A published changeset results in a commit, branch, and pull request being created on the code host.",
           "oneOf": [
             {
-              "type": "boolean",
+              "oneOf": [{ "type": "boolean" }, { "type": "string", "pattern": "^draft$" }],
               "description": "A single flag to control the publishing state for the entire campaign."
             },
             {
@@ -170,7 +170,7 @@ const CampaignSpecJSON = `{
               "items": {
                 "type": "object",
                 "description": "An object with one field: the key is the glob pattern to match against repository names; the value will be used as the published flag for matching repositories.",
-                "additionalProperties": { "type": "boolean" },
+                "additionalProperties": { "oneOf": [{ "type": "boolean" }, { "type": "string", "pattern": "^draft$" }] },
                 "minProperties": 1,
                 "maxProperties": 1
               }


### PR DESCRIPTION
Using the introduced triple of true/false/"draft", users can now specify to open a PR in draft mode on the code host.

I'm opening this up for review, but I need to get https://github.com/sourcegraph/campaignutils/pull/3 merged first in order to merge this PR. Hence, the `go.mod` file contains some local hackery that I need to override (no pun intended) once merged.

Another PR in the series of https://github.com/sourcegraph/sourcegraph/issues/7998 towards the first milestone, getting the syntax support ready.