### PR TITLE
Introduce `transformChanges` to campaign spec (RFC 265)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to `src-cli` are documented in this file.
 
 ### Added
 
+- Experimental: [`transformChanges` in campaign specs](https://docs.sourcegraph.com/campaigns/references/campaign_spec_yaml_reference#transformchanges) is now available as a feature preview to allow users to create multiple changesets in a single repository. [#398](https://github.com/sourcegraph/src-cli/pull/398)
+
 ### Changed
 
 - `src campaign [apply|preview]` now show the current execution progress in numbers next to the progress bar. [#396](https://github.com/sourcegraph/src-cli/pull/396)

--- a/cmd/src/campaign_progress_printer.go
+++ b/cmd/src/campaign_progress_printer.go
@@ -200,6 +200,9 @@ func (p *campaignProgressPrinter) PrintStatuses(statuses []*campaigns.TaskStatus
 				}
 			}
 
+			if len(ts.ChangesetSpecs) > 1 {
+				p.progress.Verbosef("  %d changeset specs generated", len(ts.ChangesetSpecs))
+			}
 			p.progress.Verbosef("  Execution took %s", ts.ExecutionTime())
 			p.progress.Verbose("")
 		}

--- a/cmd/src/campaign_progress_printer_test.go
+++ b/cmd/src/campaign_progress_printer_test.go
@@ -95,22 +95,24 @@ func TestCampaignProgressPrinterIntegration(t *testing.T) {
 		FinishedAt:         now.Add(time.Duration(5) * time.Second),
 		CurrentlyExecuting: "",
 		Err:                nil,
-		ChangesetSpec: &campaigns.ChangesetSpec{
-			BaseRepository: "graphql-id",
-			CreatedChangeset: &campaigns.CreatedChangeset{
-				BaseRef:        "refs/heads/main",
-				BaseRev:        "d34db33f",
-				HeadRepository: "graphql-id",
-				HeadRef:        "refs/heads/my-campaign",
-				Title:          "This is my campaign",
-				Body:           "This is my campaign",
-				Commits: []campaigns.GitCommitDescription{
-					{
-						Message: "This is my campaign",
-						Diff:    progressPrinterDiff,
+		ChangesetSpecs: []*campaigns.ChangesetSpec{
+			{
+				BaseRepository: "graphql-id",
+				CreatedChangeset: &campaigns.CreatedChangeset{
+					BaseRef:        "refs/heads/main",
+					BaseRev:        "d34db33f",
+					HeadRepository: "graphql-id",
+					HeadRef:        "refs/heads/my-campaign",
+					Title:          "This is my campaign",
+					Body:           "This is my campaign",
+					Commits: []campaigns.GitCommitDescription{
+						{
+							Message: "This is my campaign",
+							Diff:    progressPrinterDiff,
+						},
 					},
+					Published: false,
 				},
-				Published: false,
 			},
 		},
 	}

--- a/cmd/src/campaigns_common.go
+++ b/cmd/src/campaigns_common.go
@@ -264,12 +264,17 @@ func campaignsExecute(ctx context.Context, out *output.Output, svc *campaigns.Se
 	ids := make([]campaigns.ChangesetSpecID, len(specs))
 
 	if len(specs) > 0 {
+		var label string
+		if len(specs) == 1 {
+			label = "Sending changeset spec"
+		} else {
+			label = fmt.Sprintf("Sending %d changeset specs", len(specs))
+		}
+
 		progress := out.Progress([]output.ProgressBar{
-			{
-				Label: fmt.Sprintf("Sending %d changeset specs", len(specs)),
-				Max:   float64(len(specs)),
-			},
+			{Label: label, Max: float64(len(specs))},
 		}, nil)
+
 		for i, spec := range specs {
 			id, err := svc.CreateChangesetSpec(ctx, spec)
 			if err != nil {
@@ -279,7 +284,6 @@ func campaignsExecute(ctx context.Context, out *output.Output, svc *campaigns.Se
 			progress.SetValue(0, float64(i+1))
 		}
 		progress.Complete()
-
 	} else {
 		if len(repos) == 0 {
 			out.WriteLine(output.Linef(output.EmojiWarning, output.StyleWarning, `No changeset specs created`))

--- a/cmd/src/campaigns_common.go
+++ b/cmd/src/campaigns_common.go
@@ -265,7 +265,10 @@ func campaignsExecute(ctx context.Context, out *output.Output, svc *campaigns.Se
 
 	if len(specs) > 0 {
 		progress := out.Progress([]output.ProgressBar{
-			{Label: "Sending changeset specs", Max: float64(len(specs))},
+			{
+				Label: fmt.Sprintf("Sending %d changeset specs", len(specs)),
+				Max:   float64(len(specs)),
+			},
 		}, nil)
 		for i, spec := range specs {
 			id, err := svc.CreateChangesetSpec(ctx, spec)

--- a/internal/campaigns/campaign_spec.go
+++ b/internal/campaigns/campaign_spec.go
@@ -80,8 +80,8 @@ type TransformChanges struct {
 }
 
 type Group struct {
-	Directory    string `json:"directory,omitempty" yaml:"directory"`
-	BranchSuffix string `json:"branchSuffix,omitempty" yaml:"branchSuffix"`
+	Directory string `json:"directory,omitempty" yaml:"directory"`
+	Branch    string `json:"branch,omitempty" yaml:"branch"`
 }
 
 func ParseCampaignSpec(data []byte, features featureFlags) (*CampaignSpec, error) {

--- a/internal/campaigns/campaign_spec.go
+++ b/internal/campaigns/campaign_spec.go
@@ -32,6 +32,7 @@ type CampaignSpec struct {
 	Description       string                `json:"description,omitempty" yaml:"description"`
 	On                []OnQueryOrRepository `json:"on,omitempty" yaml:"on"`
 	Steps             []Step                `json:"steps,omitempty" yaml:"steps"`
+	TransformChanges  *TransformChanges     `json:"transformChanges,omitempty" yaml:"transformChanges,omitempty"`
 	ImportChangesets  []ImportChangeset     `json:"importChangesets,omitempty" yaml:"importChangesets"`
 	ChangesetTemplate *ChangesetTemplate    `json:"changesetTemplate,omitempty" yaml:"changesetTemplate"`
 }
@@ -72,6 +73,15 @@ type Step struct {
 	Files     map[string]string `json:"files,omitempty" yaml:"files,omitempty"`
 
 	image string
+}
+
+type TransformChanges struct {
+	Group []Group `json:"group,omitempty" yaml:"group"`
+}
+
+type Group struct {
+	Directory    string `json:"directory,omitempty" yaml:"directory"`
+	BranchSuffix string `json:"branchSuffix,omitempty" yaml:"branchSuffix"`
 }
 
 func ParseCampaignSpec(data []byte, features featureFlags) (*CampaignSpec, error) {

--- a/internal/campaigns/campaign_spec.go
+++ b/internal/campaigns/campaign_spec.go
@@ -80,8 +80,9 @@ type TransformChanges struct {
 }
 
 type Group struct {
-	Directory string `json:"directory,omitempty" yaml:"directory"`
-	Branch    string `json:"branch,omitempty" yaml:"branch"`
+	Directory  string `json:"directory,omitempty" yaml:"directory"`
+	Branch     string `json:"branch,omitempty" yaml:"branch"`
+	Repository string `json:"repository,omitempty" yaml:"repository"`
 }
 
 func ParseCampaignSpec(data []byte, features featureFlags) (*CampaignSpec, error) {

--- a/internal/campaigns/execution_cache.go
+++ b/internal/campaigns/execution_cache.go
@@ -77,7 +77,7 @@ func (c ExecutionDiskCache) cacheFilePath(key ExecutionCacheKey) (string, error)
 		return "", errors.Wrap(err, "calculating execution cache key")
 	}
 
-	return filepath.Join(c.Dir, keyString+".patch"), nil
+	return filepath.Join(c.Dir, keyString+".diff"), nil
 }
 
 func (c ExecutionDiskCache) Get(ctx context.Context, key ExecutionCacheKey) (string, bool, error) {
@@ -111,7 +111,7 @@ func (c ExecutionDiskCache) Get(ctx context.Context, key ExecutionCacheKey) (str
 		return result.Commits[0].Diff, true, nil
 	}
 
-	if strings.HasSuffix(path, ".patch") {
+	if strings.HasSuffix(path, ".diff") {
 		return string(data), true, nil
 	}
 

--- a/internal/campaigns/execution_cache.go
+++ b/internal/campaigns/execution_cache.go
@@ -5,9 +5,11 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/pkg/errors"
 )
@@ -60,8 +62,8 @@ func (key ExecutionCacheKey) Key() (string, error) {
 }
 
 type ExecutionCache interface {
-	Get(ctx context.Context, key ExecutionCacheKey) (result *ChangesetSpec, err error)
-	Set(ctx context.Context, key ExecutionCacheKey, result *ChangesetSpec) error
+	Get(ctx context.Context, key ExecutionCacheKey) (diff string, found bool, err error)
+	Set(ctx context.Context, key ExecutionCacheKey, diff string) error
 	Clear(ctx context.Context, key ExecutionCacheKey) error
 }
 
@@ -75,13 +77,13 @@ func (c ExecutionDiskCache) cacheFilePath(key ExecutionCacheKey) (string, error)
 		return "", errors.Wrap(err, "calculating execution cache key")
 	}
 
-	return filepath.Join(c.Dir, keyString+".json"), nil
+	return filepath.Join(c.Dir, keyString+".patch"), nil
 }
 
-func (c ExecutionDiskCache) Get(ctx context.Context, key ExecutionCacheKey) (*ChangesetSpec, error) {
+func (c ExecutionDiskCache) Get(ctx context.Context, key ExecutionCacheKey) (string, bool, error) {
 	path, err := c.cacheFilePath(key)
 	if err != nil {
-		return nil, err
+		return "", false, err
 	}
 
 	data, err := ioutil.ReadFile(path)
@@ -89,27 +91,34 @@ func (c ExecutionDiskCache) Get(ctx context.Context, key ExecutionCacheKey) (*Ch
 		if os.IsNotExist(err) {
 			err = nil // treat as not-found
 		}
-		return nil, err
+		return "", false, err
 	}
 
-	var result ChangesetSpec
-	if err := json.Unmarshal(data, &result); err != nil {
-		// Delete the invalid data to avoid causing an error for next time.
-		if err := os.Remove(path); err != nil {
-			return nil, errors.Wrap(err, "while deleting cache file with invalid JSON")
+	// We previously cached complete ChangesetSpecs instead of just the diffs.
+	// To be backwards compatible, we keep reading these:
+	if strings.HasSuffix(path, ".json") {
+		var result ChangesetSpec
+		if err := json.Unmarshal(data, &result); err != nil {
+			// Delete the invalid data to avoid causing an error for next time.
+			if err := os.Remove(path); err != nil {
+				return "", false, errors.Wrap(err, "while deleting cache file with invalid JSON")
+			}
+			return "", false, errors.Wrapf(err, "reading cache file %s", path)
 		}
-		return nil, errors.Wrapf(err, "reading cache file %s", path)
+		if len(result.Commits) != 1 {
+			return "", false, errors.New("cached result has no commits")
+		}
+		return result.Commits[0].Diff, true, nil
 	}
 
-	return &result, nil
+	if strings.HasSuffix(path, ".patch") {
+		return string(data), true, nil
+	}
+
+	return "", false, fmt.Errorf("unknown file format for cache file %q", path)
 }
 
-func (c ExecutionDiskCache) Set(ctx context.Context, key ExecutionCacheKey, result *ChangesetSpec) error {
-	data, err := json.Marshal(result)
-	if err != nil {
-		return err
-	}
-
+func (c ExecutionDiskCache) Set(ctx context.Context, key ExecutionCacheKey, diff string) error {
 	path, err := c.cacheFilePath(key)
 	if err != nil {
 		return err
@@ -119,7 +128,7 @@ func (c ExecutionDiskCache) Set(ctx context.Context, key ExecutionCacheKey, resu
 		return err
 	}
 
-	return ioutil.WriteFile(path, data, 0600)
+	return ioutil.WriteFile(path, []byte(diff), 0600)
 }
 
 func (c ExecutionDiskCache) Clear(ctx context.Context, key ExecutionCacheKey) error {
@@ -139,11 +148,11 @@ func (c ExecutionDiskCache) Clear(ctx context.Context, key ExecutionCacheKey) er
 // retrieve cache entries.
 type ExecutionNoOpCache struct{}
 
-func (ExecutionNoOpCache) Get(ctx context.Context, key ExecutionCacheKey) (result *ChangesetSpec, err error) {
-	return nil, nil
+func (ExecutionNoOpCache) Get(ctx context.Context, key ExecutionCacheKey) (diff string, found bool, err error) {
+	return "", false, nil
 }
 
-func (ExecutionNoOpCache) Set(ctx context.Context, key ExecutionCacheKey, result *ChangesetSpec) error {
+func (ExecutionNoOpCache) Set(ctx context.Context, key ExecutionCacheKey, diff string) error {
 	return nil
 }
 

--- a/internal/campaigns/executor.go
+++ b/internal/campaigns/executor.go
@@ -462,12 +462,12 @@ func groupFileDiffs(completeDiff, defaultBranch string, groups []Group) (map[str
 	}
 
 	// Housekeeping: we setup these two datastructures so we can
-	// - access the branchSuffixes by the directory for which they should be used
+	// - access the group.Branch by the directory for which they should be used
 	// - check against the given directories, starting with the longest one.
-	suffixesByDirectory := make(map[string]string, len(groups))
-	dirsByLen := make([]string, len(suffixesByDirectory))
+	branchesByDirectory := make(map[string]string, len(groups))
+	dirsByLen := make([]string, len(branchesByDirectory))
 	for _, g := range groups {
-		suffixesByDirectory[g.Directory] = g.BranchSuffix
+		branchesByDirectory[g.Directory] = g.Branch
 		dirsByLen = append(dirsByLen, g.Directory)
 	}
 	sort.Slice(dirsByLen, func(i, j int) bool {
@@ -501,15 +501,13 @@ func groupFileDiffs(completeDiff, defaultBranch string, groups []Group) (map[str
 			continue
 		}
 
-		// If it *did* match a directory, we look up which suffix we should add
-		// to the default branch and add it under that:
-		suffix, ok := suffixesByDirectory[matchingDir]
+		// If it *did* match a directory, we look up which branch we should use:
+		branch, ok := branchesByDirectory[matchingDir]
 		if !ok {
 			panic("this should not happen: " + matchingDir)
 		}
 
-		b := defaultBranch + suffix
-		byBranch[b] = append(byBranch[b], f)
+		byBranch[branch] = append(byBranch[branch], f)
 	}
 
 	finalDiffsByBranch := make(map[string]string, len(byBranch))

--- a/internal/campaigns/executor.go
+++ b/internal/campaigns/executor.go
@@ -524,7 +524,7 @@ func groupFileDiffs(completeDiff, defaultBranch string, groups []Group) (map[str
 		}
 
 		// .. we check whether it matches one of the given directories in the
-		// group transformations, starting with the longest one first:
+		// group transformations, with the last match winning:
 		var matchingDir string
 		for _, d := range dirs {
 			if strings.Contains(name, d) {

--- a/internal/campaigns/executor.go
+++ b/internal/campaigns/executor.go
@@ -43,7 +43,7 @@ func (e TaskExecutionErr) StatusText() string {
 }
 
 type Executor interface {
-	AddTask(repo *graphql.Repository, steps []Step, transform *TransformChanges, template *ChangesetTemplate) *TaskStatus
+	AddTask(repo *graphql.Repository, steps []Step, transform *TransformChanges, template *ChangesetTemplate)
 	LogFiles() []string
 	Start(ctx context.Context)
 	Wait() ([]*ChangesetSpec, error)
@@ -175,7 +175,7 @@ func newExecutor(opts ExecutorOpts, client api.Client, features featureFlags) *e
 	}
 }
 
-func (x *executor) AddTask(repo *graphql.Repository, steps []Step, transform *TransformChanges, template *ChangesetTemplate) *TaskStatus {
+func (x *executor) AddTask(repo *graphql.Repository, steps []Step, transform *TransformChanges, template *ChangesetTemplate) {
 	task := &Task{repo, steps, template, transform}
 	x.tasks = append(x.tasks, task)
 

--- a/internal/campaigns/executor_test.go
+++ b/internal/campaigns/executor_test.go
@@ -341,6 +341,10 @@ index 0000000..1bd79fb
 @@ -0,0 +1,1 @@
 +this is 3
 `
+
+	defaultBranch := "my-default-branch"
+	allDiffs := diff1 + diff2 + diff3
+
 	tests := []struct {
 		diff          string
 		defaultBranch string
@@ -348,8 +352,7 @@ index 0000000..1bd79fb
 		want          map[string]string
 	}{
 		{
-			diff:          diff1 + diff2 + diff3,
-			defaultBranch: "my-default-branch",
+			diff: allDiffs,
 			groups: []Group{
 				{Directory: "1/2/3", BranchSuffix: "-everything-in-3"},
 			},
@@ -359,8 +362,7 @@ index 0000000..1bd79fb
 			},
 		},
 		{
-			diff:          diff1 + diff2 + diff3,
-			defaultBranch: "my-default-branch",
+			diff: allDiffs,
 			groups: []Group{
 				{Directory: "1/2", BranchSuffix: "-everything-in-2-and-3"},
 			},
@@ -370,8 +372,7 @@ index 0000000..1bd79fb
 			},
 		},
 		{
-			diff:          diff1 + diff2 + diff3,
-			defaultBranch: "my-default-branch",
+			diff: allDiffs,
 			groups: []Group{
 				{Directory: "1", BranchSuffix: "-everything-in-1-and-2-and-3"},
 			},
@@ -381,8 +382,36 @@ index 0000000..1bd79fb
 			},
 		},
 		{
-			diff:          diff1 + diff2 + diff3,
-			defaultBranch: "my-default-branch",
+			diff: allDiffs,
+			groups: []Group{
+				{Directory: "1/2/3", BranchSuffix: "-only-in-3"},
+				{Directory: "1/2", BranchSuffix: "-only-in-2"},
+				{Directory: "1", BranchSuffix: "-only-in-1"},
+			},
+			want: map[string]string{
+				"my-default-branch":           "",
+				"my-default-branch-only-in-3": diff3,
+				"my-default-branch-only-in-2": diff2,
+				"my-default-branch-only-in-1": diff1,
+			},
+		},
+		{
+			diff: allDiffs,
+			groups: []Group{
+				// Different order than above
+				{Directory: "1", BranchSuffix: "-only-in-1"},
+				{Directory: "1/2", BranchSuffix: "-only-in-2"},
+				{Directory: "1/2/3", BranchSuffix: "-only-in-3"},
+			},
+			want: map[string]string{
+				"my-default-branch":           "",
+				"my-default-branch-only-in-3": diff3,
+				"my-default-branch-only-in-2": diff2,
+				"my-default-branch-only-in-1": diff1,
+			},
+		},
+		{
+			diff: allDiffs,
 			groups: []Group{
 				{Directory: "", BranchSuffix: "-everything"},
 			},
@@ -393,7 +422,7 @@ index 0000000..1bd79fb
 	}
 
 	for _, tc := range tests {
-		have, err := groupFileDiffs(tc.diff, tc.defaultBranch, tc.groups)
+		have, err := groupFileDiffs(tc.diff, defaultBranch, tc.groups)
 		if err != nil {
 			t.Fatalf("unexpected error: %s", err)
 		}

--- a/internal/campaigns/executor_test.go
+++ b/internal/campaigns/executor_test.go
@@ -165,7 +165,7 @@ func TestExecutor_Integration(t *testing.T) {
 			},
 			transform: &TransformChanges{
 				Group: []Group{
-					{Directory: "a/b/c", BranchSuffix: "-in-directory-c"},
+					{Directory: "a/b/c", Branch: "in-directory-c"},
 				},
 			},
 			wantFilesChanged: filesByRepository{
@@ -174,7 +174,7 @@ func TestExecutor_Integration(t *testing.T) {
 						"a/a.go",
 						"a/b/b.go",
 					},
-					changesetTemplateBranch + "-in-directory-c": []string{
+					"in-directory-c": []string{
 						"a/b/c/c.go",
 					},
 				},
@@ -354,66 +354,66 @@ index 0000000..1bd79fb
 		{
 			diff: allDiffs,
 			groups: []Group{
-				{Directory: "1/2/3", BranchSuffix: "-everything-in-3"},
+				{Directory: "1/2/3", Branch: "everything-in-3"},
 			},
 			want: map[string]string{
-				"my-default-branch":                 diff1 + diff2,
-				"my-default-branch-everything-in-3": diff3,
+				"my-default-branch": diff1 + diff2,
+				"everything-in-3":   diff3,
 			},
 		},
 		{
 			diff: allDiffs,
 			groups: []Group{
-				{Directory: "1/2", BranchSuffix: "-everything-in-2-and-3"},
+				{Directory: "1/2", Branch: "everything-in-2-and-3"},
 			},
 			want: map[string]string{
-				"my-default-branch":                       diff1,
-				"my-default-branch-everything-in-2-and-3": diff2 + diff3,
+				"my-default-branch":     diff1,
+				"everything-in-2-and-3": diff2 + diff3,
 			},
 		},
 		{
 			diff: allDiffs,
 			groups: []Group{
-				{Directory: "1", BranchSuffix: "-everything-in-1-and-2-and-3"},
-			},
-			want: map[string]string{
-				"my-default-branch":                             "",
-				"my-default-branch-everything-in-1-and-2-and-3": diff1 + diff2 + diff3,
-			},
-		},
-		{
-			diff: allDiffs,
-			groups: []Group{
-				{Directory: "1/2/3", BranchSuffix: "-only-in-3"},
-				{Directory: "1/2", BranchSuffix: "-only-in-2"},
-				{Directory: "1", BranchSuffix: "-only-in-1"},
+				{Directory: "1", Branch: "everything-in-1-and-2-and-3"},
 			},
 			want: map[string]string{
 				"my-default-branch":           "",
-				"my-default-branch-only-in-3": diff3,
-				"my-default-branch-only-in-2": diff2,
-				"my-default-branch-only-in-1": diff1,
+				"everything-in-1-and-2-and-3": diff1 + diff2 + diff3,
+			},
+		},
+		{
+			diff: allDiffs,
+			groups: []Group{
+				{Directory: "1/2/3", Branch: "only-in-3"},
+				{Directory: "1/2", Branch: "only-in-2"},
+				{Directory: "1", Branch: "only-in-1"},
+			},
+			want: map[string]string{
+				"my-default-branch": "",
+				"only-in-3":         diff3,
+				"only-in-2":         diff2,
+				"only-in-1":         diff1,
 			},
 		},
 		{
 			diff: allDiffs,
 			groups: []Group{
 				// Different order than above
-				{Directory: "1", BranchSuffix: "-only-in-1"},
-				{Directory: "1/2", BranchSuffix: "-only-in-2"},
-				{Directory: "1/2/3", BranchSuffix: "-only-in-3"},
+				{Directory: "1", Branch: "only-in-1"},
+				{Directory: "1/2", Branch: "only-in-2"},
+				{Directory: "1/2/3", Branch: "only-in-3"},
 			},
 			want: map[string]string{
-				"my-default-branch":           "",
-				"my-default-branch-only-in-3": diff3,
-				"my-default-branch-only-in-2": diff2,
-				"my-default-branch-only-in-1": diff1,
+				"my-default-branch": "",
+				"only-in-3":         diff3,
+				"only-in-2":         diff2,
+				"only-in-1":         diff1,
 			},
 		},
 		{
 			diff: allDiffs,
 			groups: []Group{
-				{Directory: "", BranchSuffix: "-everything"},
+				{Directory: "", Branch: "everything"},
 			},
 			want: map[string]string{
 				"my-default-branch": diff1 + diff2 + diff3,

--- a/internal/campaigns/features.go
+++ b/internal/campaigns/features.go
@@ -23,7 +23,7 @@ func (ff *featureFlags) setFromVersion(version string) error {
 		{&ff.allowArrayEnvironments, ">= 3.23.0", "2020-11-24"},
 		{&ff.includeAutoAuthorDetails, ">= 3.20.0", "2020-09-10"},
 		{&ff.useGzipCompression, ">= 3.21.0", "2020-10-12"},
-		{&ff.allowtransformChanges, ">= 3.23.0", "2020-12-10"},
+		{&ff.allowtransformChanges, ">= 3.23.0", "2020-12-11"},
 	} {
 		value, err := api.CheckSourcegraphVersion(version, feature.constraint, feature.minDate)
 		if err != nil {

--- a/internal/campaigns/features.go
+++ b/internal/campaigns/features.go
@@ -11,6 +11,7 @@ type featureFlags struct {
 	allowArrayEnvironments   bool
 	includeAutoAuthorDetails bool
 	useGzipCompression       bool
+	allowtransformChanges    bool
 }
 
 func (ff *featureFlags) setFromVersion(version string) error {
@@ -22,6 +23,7 @@ func (ff *featureFlags) setFromVersion(version string) error {
 		{&ff.allowArrayEnvironments, ">= 3.23.0", "2020-11-24"},
 		{&ff.includeAutoAuthorDetails, ">= 3.20.0", "2020-09-10"},
 		{&ff.useGzipCompression, ">= 3.21.0", "2020-10-12"},
+		{&ff.allowtransformChanges, ">= 3.23.0", "2020-12-10"},
 	} {
 		value, err := api.CheckSourcegraphVersion(version, feature.constraint, feature.minDate)
 		if err != nil {

--- a/internal/campaigns/service.go
+++ b/internal/campaigns/service.go
@@ -218,7 +218,7 @@ func (svc *Service) SetDockerImages(ctx context.Context, spec *CampaignSpec, pro
 
 func (svc *Service) ExecuteCampaignSpec(ctx context.Context, repos []*graphql.Repository, x Executor, spec *CampaignSpec, progress func([]*TaskStatus), skipErrors bool) ([]*ChangesetSpec, error) {
 	for _, repo := range repos {
-		x.AddTask(repo, spec.Steps, spec.ChangesetTemplate)
+		x.AddTask(repo, spec.Steps, spec.TransformChanges, spec.ChangesetTemplate)
 	}
 
 	done := make(chan struct{})

--- a/schema/campaign_spec.schema.json
+++ b/schema/campaign_spec.schema.json
@@ -128,9 +128,9 @@
               "type": "string",
               "description": "The directory path (relative to the repository root) of the changes to include in this group."
             },
-            "branchSuffix": {
+            "branch": {
               "type": "string",
-              "description": "The branch suffix to add to the `branch` attribute of the `changesetTemplate` when creating the additonal changeset."
+              "description": "The branch on the repository to propose changes to. If unset, the repository's default branch is used."
             }
           }
         }

--- a/schema/campaign_spec.schema.json
+++ b/schema/campaign_spec.schema.json
@@ -126,11 +126,13 @@
           "properties": {
             "directory": {
               "type": "string",
-              "description": "The directory path (relative to the repository root) of the changes to include in this group."
+              "description": "The directory path (relative to the repository root) of the changes to include in this group.",
+              "minLength": 1
             },
             "branch": {
               "type": "string",
-              "description": "The branch on the repository to propose changes to. If unset, the repository's default branch is used."
+              "description": "The branch on the repository to propose changes to. If unset, the repository's default branch is used.",
+              "minLength": 1
             },
             "repository": {
               "type": "string",

--- a/schema/campaign_spec.schema.json
+++ b/schema/campaign_spec.schema.json
@@ -131,6 +131,11 @@
             "branch": {
               "type": "string",
               "description": "The branch on the repository to propose changes to. If unset, the repository's default branch is used."
+            },
+            "repository": {
+              "type": "string",
+              "description": "Only apply this transformation in the repository with this name (as it is known to Sourcegraph).",
+              "examples": ["github.com/foo/bar"]
             }
           }
         }

--- a/schema/campaign_spec.schema.json
+++ b/schema/campaign_spec.schema.json
@@ -113,6 +113,29 @@
         }
       }
     },
+    "transformChanges": {
+      "type": "object",
+      "description": "Optional transformations to apply to the changes produced in each repository.",
+      "additionalProperties": false,
+      "properties": {
+        "group": {
+          "type": "array",
+          "description": "A list of groups of changes in a repository that each create a separate, additional changeset for this repository, with all ungrouped changes being in the default changeset.",
+          "additionalProperties": false,
+          "required": ["directory", "branchSuffix"],
+          "properties": {
+            "directory": {
+              "type": "string",
+              "description": "The directory path (relative to the repository root) of the changes to include in this group."
+            },
+            "branchSuffix": {
+              "type": "string",
+              "description": "The branch suffix to add to the `branch` attribute of the `changesetTemplate` when creating the additonal changeset."
+            }
+          }
+        }
+      }
+    },
     "importChangesets": {
       "type": "array",
       "description": "Import existing changesets on code hosts.",

--- a/schema/campaign_spec_stringdata.go
+++ b/schema/campaign_spec_stringdata.go
@@ -131,11 +131,13 @@ const CampaignSpecJSON = `{
           "properties": {
             "directory": {
               "type": "string",
-              "description": "The directory path (relative to the repository root) of the changes to include in this group."
+              "description": "The directory path (relative to the repository root) of the changes to include in this group.",
+              "minLength": 1
             },
             "branch": {
               "type": "string",
-              "description": "The branch on the repository to propose changes to. If unset, the repository's default branch is used."
+              "description": "The branch on the repository to propose changes to. If unset, the repository's default branch is used.",
+              "minLength": 1
             },
             "repository": {
               "type": "string",

--- a/schema/campaign_spec_stringdata.go
+++ b/schema/campaign_spec_stringdata.go
@@ -133,9 +133,9 @@ const CampaignSpecJSON = `{
               "type": "string",
               "description": "The directory path (relative to the repository root) of the changes to include in this group."
             },
-            "branchSuffix": {
+            "branch": {
               "type": "string",
-              "description": "The branch suffix to add to the ` + "`" + `branch` + "`" + ` attribute of the ` + "`" + `changesetTemplate` + "`" + ` when creating the additonal changeset."
+              "description": "The branch on the repository to propose changes to. If unset, the repository's default branch is used."
             }
           }
         }

--- a/schema/campaign_spec_stringdata.go
+++ b/schema/campaign_spec_stringdata.go
@@ -136,6 +136,11 @@ const CampaignSpecJSON = `{
             "branch": {
               "type": "string",
               "description": "The branch on the repository to propose changes to. If unset, the repository's default branch is used."
+            },
+            "repository": {
+              "type": "string",
+              "description": "Only apply this transformation in the repository with this name (as it is known to Sourcegraph).",
+              "examples": ["github.com/foo/bar"]
             }
           }
         }

--- a/schema/campaign_spec_stringdata.go
+++ b/schema/campaign_spec_stringdata.go
@@ -118,6 +118,29 @@ const CampaignSpecJSON = `{
         }
       }
     },
+    "transformChanges": {
+      "type": "object",
+      "description": "Optional transformations to apply to the changes produced in each repository.",
+      "additionalProperties": false,
+      "properties": {
+        "group": {
+          "type": "array",
+          "description": "A list of groups of changes in a repository that each create a separate, additional changeset for this repository, with all ungrouped changes being in the default changeset.",
+          "additionalProperties": false,
+          "required": ["directory", "branchSuffix"],
+          "properties": {
+            "directory": {
+              "type": "string",
+              "description": "The directory path (relative to the repository root) of the changes to include in this group."
+            },
+            "branchSuffix": {
+              "type": "string",
+              "description": "The branch suffix to add to the ` + "`" + `branch` + "`" + ` attribute of the ` + "`" + `changesetTemplate` + "`" + ` when creating the additonal changeset."
+            }
+          }
+        }
+      }
+    },
     "importChangesets": {
       "type": "array",
       "description": "Import existing changesets on code hosts.",


### PR DESCRIPTION
This is the implementation of the suggested solution for **Option B** in [RFC 265: Multiple changesets per repository](https://docs.google.com/document/d/1cXEuUdYJeK-uwZpowhorPGSAUfE87QkaLbf9r_EVRfI/edit) to produce multiple changesets in a single repository.

It depends on https://github.com/sourcegraph/sourcegraph/pull/16235. It fixes https://github.com/sourcegraph/sourcegraph/issues/14970.

**IMPORTANT**: this _only_ implements the first step in ["Defintion of success"](https://docs.google.com/document/d/1cXEuUdYJeK-uwZpowhorPGSAUfE87QkaLbf9r_EVRfI/edit#bookmark=id.rs92im1omcfo). It does **not** yet implement addressing multiple changesets in the same repository separately (that's Part2 in the RFC).

What this does is to introduce the `transformChanges` property to campaign specs (see https://github.com/sourcegraph/sourcegraph/pull/16235 for schema change on server).

Here is an example campaign spec using it:

```yaml
name: multi-changesets
description: This is a testing campaign that should have multiple changesets in a single repository.

on:
  - repositoriesMatchingQuery: repo:src-cli|automation-testing$

steps:
  - run: echo ".swp" >> .gitignore
    container: alpine:3
  - run: if [[ -e gopkg/main.go ]]; then echo "func unused() int { return 99 }" >> gopkg/main.go; fi
    container: alpine:3
  - run: mkdir foobar && echo "Hey there" foobar/hello.txt
    container: alpine:3

# Transform the changes produced in each repository.
transformChanges:
  # Group the file diffs by directory and produce one additional changeset per group.
  group:
    - directory: gopkg
      branch: thorsten/multi-changesets-backend # will replace the `branch` in the `changesetTemplate`
    - directory: foobar
      repository: github.com/sourcegraph/automation-testing # optional: only apply the rule in this repository
      branch: thorsten/multi-changesets-foobar # will replace the `branch` in the `changesetTemplate`

changesetTemplate:
  title: multi-changesets
  body: multi-changesets
  branch: thorsten/multi-changesets
  commit:
    message: multi-changesets
  published: false
```

#### Changelog of this PR 

- 02 Dec: Updated the code and the PR description to use the new `branch` property instead of `branchSuffix` to incorporate feedback on RFC 265.
- 02 Dec: Added the optional `repository` attribute to the `group`.
- 10 Dec: Added validation to make sure that multiple changesets cannot be created with the _same_ branch in the _same_ repository. Updated PR description.