### PR TITLE
Fix race conditions when printing current status of tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ All notable changes to `src-cli` are documented in this file.
 
 ### Fixed
 
+- Two race conditions in the terminal UI of `src campaign [apply|preview]` have been fixed. [#399](https://github.com/sourcegraph/src-cli/pull/399)
+
 ### Removed
 
 ## 3.22.4

--- a/cmd/src/campaign_progress_printer.go
+++ b/cmd/src/campaign_progress_printer.go
@@ -128,11 +128,13 @@ func (p *campaignProgressPrinter) PrintStatuses(statuses []*campaigns.TaskStatus
 	statusBarIndex := 0
 	for _, ts := range currentlyRunning {
 		if _, ok := p.runningTasks[ts.RepoName]; ok {
+			// Update the status
+			p.runningTasks[ts.RepoName] = ts
 			continue
 		}
 
-		newlyStarted[ts.RepoName] = ts
 		p.runningTasks[ts.RepoName] = ts
+		newlyStarted[ts.RepoName] = ts
 
 		// Find free status bar slot
 		_, ok := p.statusBarRepo[statusBarIndex]

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/ssor/bom v0.0.0-20170718123548-6386211fdfcf // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	golang.org/x/net v0.0.0-20200625001655-4c5254603344
+	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
 	golang.org/x/sys v0.0.0-20200622214017-ed371f2e16b4
 	gopkg.in/yaml.v2 v2.3.0
 	jaytaylor.com/html2text v0.0.0-20200412013138-3577fbdbcff7

--- a/go.sum
+++ b/go.sum
@@ -86,6 +86,7 @@ golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20200625001655-4c5254603344 h1:vGXIOMxbNfDTk/aXCmfdLgkrSV+Z2tcbze+pEc3v5W4=
 golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e h1:vcxGaoTs7kV8m5Np9uUNQin4BrLOthgV7252N8V+FwY=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
This fixes https://github.com/sourcegraph/sourcegraph/issues/16195 by doing two things:

1. It threads every update and read of `*TaskStatus` in `executor` through a mutex to provide a consistent view of all `[]*TaskStatus`. While we had a `sync.Map` in place it didn't protect us from race conditions, since we passed around _pointers_ to `TaskStatus` freely: the `executor` goroutines would happily write to a `*TaskStatus` and the `campaignProgressPrinter.PrintStatus` would read `[]*TaskStatus` _while they're being updated_. The `sync.Map` was useless in practice. So instead of that, I added a mutex that's used when updating a `*TaskStatus` and when reading _all_ `[]*TaskStatus` when printing the status.
2. It uses a 1-capacity semaphore to control access to the `campaignProgressPrinter` through the `PrintStatuses` callback: only one execution at a time and if another execution is already in progress it returns.