### PR TITLE
CI: remove last vestiges of Travis

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -10,10 +10,12 @@ go install ./cmd/src
 ## Releasing
 
 1.  If this is a non-patch release, update the changelog. Add a new section `## $MAJOR.MINOR` to [`CHANGELOG.md`](https://github.com/sourcegraph/src-cli/blob/main/CHANGELOG.md#unreleased) immediately under `## Unreleased changes`. Add new empty `Added`, `Changed`, `Fixed`, and `Removed` sections under `## Unreleased changes`.
-1.  Find the latest version (either via the releases tab on GitHub or via git tags) to determine which version you are releasing.
-2.  `VERSION=9.9.9 ./release.sh` (replace `9.9.9` with the version you are releasing)
-3.  Travis will automatically perform the release, which you can find [on the branches tab](https://travis-ci.org/github/sourcegraph/src-cli/branches). Once it has finished, **confirm that the curl commands fetch the latest version above**.
-4.  Update the `MinimumVersion` constant in the [src-cli package](https://github.com/sourcegraph/sourcegraph/tree/main/internal/src-cli/consts.go).
+2.  Find the latest version (either via the releases tab on GitHub or via git tags) to determine which version you are releasing.
+3.  `VERSION=9.9.9 ./release.sh` (replace `9.9.9` with the version you are releasing)
+4.  GitHub will automatically perform the release via the [goreleaser action](https://github.com/sourcegraph/src-cli/actions?query=workflow%3AGoreleaser). Once it has finished, **you need to confirm**:
+    1. The [curl commands in the README](README.markdown#installation) fetch the latest version above.
+    2. The [releases section of the repo sidebar](https://github.com/sourcegraph/src-cli) shows the correct version.
+5.  Update the `MinimumVersion` constant in the [src-cli package](https://github.com/sourcegraph/sourcegraph/tree/main/internal/src-cli/consts.go).
 
 ### Patch releases
 

--- a/README.markdown
+++ b/README.markdown
@@ -1,4 +1,4 @@
-# [Sourcegraph](https://sourcegraph.com) CLI [![Build Status](https://travis-ci.org/sourcegraph/src-cli.svg)](https://travis-ci.org/sourcegraph/src-cli) [![Go Report Card](https://goreportcard.com/badge/sourcegraph/src-cli)](https://goreportcard.com/report/sourcegraph/src-cli)
+# [Sourcegraph](https://sourcegraph.com) CLI [![Build Status](https://github.com/sourcegraph/src-cli/workflows/Go%20CI/badge.svg)](https://github.com/sourcegraph/src-cli/actions?query=workflow%3A%22Go+CI%22) [![Go Report Card](https://goreportcard.com/badge/sourcegraph/src-cli)](https://goreportcard.com/report/sourcegraph/src-cli)
 
 <img src="https://user-images.githubusercontent.com/3173176/43567326-3db5f31c-95e6-11e8-9e74-4c04079c01b0.png" width=500 align=right>
 


### PR DESCRIPTION
As @chrispine noticed when releasing 3.21.9, we have a dangling reference to Travis in our release checklist. We also still had the old CI badge kicking around, so let's fix them both at once.