### PR TITLE
Print only status bars that have been activated

### DIFF
--- a/cmd/src/campaign_progress_printer.go
+++ b/cmd/src/campaign_progress_printer.go
@@ -45,7 +45,7 @@ func (p *campaignProgressPrinter) initProgressBar(statuses []*campaigns.TaskStat
 
 	statusBars := make([]*output.StatusBar, 0, numStatusBars)
 	for i := 0; i < numStatusBars; i++ {
-		statusBars = append(statusBars, output.NewStatusBarWithLabel("Starting worker..."))
+		statusBars = append(statusBars, output.NewStatusBar())
 	}
 
 	p.progress = p.out.ProgressWithStatusBars([]output.ProgressBar{{

--- a/internal/output/status_bar.go
+++ b/internal/output/status_bar.go
@@ -11,8 +11,9 @@ type StatusBar struct {
 	format string
 	args   []interface{}
 
-	startedAt  time.Time
-	finishedAt time.Time
+	initialized bool
+	startedAt   time.Time
+	finishedAt  time.Time
 }
 
 // Completef sets the StatusBar to completed and updates its text.
@@ -25,6 +26,7 @@ func (sb *StatusBar) Completef(format string, args ...interface{}) {
 
 // Resetf sets the status of the StatusBar to incomplete and updates its label and text.
 func (sb *StatusBar) Resetf(label, format string, args ...interface{}) {
+	sb.initialized = true
 	sb.completed = false
 	sb.label = label
 	sb.format = format
@@ -34,6 +36,7 @@ func (sb *StatusBar) Resetf(label, format string, args ...interface{}) {
 
 // Updatef updates the StatusBar's text.
 func (sb *StatusBar) Updatef(format string, args ...interface{}) {
+	sb.initialized = true
 	sb.format = format
 	sb.args = args
 }
@@ -52,3 +55,5 @@ func (sb *StatusBar) runtime() time.Duration {
 func NewStatusBarWithLabel(label string) *StatusBar {
 	return &StatusBar{label: label, startedAt: time.Now()}
 }
+
+func NewStatusBar() *StatusBar { return &StatusBar{} }


### PR DESCRIPTION
This fixes #348 by changing the behaviour of the
`progressWithStatusBarsTTY` to only print status bars that have been
updated/reset.

It removes the placeholder label "Starting worker..." and simply doesn't
display status bars that don't have a value yet.

@LawnGnome can you maybe test this too? I tried to replicate different scenarios (cached, uncached, subset cached, more than numProcesses, less than numProcesses) but I'm not sure whether I caught your bug.