### PR TITLE
Return error if additional args passed to campaigns command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ All notable changes to `src-cli` are documented in this file.
 
 ### Fixed
 
+- `src campaign [validate|apply|preview]` now print an error and usage information if a user accidentally provides an additional argument. [#384](https://github.com/sourcegraph/src-cli/pull/384)
+
 ### Removed
 
 ## 3.22.0

--- a/cmd/src/campaigns_apply.go
+++ b/cmd/src/campaigns_apply.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 
@@ -55,6 +56,10 @@ Examples:
 	handler := func(args []string) error {
 		if err := flagSet.Parse(args); err != nil {
 			return err
+		}
+
+		if len(flagSet.Args()) != 0 {
+			return &usageError{errors.New("additional arguments not allowed")}
 		}
 
 		out := output.NewOutput(flagSet.Output(), output.OutputOpts{Verbose: *verbose})

--- a/cmd/src/campaigns_preview.go
+++ b/cmd/src/campaigns_preview.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 
@@ -30,6 +31,10 @@ Examples:
 	handler := func(args []string) error {
 		if err := flagSet.Parse(args); err != nil {
 			return err
+		}
+
+		if len(flagSet.Args()) != 0 {
+			return &usageError{errors.New("additional arguments not allowed")}
 		}
 
 		out := output.NewOutput(flagSet.Output(), output.OutputOpts{Verbose: *verbose})

--- a/cmd/src/campaigns_validate.go
+++ b/cmd/src/campaigns_validate.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 
@@ -28,6 +29,10 @@ Examples:
 	handler := func(args []string) error {
 		if err := flagSet.Parse(args); err != nil {
 			return err
+		}
+
+		if len(flagSet.Args()) != 0 {
+			return &usageError{errors.New("additional arguments not allowed")}
 		}
 
 		specFile, err := campaignsOpenFileFlag(fileFlag)

--- a/cmd/src/cmd.go
+++ b/cmd/src/cmd.go
@@ -93,7 +93,7 @@ func (c commander) run(flagSet *flag.FlagSet, cmdName, usageText string, args []
 		// Execute the subcommand.
 		if err := cmd.handler(flagSet.Args()[1:]); err != nil {
 			if _, ok := err.(*usageError); ok {
-				log.Println(err)
+				log.Printf("error: %s\n\n", err)
 				cmd.flagSet.Usage()
 				os.Exit(2)
 			}


### PR DESCRIPTION
This should stop users from running into https://github.com/sourcegraph/src-cli/issues/383