### PR TITLE
Fix out-of-bounds panic in progress printer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ All notable changes to `src-cli` are documented in this file.
 
 ### Fixed
 
+- Fixed a bug that could cause `src campaign [apply|preview]` to crash in rare circumstances when executing a campaign spec due to a bug in the logic for the progress bar. [#378](https://github.com/sourcegraph/src-cli/pull/378)
+
 ### Removed
 
 ## 3.21.9
@@ -24,7 +26,6 @@ All notable changes to `src-cli` are documented in this file.
 ### Added
 
 - Commands for campaigns no longer require the `-namespace` parameter. If omitted, campaigns will use the currently authenticated user as the namespace. [#372](https://github.com/sourcegraph/src-cli/pull/372)
-
 - `src campaign [apply|preview]` now caches the result of running steps in a repository even if they didn't produce changes.
 
 ## 3.21.8


### PR DESCRIPTION
We ran into an out-of-bounds panic when we had more tasks reporting as
"currently running" than the number of status bars we had.

That was due to a lack of defensive checks in the face of a possible
race condition.

The race condition leads the `PrintStatuses` method seeing more
"currently running" tasks than there can technically be.

The race condition is between the `PrintStatus` method that prints the
slices of pointers to `*TaskStatus` and the tasks themselves updating
the status non-atomatically.

At least that's what it seems like. I'm not 100% sure about the cause
yet, but I could reproduce the issue by simply injecting more statuses
at the top of `PrintStatuses`. The code here fixes it.

---

I'm still trying to find out exactly why it happens, but I do think this code should be in there in _any case_, that's why I'm opening up this PR.