### PR TITLE
Show failed tasks as errors in statusbars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ All notable changes to `src-cli` are documented in this file.
 
 ### Changed
 
+- The progress bar in `src campaign [preview|apply]` now shows when executing a step failed in a repository by styling the line red and displaying standard error output. [#355](https://github.com/sourcegraph/src-cli/pull/355)
+
 ### Fixed
 
 ## 3.21.2

--- a/internal/campaigns/executor.go
+++ b/internal/campaigns/executor.go
@@ -32,6 +32,13 @@ func (e TaskExecutionErr) Error() string {
 	)
 }
 
+func (e TaskExecutionErr) StatusText() string {
+	if texter, ok := e.Err.(interface{ StatusText() string }); ok {
+		return texter.StatusText()
+	}
+	return e.Err.Error()
+}
+
 type Executor interface {
 	AddTask(repo *graphql.Repository, steps []Step, template *ChangesetTemplate) *TaskStatus
 	LogFiles() []string

--- a/internal/campaigns/executor.go
+++ b/internal/campaigns/executor.go
@@ -33,8 +33,8 @@ func (e TaskExecutionErr) Error() string {
 }
 
 func (e TaskExecutionErr) StatusText() string {
-	if texter, ok := e.Err.(interface{ StatusText() string }); ok {
-		return texter.StatusText()
+	if stepErr, ok := e.Err.(stepFailedErr); ok {
+		return stepErr.SingleLineError()
 	}
 	return e.Err.Error()
 }

--- a/internal/campaigns/run_steps.go
+++ b/internal/campaigns/run_steps.go
@@ -262,3 +262,10 @@ func (e stepFailedErr) Error() string {
 
 	return out.String()
 }
+
+func (e stepFailedErr) StatusText() string {
+	if len(e.Stderr) > 0 {
+		return strings.Split(e.Stderr, "\n")[0]
+	}
+	return e.Err.Error()
+}

--- a/internal/campaigns/run_steps.go
+++ b/internal/campaigns/run_steps.go
@@ -263,9 +263,11 @@ func (e stepFailedErr) Error() string {
 	return out.String()
 }
 
-func (e stepFailedErr) StatusText() string {
+func (e stepFailedErr) SingleLineError() string {
+	out := e.Err.Error()
 	if len(e.Stderr) > 0 {
-		return strings.Split(e.Stderr, "\n")[0]
+		out = e.Stderr
 	}
-	return e.Err.Error()
+
+	return strings.Split(out, "\n")[0]
 }

--- a/internal/output/progress_with_status_bars.go
+++ b/internal/output/progress_with_status_bars.go
@@ -5,6 +5,7 @@ type ProgressWithStatusBars interface {
 
 	StatusBarUpdatef(i int, format string, args ...interface{})
 	StatusBarCompletef(i int, format string, args ...interface{})
+	StatusBarFailf(i int, format string, args ...interface{})
 	StatusBarResetf(i int, label, format string, args ...interface{})
 }
 

--- a/internal/output/progress_with_status_bars_simple.go
+++ b/internal/output/progress_with_status_bars_simple.go
@@ -32,6 +32,16 @@ func (p *progressWithStatusBarsSimple) StatusBarCompletef(i int, format string, 
 	}
 }
 
+func (p *progressWithStatusBarsSimple) StatusBarFailf(i int, format string, args ...interface{}) {
+	if p.statusBars[i] != nil {
+		wasCompleted := p.statusBars[i].completed
+		p.statusBars[i].Failf(format, args...)
+		if !wasCompleted {
+			writeStatusBar(p.Output, p.statusBars[i])
+		}
+	}
+}
+
 func (p *progressWithStatusBarsSimple) StatusBarResetf(i int, label, format string, args ...interface{}) {
 	if p.statusBars[i] != nil {
 		p.statusBars[i].Resetf(label, format, args...)

--- a/internal/output/progress_with_status_bars_tty.go
+++ b/internal/output/progress_with_status_bars_tty.go
@@ -153,6 +153,17 @@ func (p *progressWithStatusBarsTTY) StatusBarCompletef(i int, format string, arg
 	p.drawInSitu()
 }
 
+func (p *progressWithStatusBarsTTY) StatusBarFailf(i int, format string, args ...interface{}) {
+	p.o.lock.Lock()
+	defer p.o.lock.Unlock()
+
+	if p.statusBars[i] != nil {
+		p.statusBars[i].Failf(format, args...)
+	}
+
+	p.drawInSitu()
+}
+
 func (p *progressWithStatusBarsTTY) draw() {
 	for _, bar := range p.bars {
 		p.writeBar(bar)
@@ -205,8 +216,13 @@ func (p *progressWithStatusBarsTTY) determineStatusBarLabelWidth() {
 func (p *progressWithStatusBarsTTY) writeStatusBar(last bool, statusBar *StatusBar) {
 	style := StylePending
 	if statusBar.completed {
-		style = StyleSuccess
+		if statusBar.failed {
+			style = StyleWarning
+		} else {
+			style = StyleSuccess
+		}
 	}
+
 	box := "├── "
 	if last {
 		box = "└── "

--- a/internal/output/status_bar.go
+++ b/internal/output/status_bar.go
@@ -6,6 +6,7 @@ import "time"
 // of a process.
 type StatusBar struct {
 	completed bool
+	failed    bool
 
 	label  string
 	format string
@@ -24,10 +25,17 @@ func (sb *StatusBar) Completef(format string, args ...interface{}) {
 	sb.finishedAt = time.Now()
 }
 
+// Failf sets the StatusBar to completed and failed and updates its text.
+func (sb *StatusBar) Failf(format string, args ...interface{}) {
+	sb.Completef(format, args...)
+	sb.failed = true
+}
+
 // Resetf sets the status of the StatusBar to incomplete and updates its label and text.
 func (sb *StatusBar) Resetf(label, format string, args ...interface{}) {
 	sb.initialized = true
 	sb.completed = false
+	sb.failed = false
 	sb.label = label
 	sb.format = format
 	sb.args = args


### PR DESCRIPTION
Yesterday I noticed that when executing steps fails in a repository we simply show "No changes" in the status bars. If you execute steps in a lot of repositories that means you'll need to wait until all of them are finished to get feedback on whether one of them failed.

This changes the behaviour from this

![before](https://user-images.githubusercontent.com/1185253/96271113-c6eb8180-0fcc-11eb-82d0-c692a8291c89.gif)

to this:

![screenshot_2020-10-16_16 28 24](https://user-images.githubusercontent.com/1185253/96271130-cce16280-0fcc-11eb-9348-4c59bcf33c26.gif)

I'm not super happy with the `StatusText()` and `SingleLineError()` methods and how to best interface them, but then again I never found wrapped errors easy to manage. If you have any ideas: let me know!