### PR TITLE
Query and use the repository.branch when defined in spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ All notable changes to `src-cli` are documented in this file.
 
 ### Fixed
 
+- The evaluation of the [`repository.branch` attribute](https://docs.sourcegraph.com/campaigns/references/campaign_spec_yaml_reference#on-repository) has been fixed to actually cause the correct version of the repository to be used. [#393](https://github.com/sourcegraph/src-cli/pull/393)
+
 ### Removed
 
 ## 3.22.3

--- a/cmd/src/campaigns_common.go
+++ b/cmd/src/campaigns_common.go
@@ -234,6 +234,10 @@ func campaignsExecute(ctx context.Context, out *output.Output, svc *campaigns.Se
 		campaignsCompletePending(pending, "Resolved repositories")
 	}
 
+	for _, r := range repos {
+		fmt.Printf("Name=%s, BaseRef()=%s, Rev()=%s\n", r.Name, r.BaseRef(), r.Rev())
+	}
+
 	p := newCampaignProgressPrinter(out, *verbose, opts.Parallelism)
 	specs, err := svc.ExecuteCampaignSpec(ctx, repos, executor, campaignSpec, p.PrintStatuses)
 	if err != nil {

--- a/cmd/src/campaigns_common.go
+++ b/cmd/src/campaigns_common.go
@@ -234,10 +234,6 @@ func campaignsExecute(ctx context.Context, out *output.Output, svc *campaigns.Se
 		campaignsCompletePending(pending, "Resolved repositories")
 	}
 
-	for _, r := range repos {
-		fmt.Printf("Name=%s, BaseRef()=%s, Rev()=%s\n", r.Name, r.BaseRef(), r.Rev())
-	}
-
 	p := newCampaignProgressPrinter(out, *verbose, opts.Parallelism)
 	specs, err := svc.ExecuteCampaignSpec(ctx, repos, executor, campaignSpec, p.PrintStatuses)
 	if err != nil {

--- a/internal/campaigns/archive_fetcher.go
+++ b/internal/campaigns/archive_fetcher.go
@@ -120,12 +120,11 @@ func fetchRepositoryArchive(ctx context.Context, client api.Client, repo *graphq
 }
 
 func repositoryZipArchivePath(repo *graphql.Repository) string {
-	return path.Join("", repo.Name+"@"+repo.DefaultBranch.Name, "-", "raw")
+	return path.Join("", repo.Name+"@"+repo.BaseRef(), "-", "raw")
 }
 
 func localRepositoryZipArchivePath(dir string, repo *graphql.Repository) string {
-	ref := repo.DefaultBranch.Target.OID
-	return filepath.Join(dir, fmt.Sprintf("%s-%s.zip", repo.Slug(), ref))
+	return filepath.Join(dir, fmt.Sprintf("%s-%s.zip", repo.Slug(), repo.Rev()))
 }
 
 func unzip(zipFile, dest string) error {

--- a/internal/campaigns/archive_fetcher_test.go
+++ b/internal/campaigns/archive_fetcher_test.go
@@ -30,7 +30,7 @@ func TestWorkspaceCreator_Create(t *testing.T) {
 	repo := &graphql.Repository{
 		ID:            "src-cli",
 		Name:          "github.com/sourcegraph/src-cli",
-		DefaultBranch: &graphql.Branch{Name: "main", Target: struct{ OID string }{OID: "d34db33f"}},
+		DefaultBranch: &graphql.Branch{Name: "main", Target: graphql.Target{OID: "d34db33f"}},
 	}
 
 	archive := mockRepoArchive{
@@ -154,6 +154,48 @@ func TestWorkspaceCreator_Create(t *testing.T) {
 		}
 		if ok {
 			t.Fatalf("zip file in temp dir was not cleaned up")
+		}
+	})
+
+	t.Run("non-default branch", func(t *testing.T) {
+		otherBranchOID := "f00b4r"
+		repo := &graphql.Repository{
+			ID:            "src-cli-with-non-main-branch",
+			Name:          "github.com/sourcegraph/src-cli",
+			DefaultBranch: &graphql.Branch{Name: "main", Target: graphql.Target{OID: "d34db33f"}},
+			Branches: struct {
+				Nodes []*graphql.Branch
+			}{
+				Nodes: []*graphql.Branch{
+					&graphql.Branch{Name: "other-branch", Target: graphql.Target{OID: otherBranchOID}},
+				},
+			},
+		}
+
+		archive := mockRepoArchive{repo: repo, files: map[string]string{}}
+
+		ts := httptest.NewServer(newZipArchivesMux(t, nil, archive))
+		defer ts.Close()
+
+		var clientBuffer bytes.Buffer
+		client := api.NewClient(api.ClientOpts{Endpoint: ts.URL, Out: &clientBuffer})
+
+		testTempDir := workspaceTmpDir(t)
+
+		creator := &WorkspaceCreator{dir: testTempDir, client: client}
+
+		_, err := creator.Create(context.Background(), repo)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+
+		wantZipFile := "github.com-sourcegraph-src-cli-" + otherBranchOID + ".zip"
+		ok, err := dirContains(creator.dir, wantZipFile)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !ok {
+			t.Fatalf("temp dir doesnt contain zip file")
 		}
 	})
 }

--- a/internal/campaigns/archive_fetcher_test.go
+++ b/internal/campaigns/archive_fetcher_test.go
@@ -163,13 +163,9 @@ func TestWorkspaceCreator_Create(t *testing.T) {
 			ID:            "src-cli-with-non-main-branch",
 			Name:          "github.com/sourcegraph/src-cli",
 			DefaultBranch: &graphql.Branch{Name: "main", Target: graphql.Target{OID: "d34db33f"}},
-			Branches: struct {
-				Nodes []*graphql.Branch
-			}{
-				Nodes: []*graphql.Branch{
-					&graphql.Branch{Name: "other-branch", Target: graphql.Target{OID: otherBranchOID}},
-				},
-			},
+
+			Commit: graphql.Target{OID: otherBranchOID},
+			Branch: graphql.Branch{Name: "other-branch", Target: graphql.Target{OID: otherBranchOID}},
 		}
 
 		archive := mockRepoArchive{repo: repo, files: map[string]string{}}

--- a/internal/campaigns/executor_test.go
+++ b/internal/campaigns/executor_test.go
@@ -37,14 +37,23 @@ func TestExecutor_Integration(t *testing.T) {
 	srcCLIRepo := &graphql.Repository{
 		ID:            "src-cli",
 		Name:          "github.com/sourcegraph/src-cli",
-		DefaultBranch: &graphql.Branch{Name: "main", Target: struct{ OID string }{OID: "d34db33f"}},
+		DefaultBranch: &graphql.Branch{Name: "main", Target: graphql.Target{OID: "d34db33f"}},
 	}
 	sourcegraphRepo := &graphql.Repository{
 		ID:   "sourcegraph",
 		Name: "github.com/sourcegraph/sourcegraph",
 		DefaultBranch: &graphql.Branch{
 			Name:   "main",
-			Target: struct{ OID string }{OID: "f00b4r3r"},
+			Target: graphql.Target{OID: "f00b4r3r"},
+		},
+
+		Branches: graphql.Branches{
+			Nodes: []*graphql.Branch{
+				&graphql.Branch{
+					Name:   "other-branch",
+					Target: graphql.Target{OID: "0therbr4nch"},
+				},
+			},
 		},
 	}
 
@@ -220,7 +229,7 @@ func newZipArchivesMux(t *testing.T, callback http.HandlerFunc, archives ...mock
 
 	for _, archive := range archives {
 		files := archive.files
-		path := fmt.Sprintf("/%s@%s/-/raw", archive.repo.Name, archive.repo.DefaultBranch.Name)
+		path := fmt.Sprintf("/%s@%s/-/raw", archive.repo.Name, archive.repo.BaseRef())
 
 		downloadName := filepath.Base(archive.repo.Name)
 		mediaType := mime.FormatMediaType("Attachment", map[string]string{

--- a/internal/campaigns/executor_test.go
+++ b/internal/campaigns/executor_test.go
@@ -46,15 +46,6 @@ func TestExecutor_Integration(t *testing.T) {
 			Name:   "main",
 			Target: graphql.Target{OID: "f00b4r3r"},
 		},
-
-		Branches: graphql.Branches{
-			Nodes: []*graphql.Branch{
-				&graphql.Branch{
-					Name:   "other-branch",
-					Target: graphql.Target{OID: "0therbr4nch"},
-				},
-			},
-		},
 	}
 
 	tests := []struct {

--- a/internal/campaigns/graphql/repository.go
+++ b/internal/campaigns/graphql/repository.go
@@ -19,23 +19,6 @@ fragment repositoryFields on Repository {
             oid
         }
     }
-}
-`
-
-const RepositoryWithCommitFragment = `
-fragment repositoryFieldsWithCommit on Repository {
-    id
-    name
-    url
-    externalRepository {
-        serviceType
-    }
-    defaultBranch {
-        name
-        target {
-            oid
-        }
-    }
     commit(rev: $rev) @include(if:$queryCommit) {
         oid
 	}

--- a/internal/campaigns/graphql/repository.go
+++ b/internal/campaigns/graphql/repository.go
@@ -21,7 +21,7 @@ fragment repositoryFields on Repository {
     }
     commit(rev: $rev) @include(if:$queryCommit) {
         oid
-	}
+    }
 }
 `
 
@@ -32,10 +32,6 @@ type Target struct {
 type Branch struct {
 	Name   string
 	Target Target
-}
-
-type Branches struct {
-	Nodes []*Branch
 }
 
 type Repository struct {

--- a/internal/campaigns/service.go
+++ b/internal/campaigns/service.go
@@ -432,7 +432,7 @@ func (svc *Service) ResolveRepositoriesOn(ctx context.Context, on *OnQueryOrRepo
 }
 
 const repositoryNameQuery = `
-query Repository($name: String!, $queryCommit: Boolean!, $rev: String) {
+query Repository($name: String!, $queryCommit: Boolean!, $rev: String!) {
     repository(name: $name) {
         ...repositoryFields
     }


### PR DESCRIPTION
This fixes https://github.com/sourcegraph/sourcegraph/issues/15070 by changing the evaluation of the `on.repository` field in the campaign spec to actually query for and use the `branch` attribute.

It queries the GraphQL API for a commit that matches the exact rev and returns an error if no commit was found.

If the campaign spec uses `repositoriesMatchingQuery` and `repository`, like this

```yaml
  - repositoriesMatchingQuery: repo:automation-testing
  - repository: github.com/sourcegraph/automation-testing
    branch: thorstens-test-branch
```

then the second branch, `thorstens-test-branch`, is checked out and used as the base branch for the changeset.

What we don't support yet is using a revspec in the search query, like `repo:github.com/sourcegraph/automation-testing@thorstens-test-branch foobar`, and using that to check out the branch. We can tackle that in a separate ticket/PR.

For now, this fixes the original problem and allows users to run the steps for a specified subset of repositories in specific branches.

(Side note: the search results in the template variable `${{ repository.search_result_paths }}` are populated by the query, even though they might not match any results in the second branch — that's undefined behaviour for now, but I want to document it in the docs.)