### PR TITLE
campaigns: restore pre-3.20 instance compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ All notable changes to `src-cli` are documented in this file.
 
 ### Fixed
 
+- Restored backward compatibility when creating campaigns against Sourcegraph 3.19, provided author details are not provided in the campaign spec. [#370](https://github.com/sourcegraph/src-cli/pull/370)
+
 ### Removed
 
 ## 3.21.6

--- a/internal/campaigns/changeset_spec.go
+++ b/internal/campaigns/changeset_spec.go
@@ -28,6 +28,6 @@ type CreatedChangeset struct {
 type GitCommitDescription struct {
 	Message     string `json:"message"`
 	Diff        string `json:"diff"`
-	AuthorName  string `json:"authorName"`
-	AuthorEmail string `json:"authorEmail"`
+	AuthorName  string `json:"authorName,omitempty"`
+	AuthorEmail string `json:"authorEmail,omitempty"`
 }

--- a/internal/campaigns/executor_test.go
+++ b/internal/campaigns/executor_test.go
@@ -144,7 +144,7 @@ func TestExecutor_Integration(t *testing.T) {
 				opts.Timeout = 5 * time.Second
 			}
 
-			executor := newExecutor(opts, client)
+			executor := newExecutor(opts, client, featuresAllEnabled())
 
 			template := &ChangesetTemplate{}
 			for _, r := range tc.repos {

--- a/internal/campaigns/features.go
+++ b/internal/campaigns/features.go
@@ -1,0 +1,32 @@
+package campaigns
+
+import (
+	"github.com/pkg/errors"
+	"github.com/sourcegraph/src-cli/internal/api"
+)
+
+// featureFlags represent features that are only available on certain
+// Sourcegraph versions and we therefore have to detect at runtime.
+type featureFlags struct {
+	includeAutoAuthorDetails bool
+	useGzipCompression       bool
+}
+
+func (ff *featureFlags) setFromVersion(version string) error {
+	for _, feature := range []struct {
+		flag       *bool
+		constraint string
+		minDate    string
+	}{
+		{&ff.includeAutoAuthorDetails, ">= 3.20.0", "2020-09-10"},
+		{&ff.useGzipCompression, ">= 3.21.0", "2020-10-12"},
+	} {
+		value, err := api.CheckSourcegraphVersion(version, feature.constraint, feature.minDate)
+		if err != nil {
+			return errors.Wrap(err, "failed to check version returned by Sourcegraph")
+		}
+		*feature.flag = value
+	}
+
+	return nil
+}

--- a/internal/campaigns/features_test.go
+++ b/internal/campaigns/features_test.go
@@ -1,0 +1,8 @@
+package campaigns
+
+func featuresAllEnabled() featureFlags {
+	return featureFlags{
+		includeAutoAuthorDetails: true,
+		useGzipCompression:       true,
+	}
+}


### PR DESCRIPTION
The author name and e-mail fields were always sent, but the schema Sourcegraph 3.19 uses to validate changeset specs don't include these fields. Since we're doing version detection for feature flags (quirks) now anyway, let's use that to not set the author name and e-mail if they're not explicitly provided when talking to a 3.19 instance.

If the user provides an author name and/or e-mail and sends a changeset spec to a pre-3.20 instance, the request will fail, but since those are 3.20 features that's OK.