### PR TITLE
-v everywhere! Huge quality of life improvement! Merge now!

### DIFF
--- a/cmd/src/campaigns_common.go
+++ b/cmd/src/campaigns_common.go
@@ -96,6 +96,8 @@ func newCampaignsApplyFlags(flagSet *flag.FlagSet, cacheDir, tempDir string) *ca
 		"If true, deletes downloaded repository archives after executing campaign steps.",
 	)
 
+	flagSet.BoolVar(verbose, "v", false, "print verbose output")
+
 	return caf
 }
 


### PR DESCRIPTION
Before:

    $ src campaign apply -f campaign.yaml -v
    flag provided but not defined: -v
    Usage of 'src campaigns apply':
    -allow-unsupported
            Allow unsupported code hosts.
    [ ... ]

You had to specify `-v` right after `src` and before `campaign [apply|preview]`.

That means everytime I wanted to switch to verbose mode I had to *edit*
the previous command instead of just append a `-v`.

Now, with this change...

... switching to verbose mode is easier than ever...

Look:

    $ src campaign apply -f campaign.yaml -v

    [... command runs, people are happy :D :D :D ... ]