### PR TITLE
Ensure that cache dir exists before downloading ZIP archive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ All notable changes to `src-cli` are documented in this file.
 
 ### Fixed
 
-- The cache dir used by `src campaign [preview|apply]` is now created before trying to create files in it, fixing a bug where the first run of the command could fail with a "file doesn't exist" error message.
+- The cache dir used by `src campaign [preview|apply]` is now created before trying to create files in it, fixing a bug where the first run of the command could fail with a "file doesn't exist" error message. [#352](https://github.com/sourcegraph/src-cli/pull/352)
 
 ## 3.21.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ All notable changes to `src-cli` are documented in this file.
 
 ### Fixed
 
+- The cache dir used by `src campaign [preview|apply]` is now created before trying to create files in it, fixing a bug where the first run of the command could fail with a "file doesn't exist" error message.
+
 ## 3.21.1
 
 ### Added

--- a/internal/campaigns/archive_fetcher.go
+++ b/internal/campaigns/archive_fetcher.go
@@ -86,6 +86,10 @@ func fetchRepositoryArchive(ctx context.Context, client api.Client, repo *graphq
 		return fmt.Errorf("unable to fetch archive (HTTP %d from %s)", resp.StatusCode, req.URL.String())
 	}
 
+	if err := os.MkdirAll(filepath.Dir(dest), 0700); err != nil {
+		return err
+	}
+
 	f, err := os.Create(dest)
 	if err != nil {
 		return err


### PR DESCRIPTION
Reported by a customer.