### PR TITLE
Clean up partially-downloaded ZIP files if aborted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ All notable changes to `src-cli` are documented in this file.
 
 ### Fixed
 
+- If `src campaign [validate|apply|preview]` was aborted while it was downloading repository archives it could leave behind partial ZIP files that would produce an error on the next run. This is now fixed by deleting partial files on abort. [#388](https://github.com/sourcegraph/src-cli/pull/388)
+
 ### Removed
 
 ## 3.22.1

--- a/internal/campaigns/archive_fetcher.go
+++ b/internal/campaigns/archive_fetcher.go
@@ -34,7 +34,14 @@ func (wc *WorkspaceCreator) Create(ctx context.Context, repo *graphql.Repository
 	}
 
 	if !exists {
-		if err := fetchRepositoryArchive(ctx, wc.client, repo, path); err != nil {
+		err = fetchRepositoryArchive(ctx, wc.client, repo, path)
+		if err != nil {
+			if errors.Is(err, context.Canceled) || errors.Cause(err) == context.Canceled {
+				// If the context got cancelled while we were downloading the
+				// file, we remove the partially downloaded file.
+				os.Remove(path)
+			}
+
 			return "", errors.Wrap(err, "fetching ZIP archive")
 		}
 	}

--- a/internal/campaigns/archive_fetcher.go
+++ b/internal/campaigns/archive_fetcher.go
@@ -36,11 +36,10 @@ func (wc *WorkspaceCreator) Create(ctx context.Context, repo *graphql.Repository
 	if !exists {
 		err = fetchRepositoryArchive(ctx, wc.client, repo, path)
 		if err != nil {
-			if errors.Is(err, context.Canceled) || errors.Cause(err) == context.Canceled {
-				// If the context got cancelled while we were downloading the
-				// file, we remove the partially downloaded file.
-				os.Remove(path)
-			}
+			// If the context got cancelled, or we ran out of disk space, or
+			// ... while we were downloading the file, we remove the partially
+			// downloaded file.
+			os.Remove(path)
 
 			return "", errors.Wrap(err, "fetching ZIP archive")
 		}


### PR DESCRIPTION
This fixes https://github.com/sourcegraph/sourcegraph/issues/15865

This fixes a bug where src-cli would leave partially-downloaded ZIP
files behind when the user hit Ctrl-C while a download was ongoing.

The `fetchRepositoryArchive` would then run into a context-cancelation
error when doing the request or the `io.Copy` and not clean up the file.

The code here checks whether the cause of the error is a cancelation
and, if so, cleans up the zip file.