### PR TITLE
Add -skip-errors flag to src campaign apply|preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to `src-cli` are documented in this file.
 ### Added
 
 - Campaign steps may now include environment variables from outside of the campaign spec using [array syntax](http://docs.sourcegraph.com/campaigns/references/campaign_spec_yaml_reference#environment-array). [#392](https://github.com/sourcegraph/src-cli/pull/392)
+- A new `-skip-errors` flag has been added to `src campaign [apply|preview]` to allow users to continue execution of and upload a campaign spec even if execution failed in some repositories. [#395](https://github.com/sourcegraph/src-cli/pull/395)
 
 ### Changed
 

--- a/cmd/src/campaigns_apply.go
+++ b/cmd/src/campaigns_apply.go
@@ -78,6 +78,7 @@ Examples:
 
 		if err := doApply(ctx, out, svc, flags); err != nil {
 			printExecutionError(out, err)
+			out.Write("")
 			return &exitCodeError{nil, 1}
 		}
 

--- a/cmd/src/campaigns_apply.go
+++ b/cmd/src/campaigns_apply.go
@@ -79,6 +79,9 @@ Examples:
 		if err := doApply(ctx, out, svc, flags); err != nil {
 			printExecutionError(out, err)
 			out.Write("")
+			if !flags.skipErrors {
+				out.WriteLine(useSkipErrorsNotice)
+			}
 			return &exitCodeError{nil, 1}
 		}
 

--- a/cmd/src/campaigns_apply.go
+++ b/cmd/src/campaigns_apply.go
@@ -79,9 +79,6 @@ Examples:
 		if err := doApply(ctx, out, svc, flags); err != nil {
 			printExecutionError(out, err)
 			out.Write("")
-			if !flags.skipErrors {
-				out.WriteLine(useSkipErrorsNotice)
-			}
 			return &exitCodeError{nil, 1}
 		}
 

--- a/cmd/src/campaigns_common.go
+++ b/cmd/src/campaigns_common.go
@@ -294,8 +294,6 @@ func campaignsExecute(ctx context.Context, out *output.Output, svc *campaigns.Se
 	return id, url, nil
 }
 
-var useSkipErrorsNotice = output.Line(output.EmojiLightbulb, output.StylePending, "Use -skip-errors to skip the errors and upload the campaign spec regardless.")
-
 // campaignsParseSpec parses and validates the given campaign spec. If the spec
 // has validation errors, the errors are output in a human readable form and an
 // exitCodeError is returned.

--- a/cmd/src/campaigns_common.go
+++ b/cmd/src/campaigns_common.go
@@ -294,6 +294,8 @@ func campaignsExecute(ctx context.Context, out *output.Output, svc *campaigns.Se
 	return id, url, nil
 }
 
+var useSkipErrorsNotice = output.Line(output.EmojiLightbulb, output.StylePending, "Use -skip-errors to skip the errors and upload the campaign spec regardless.")
+
 // campaignsParseSpec parses and validates the given campaign spec. If the spec
 // has validation errors, the errors are output in a human readable form and an
 // exitCodeError is returned.

--- a/cmd/src/campaigns_preview.go
+++ b/cmd/src/campaigns_preview.go
@@ -54,6 +54,7 @@ Examples:
 		_, url, err := campaignsExecute(ctx, out, svc, flags)
 		if err != nil {
 			printExecutionError(out, err)
+			out.Write("")
 			return &exitCodeError{nil, 1}
 		}
 

--- a/cmd/src/campaigns_preview.go
+++ b/cmd/src/campaigns_preview.go
@@ -55,9 +55,6 @@ Examples:
 		if err != nil {
 			printExecutionError(out, err)
 			out.Write("")
-			if !flags.skipErrors {
-				out.WriteLine(useSkipErrorsNotice)
-			}
 			return &exitCodeError{nil, 1}
 		}
 

--- a/cmd/src/campaigns_preview.go
+++ b/cmd/src/campaigns_preview.go
@@ -55,6 +55,9 @@ Examples:
 		if err != nil {
 			printExecutionError(out, err)
 			out.Write("")
+			if !flags.skipErrors {
+				out.WriteLine(useSkipErrorsNotice)
+			}
 			return &exitCodeError{nil, 1}
 		}
 

--- a/internal/campaigns/service.go
+++ b/internal/campaigns/service.go
@@ -193,7 +193,6 @@ type ExecutorOpts struct {
 	KeepLogs   bool
 	TempDir    string
 	CacheDir   string
-	SkipErrors bool
 }
 
 func (svc *Service) NewExecutor(opts ExecutorOpts) Executor {
@@ -267,6 +266,7 @@ func (svc *Service) ExecuteCampaignSpec(ctx context.Context, repos []*graphql.Re
 			wrapped := errors.Wrapf(err, "resolving repository name %q", ic.Repository)
 			if skipErrors {
 				errs = multierror.Append(errs, wrapped)
+				continue
 			} else {
 				return nil, wrapped
 			}
@@ -287,12 +287,7 @@ func (svc *Service) ExecuteCampaignSpec(ctx context.Context, repos []*graphql.Re
 			case float64:
 				sid = strconv.FormatFloat(tid, 'f', -1, 64)
 			default:
-				err := errors.Errorf("cannot convert value of type %T into a valid external ID: expected string or int", id)
-				if skipErrors {
-					errs = multierror.Append(errs, err)
-				} else {
-					return nil, err
-				}
+				return nil, errors.Errorf("cannot convert value of type %T into a valid external ID: expected string or int", id)
 			}
 
 			specs = append(specs, &ChangesetSpec{

--- a/internal/output/emoji.go
+++ b/internal/output/emoji.go
@@ -2,7 +2,8 @@ package output
 
 // Standard emoji for use in output.
 const (
-	EmojiFailure = "❌"
-	EmojiWarning = "❗️"
-	EmojiSuccess = "✅"
+	EmojiFailure   = "❌"
+	EmojiWarning   = "❗️"
+	EmojiLightbulb = "💡"
+	EmojiSuccess   = "✅"
 )

--- a/internal/output/emoji.go
+++ b/internal/output/emoji.go
@@ -2,8 +2,7 @@ package output
 
 // Standard emoji for use in output.
 const (
-	EmojiFailure   = "❌"
-	EmojiWarning   = "❗️"
-	EmojiLightbulb = "💡"
-	EmojiSuccess   = "✅"
+	EmojiFailure = "❌"
+	EmojiWarning = "❗️"
+	EmojiSuccess = "✅"
 )


### PR DESCRIPTION
This fixes https://github.com/sourcegraph/sourcegraph/issues/15790 by adding the `-skip-errors` flag.

Note: I made the conscious decision to only skip "runtime errors", i.e.: we can skip the failed step execution, or we can skip the failed importing of a changeset (see "after" screenshot). That means validation errors etc. are not skipped. Because I don't think that makes sense.

### Before
<img width="927" alt="before" src="https://user-images.githubusercontent.com/1185253/100088649-bee6f300-2e50-11eb-8b2b-24a7dc017c65.png">


### After

<img width="927" alt="after" src="https://user-images.githubusercontent.com/1185253/100088662-c4dcd400-2e50-11eb-9281-66a3535613df.png">
