### PR TITLE
Fix killing of unresponsive containers by adding init process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ All notable changes to `src-cli` are documented in this file.
 
 ### Fixed
 
+- Unresponsive containers started by `src campaign [apply|preview]` can now be killed by hitting Ctrl-C. Previously the signal wasn't properly forwarded to the process in the container.
+
 ## 3.21.5
 
 ### Added

--- a/internal/campaigns/run_steps.go
+++ b/internal/campaigns/run_steps.go
@@ -150,6 +150,7 @@ func runSteps(ctx context.Context, wc *WorkspaceCreator, repo *graphql.Repositor
 		args := []string{
 			"run",
 			"--rm",
+			"--init",
 			"--cidfile", cidFile.Name(),
 			"--workdir", workDir,
 			"--mount", fmt.Sprintf("type=bind,source=%s,target=%s", volumeDir, workDir),


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/15314

This adds the `--init` flag to the `docker run` command so that the
entrypoint process (`bash` in our case) is started by a init process.
That fixes the behaviour of the interrupt signal simply having no
effect.

From what I could gather that's because PID 1 (which is the
`--entrypoint` in a Docker container) is protected and cannot be killed.
But `--init` is given the PID1 is an init process, which forwards the
signal to our entrypoint and kills it, exiting afterwards.

Resources:

- https://stackoverflow.com/questions/45718967/how-do-you-kill-a-docker-containers-default-command-without-killing-the-entire-c
- https://unix.stackexchange.com/questions/457649/unable-to-kill-process-with-pid-1-in-docker-container
- https://stackoverflow.com/questions/31538314/stopping-docker-container-from-inside