### PR TITLE
Don't use git config that might be present on the host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ All notable changes to `src-cli` are documented in this file.
 
 ### Fixed
 
+- `src campaign [apply|preview]` could sometimes fail to parse the produced diffs in a repository in case `git` was configured to use a custom `diff` program. The fix is to ignore any `git` configuration. [#373](https://github.com/sourcegraph/src-cli/pull/373)
+
 ### Removed
 
 ## 3.21.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ All notable changes to `src-cli` are documented in this file.
 
 ### Fixed
 
-- `src campaign [apply|preview]` could sometimes fail to parse the produced diffs in a repository in case `git` was configured to use a custom `diff` program. The fix is to ignore any `git` configuration. [#373](https://github.com/sourcegraph/src-cli/pull/373)
+- `src campaign [apply|preview]` could fail to parse the produced diff in a repository when `git` was configured to use a custom `diff` program. The fix is to ignore any local `git` configuration when running `git` commands. [#373](https://github.com/sourcegraph/src-cli/pull/373)
 
 ### Removed
 

--- a/internal/campaigns/run_steps.go
+++ b/internal/campaigns/run_steps.go
@@ -39,6 +39,8 @@ func runSteps(ctx context.Context, wc *WorkspaceCreator, repo *graphql.Repositor
 			// looking warnings.
 			"GIT_AUTHOR_NAME=Sourcegraph",
 			"GIT_AUTHOR_EMAIL=campaigns@sourcegraph.com",
+			"GIT_COMMITTER_NAME=Sourcegraph",
+			"GIT_COMMITTER_EMAIL=campaigns@sourcegraph.com",
 		}
 		cmd.Dir = volumeDir
 		out, err := cmd.CombinedOutput()

--- a/internal/campaigns/run_steps.go
+++ b/internal/campaigns/run_steps.go
@@ -28,6 +28,18 @@ func runSteps(ctx context.Context, wc *WorkspaceCreator, repo *graphql.Repositor
 
 	runGitCmd := func(args ...string) ([]byte, error) {
 		cmd := exec.CommandContext(ctx, "git", args...)
+		cmd.Env = []string{
+			// Don't use the system wide git config.
+			"GIT_CONFIG_NOSYSTEM=1",
+			// And also not any other, because they can mess up output, change defaults, .. which can do unexpected things.
+			"GIT_CONFIG=/dev/null",
+			// Set user.name and user.email in the local repository. The user name and
+			// e-mail will eventually be ignored anyway, since we're just using the Git
+			// repository to generate diffs, but we don't want git to generate alarming
+			// looking warnings.
+			"GIT_AUTHOR_NAME=Sourcegraph",
+			"GIT_AUTHOR_EMAIL=campaigns@sourcegraph.com",
+		}
 		cmd.Dir = volumeDir
 		out, err := cmd.CombinedOutput()
 		if err != nil {
@@ -39,17 +51,6 @@ func runSteps(ctx context.Context, wc *WorkspaceCreator, repo *graphql.Repositor
 	reportProgress("Initializing workspace")
 	if _, err := runGitCmd("init"); err != nil {
 		return nil, errors.Wrap(err, "git init failed")
-	}
-
-	// Set user.name and user.email in the local repository. The user name and
-	// e-mail will eventually be ignored anyway, since we're just using the Git
-	// repository to generate diffs, but we don't want git to generate alarming
-	// looking warnings.
-	if _, err := runGitCmd("config", "--local", "user.name", "Sourcegraph"); err != nil {
-		return nil, errors.Wrap(err, "git config user.name failed")
-	}
-	if _, err := runGitCmd("config", "--local", "user.email", "campaigns@sourcegraph.com"); err != nil {
-		return nil, errors.Wrap(err, "git config user.email failed")
 	}
 
 	// --force because we want previously "gitignored" files in the repository


### PR DESCRIPTION
This can cause unexpected git behavior, like a different diff tool, ANSI coloring in the diff and probably other bad magic.

Closes https://github.com/sourcegraph/src-cli/issues/371