### PR TITLE
campaigns: allow env usage in campaign steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to `src-cli` are documented in this file.
 
 ### Added
 
+- Campaign steps may now include environment variables from outside of the campaign spec using [array syntax](http://docs.sourcegraph.com/campaigns/references/campaign_spec_yaml_reference#environment-array). [#392](https://github.com/sourcegraph/src-cli/pull/392)
+
 ### Changed
 
 ### Fixed

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/olekukonko/tablewriter v0.0.4 // indirect
 	github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4
 	github.com/pkg/errors v0.9.1
-	github.com/sourcegraph/campaignutils v0.0.0-20201016010611-63eb2bca27ad
+	github.com/sourcegraph/campaignutils v0.0.0-20201123212545-3f96e1fcd9b3
 	github.com/sourcegraph/codeintelutils v0.0.0-20201118031531-b82ba3167b30
 	github.com/sourcegraph/go-diff v0.6.1
 	github.com/sourcegraph/jsonx v0.0.0-20200629203448-1a936bd500cf

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/olekukonko/tablewriter v0.0.4 // indirect
 	github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4
 	github.com/pkg/errors v0.9.1
-	github.com/sourcegraph/campaignutils v0.0.0-20201123212545-3f96e1fcd9b3
+	github.com/sourcegraph/campaignutils v0.0.0-20201124055807-2f9cfa9317e2
 	github.com/sourcegraph/codeintelutils v0.0.0-20201118031531-b82ba3167b30
 	github.com/sourcegraph/go-diff v0.6.1
 	github.com/sourcegraph/jsonx v0.0.0-20200629203448-1a936bd500cf

--- a/go.sum
+++ b/go.sum
@@ -50,8 +50,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/shurcooL/go v0.0.0-20180423040247-9e1955d9fb6e/go.mod h1:TDJrrUr11Vxrven61rcy3hJMUqaf/CLWYhHNPmT14Lk=
 github.com/shurcooL/go-goon v0.0.0-20170922171312-37c2f522c041/go.mod h1:N5mDOmsrJOB+vfqUK+7DmDyjhSLIIBnXo9lvZJj3MWQ=
-github.com/sourcegraph/campaignutils v0.0.0-20201123212545-3f96e1fcd9b3 h1:JYGPqpRHJ5fWUFRomZ4Zgvn5N15hrdQDhY03Pp1g7Wc=
-github.com/sourcegraph/campaignutils v0.0.0-20201123212545-3f96e1fcd9b3/go.mod h1:xm6i78Mk2t4DBLQDqEFc/3x6IPf7yYZCgbNaTQGhJHA=
+github.com/sourcegraph/campaignutils v0.0.0-20201124055807-2f9cfa9317e2 h1:MJu/6WzWdPegzYnZLb04IS0u4VyUpPIAHQyWT5i2vR8=
+github.com/sourcegraph/campaignutils v0.0.0-20201124055807-2f9cfa9317e2/go.mod h1:xm6i78Mk2t4DBLQDqEFc/3x6IPf7yYZCgbNaTQGhJHA=
 github.com/sourcegraph/codeintelutils v0.0.0-20201118031531-b82ba3167b30 h1:HrRrPyskdkHc6MqQS3ehH+DSraFnOhtvBWQ6AzEJC1o=
 github.com/sourcegraph/codeintelutils v0.0.0-20201118031531-b82ba3167b30/go.mod h1:HplI8gRslTrTUUsSYwu28hSOderix7m5dHNca7xBzeo=
 github.com/sourcegraph/go-diff v0.6.1 h1:hmA1LzxW0n1c3Q4YbrFgg4P99GSnebYa3x8gr0HZqLQ=

--- a/go.sum
+++ b/go.sum
@@ -50,8 +50,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/shurcooL/go v0.0.0-20180423040247-9e1955d9fb6e/go.mod h1:TDJrrUr11Vxrven61rcy3hJMUqaf/CLWYhHNPmT14Lk=
 github.com/shurcooL/go-goon v0.0.0-20170922171312-37c2f522c041/go.mod h1:N5mDOmsrJOB+vfqUK+7DmDyjhSLIIBnXo9lvZJj3MWQ=
-github.com/sourcegraph/campaignutils v0.0.0-20201016010611-63eb2bca27ad h1:HeSWFpxau4Jqk0s4yEhOdep+KYrJDm0497uhb/hnsgU=
-github.com/sourcegraph/campaignutils v0.0.0-20201016010611-63eb2bca27ad/go.mod h1:xm6i78Mk2t4DBLQDqEFc/3x6IPf7yYZCgbNaTQGhJHA=
+github.com/sourcegraph/campaignutils v0.0.0-20201123212545-3f96e1fcd9b3 h1:JYGPqpRHJ5fWUFRomZ4Zgvn5N15hrdQDhY03Pp1g7Wc=
+github.com/sourcegraph/campaignutils v0.0.0-20201123212545-3f96e1fcd9b3/go.mod h1:xm6i78Mk2t4DBLQDqEFc/3x6IPf7yYZCgbNaTQGhJHA=
 github.com/sourcegraph/codeintelutils v0.0.0-20201118031531-b82ba3167b30 h1:HrRrPyskdkHc6MqQS3ehH+DSraFnOhtvBWQ6AzEJC1o=
 github.com/sourcegraph/codeintelutils v0.0.0-20201118031531-b82ba3167b30/go.mod h1:HplI8gRslTrTUUsSYwu28hSOderix7m5dHNca7xBzeo=
 github.com/sourcegraph/go-diff v0.6.1 h1:hmA1LzxW0n1c3Q4YbrFgg4P99GSnebYa3x8gr0HZqLQ=

--- a/internal/campaigns/execution_cache_test.go
+++ b/internal/campaigns/execution_cache_test.go
@@ -1,7 +1,6 @@
 package campaigns
 
 import (
-	"encoding/json"
 	"os"
 	"testing"
 
@@ -31,7 +30,7 @@ func TestExecutionCacheKey(t *testing.T) {
 	key := ExecutionCacheKey{&Task{Steps: steps}}
 
 	// All righty. Let's get ourselves a baseline cache key here.
-	initial, err := json.Marshal(key)
+	initial, err := key.Key()
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -41,7 +40,7 @@ func TestExecutionCacheKey(t *testing.T) {
 	if err := os.Setenv(testExecutionCacheKeyEnv+"_UNRELATED", "foo"); err != nil {
 		t.Fatal(err)
 	}
-	have, err := json.Marshal(key)
+	have, err := key.Key()
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -54,7 +53,7 @@ func TestExecutionCacheKey(t *testing.T) {
 	if err := os.Setenv(testExecutionCacheKeyEnv, "foo"); err != nil {
 		t.Fatal(err)
 	}
-	have, err = json.Marshal(key)
+	have, err = key.Key()
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -66,7 +65,7 @@ func TestExecutionCacheKey(t *testing.T) {
 	if err := os.Setenv(testExecutionCacheKeyEnv, "bar"); err != nil {
 		t.Fatal(err)
 	}
-	again, err := json.Marshal(key)
+	again, err := key.Key()
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -79,7 +78,7 @@ func TestExecutionCacheKey(t *testing.T) {
 	if err := os.Unsetenv(testExecutionCacheKeyEnv); err != nil {
 		t.Fatal(err)
 	}
-	have, err = json.Marshal(key)
+	have, err = key.Key()
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}

--- a/internal/campaigns/execution_cache_test.go
+++ b/internal/campaigns/execution_cache_test.go
@@ -1,0 +1,89 @@
+package campaigns
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"gopkg.in/yaml.v2"
+)
+
+const testExecutionCacheKeyEnv = "TEST_EXECUTION_CACHE_KEY_ENV"
+
+func TestExecutionCacheKey(t *testing.T) {
+	// Let's set up an array of steps that we can test with. One step will
+	// depend on an environment variable outside the spec.
+	var steps []Step
+	if err := yaml.Unmarshal([]byte(`
+- run: foo
+  env:
+    FOO: BAR
+
+- run: bar
+  env:
+    - FOO: BAR
+    - `+testExecutionCacheKeyEnv+`
+`), &steps); err != nil {
+		t.Fatal(err)
+	}
+
+	// And now we can set up a key to work with.
+	key := ExecutionCacheKey{&Task{Steps: steps}}
+
+	// All righty. Let's get ourselves a baseline cache key here.
+	initial, err := json.Marshal(key)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// Let's set an unrelated environment variable and ensure we still have the
+	// same key.
+	if err := os.Setenv(testExecutionCacheKeyEnv+"_UNRELATED", "foo"); err != nil {
+		t.Fatal(err)
+	}
+	have, err := json.Marshal(key)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if string(initial) != string(have) {
+		t.Errorf("unexpected change in key: initial=%q have=%q", initial, have)
+	}
+
+	// Let's now set the environment variable referenced in the steps and verify
+	// that the cache key does change.
+	if err := os.Setenv(testExecutionCacheKeyEnv, "foo"); err != nil {
+		t.Fatal(err)
+	}
+	have, err = json.Marshal(key)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if string(initial) == string(have) {
+		t.Errorf("unexpected lack of change in key: %q", have)
+	}
+
+	// And, just to be sure, let's change it again.
+	if err := os.Setenv(testExecutionCacheKeyEnv, "bar"); err != nil {
+		t.Fatal(err)
+	}
+	again, err := json.Marshal(key)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if string(initial) == string(again) || string(have) == string(again) {
+		t.Errorf("unexpected lack of change in key: %q", again)
+	}
+
+	// Finally, if we unset the environment variable again, we should get a key
+	// that matches the initial key.
+	if err := os.Unsetenv(testExecutionCacheKeyEnv); err != nil {
+		t.Fatal(err)
+	}
+	have, err = json.Marshal(key)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if string(initial) != string(have) {
+		t.Errorf("unexpected change in key: initial=%q have=%q", initial, have)
+	}
+}

--- a/internal/campaigns/features.go
+++ b/internal/campaigns/features.go
@@ -8,6 +8,7 @@ import (
 // featureFlags represent features that are only available on certain
 // Sourcegraph versions and we therefore have to detect at runtime.
 type featureFlags struct {
+	allowArrayEnvironments   bool
 	includeAutoAuthorDetails bool
 	useGzipCompression       bool
 }
@@ -18,6 +19,7 @@ func (ff *featureFlags) setFromVersion(version string) error {
 		constraint string
 		minDate    string
 	}{
+		{&ff.allowArrayEnvironments, ">= 3.23.0", "2020-11-24"},
 		{&ff.includeAutoAuthorDetails, ">= 3.20.0", "2020-09-10"},
 		{&ff.useGzipCompression, ">= 3.21.0", "2020-10-12"},
 	} {

--- a/internal/campaigns/features_test.go
+++ b/internal/campaigns/features_test.go
@@ -2,6 +2,7 @@ package campaigns
 
 func featuresAllEnabled() featureFlags {
 	return featureFlags{
+		allowArrayEnvironments:   true,
 		includeAutoAuthorDetails: true,
 		useGzipCompression:       true,
 	}

--- a/internal/campaigns/run_steps.go
+++ b/internal/campaigns/run_steps.go
@@ -168,10 +168,16 @@ func runSteps(ctx context.Context, wc *WorkspaceCreator, repo *graphql.Repositor
 			filesToMount[name] = fp
 		}
 
-		// Render the step.Env variables as templates.
-		env, err := renderStepEnv(step.Env, &stepContext)
+		// Resolve step.Env given the current environment.
+		stepEnv, err := step.Env.Resolve(os.Environ())
 		if err != nil {
-			return nil, errors.Wrap(err, "parsing step files")
+			return nil, errors.Wrap(err, "resolving step environment")
+		}
+
+		// Render the step.Env variables as templates.
+		env, err := renderStepEnv(stepEnv, &stepContext)
+		if err != nil {
+			return nil, errors.Wrap(err, "parsing step environment")
 		}
 
 		reportProgress(runScript.String())

--- a/internal/campaigns/service.go
+++ b/internal/campaigns/service.go
@@ -293,7 +293,7 @@ func (svc *Service) ParseCampaignSpec(in io.Reader) (*CampaignSpec, string, erro
 		return nil, "", errors.Wrap(err, "reading campaign spec")
 	}
 
-	spec, err := ParseCampaignSpec(data)
+	spec, err := ParseCampaignSpec(data, svc.features)
 	if err != nil {
 		return nil, "", errors.Wrap(err, "parsing campaign spec")
 	}

--- a/schema/campaign_spec.schema.json
+++ b/schema/campaign_spec.schema.json
@@ -76,11 +76,34 @@
             "examples": ["alpine:3"]
           },
           "env": {
-            "type": "object",
-            "description": "Environment variables to set in the environment when running this command.",
-            "additionalProperties": {
-              "type": "string"
-            }
+            "description": "Environment variables to set in the step environment.",
+            "oneOf": [
+              {
+                "type": "object",
+                "description": "Environment variables to set in the step environment.",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              },
+              {
+                "type": "array",
+                "items": {
+                  "oneOf": [
+                    {
+                      "type": "string",
+                      "description": "An environment variable to set in the step environment: the value will be passed through from the environment src is running within."
+                    },
+                    {
+                      "type": "object",
+                      "description": "An environment variable to set in the step environment: the value will be passed through from the environment src is running within.",
+                      "additionalProperties": { "type": "string" },
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ]
+                }
+              }
+            ]
           },
           "files": {
             "type": "object",

--- a/schema/campaign_spec_stringdata.go
+++ b/schema/campaign_spec_stringdata.go
@@ -81,11 +81,34 @@ const CampaignSpecJSON = `{
             "examples": ["alpine:3"]
           },
           "env": {
-            "type": "object",
-            "description": "Environment variables to set in the environment when running this command.",
-            "additionalProperties": {
-              "type": "string"
-            }
+            "description": "Environment variables to set in the step environment.",
+            "oneOf": [
+              {
+                "type": "object",
+                "description": "Environment variables to set in the step environment.",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              },
+              {
+                "type": "array",
+                "items": {
+                  "oneOf": [
+                    {
+                      "type": "string",
+                      "description": "An environment variable to set in the step environment: the value will be passed through from the environment src is running within."
+                    },
+                    {
+                      "type": "object",
+                      "description": "An environment variable to set in the step environment: the value will be passed through from the environment src is running within.",
+                      "additionalProperties": { "type": "string" },
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ]
+                }
+              }
+            ]
           },
           "files": {
             "type": "object",


### PR DESCRIPTION
This is the src-cli component of sourcegraph/sourcegraph#15822.

There's also a new feature flag in here to maintain backward compatibility with older Sourcegraph versions, at the cost of extra work when parsing the campaign spec. I think that's the right tradeoff.