### PR TITLE
Snapshot test the terminal UI

### DIFF
--- a/cmd/src/campaign_progress_printer.go
+++ b/cmd/src/campaign_progress_printer.go
@@ -70,7 +70,7 @@ func (p *campaignProgressPrinter) initProgressBar(statuses []*campaigns.TaskStat
 		},
 	}
 
-	opts := output.DefaultProgressTTYOpts.WithForceNoSpinner(p.forceNoSpinner)
+	opts := output.DefaultProgressTTYOpts.WithoutSpinner()
 	p.progress = p.out.ProgressWithStatusBars(progressBars, statusBars, opts)
 
 	return numStatusBars

--- a/cmd/src/campaign_progress_printer.go
+++ b/cmd/src/campaign_progress_printer.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/sourcegraph/go-diff/diff"
@@ -305,14 +306,14 @@ func verboseDiffSummary(fileDiffs []*diff.FileDiff) ([]string, error) {
 		sumInsertions  int
 		sumDeletions   int
 	)
+	sort.Slice(fileDiffs, func(i, j int) bool {
+		return diffDisplayName(fileDiffs[i]) < diffDisplayName(fileDiffs[j])
+	})
 
 	fileStats := make(map[string]string, len(fileDiffs))
 
 	for _, f := range fileDiffs {
-		name := f.NewName
-		if name == "/dev/null" {
-			name = f.OrigName
-		}
+		name := diffDisplayName(f)
 
 		if len(name) > maxFilenameLen {
 			maxFilenameLen = len(name)
@@ -349,4 +350,12 @@ func verboseDiffSummary(fileDiffs []*diff.FileDiff) ([]string, error) {
 	))
 
 	return lines, nil
+}
+
+func diffDisplayName(f *diff.FileDiff) string {
+	name := f.NewName
+	if name == "/dev/null" {
+		name = f.OrigName
+	}
+	return name
 }

--- a/cmd/src/campaign_progress_printer.go
+++ b/cmd/src/campaign_progress_printer.go
@@ -63,16 +63,15 @@ func (p *campaignProgressPrinter) initProgressBar(statuses []*campaigns.TaskStat
 		statusBars = append(statusBars, output.NewStatusBar())
 	}
 
-	p.progress = p.out.ProgressWithStatusBars([]output.ProgressBar{{
-		Label: fmt.Sprintf("Executing ... (0/%d, 0 errored)", len(statuses)),
-		Max:   float64(len(statuses)),
-	}}, statusBars, &output.ProgressOpts{
-		// TODO: Hacky, only for testing
-		ForceNoSpinner: p.forceNoSpinner,
-		SuccessEmoji:   "\u2705",
-		SuccessStyle:   output.StyleSuccess,
-		PendingStyle:   output.StylePending,
-	})
+	progressBars := []output.ProgressBar{
+		{
+			Label: fmt.Sprintf("Executing ... (0/%d, 0 errored)", len(statuses)),
+			Max:   float64(len(statuses)),
+		},
+	}
+
+	opts := output.DefaultProgressTTYOpts.WithForceNoSpinner(p.forceNoSpinner)
+	p.progress = p.out.ProgressWithStatusBars(progressBars, statusBars, opts)
 
 	return numStatusBars
 }

--- a/cmd/src/campaign_progress_printer.go
+++ b/cmd/src/campaign_progress_printer.go
@@ -306,14 +306,14 @@ func verboseDiffSummary(fileDiffs []*diff.FileDiff) ([]string, error) {
 		sumInsertions  int
 		sumDeletions   int
 	)
-	sort.Slice(fileDiffs, func(i, j int) bool {
-		return diffDisplayName(fileDiffs[i]) < diffDisplayName(fileDiffs[j])
-	})
 
 	fileStats := make(map[string]string, len(fileDiffs))
+	fileNames := make([]string, len(fileDiffs))
 
-	for _, f := range fileDiffs {
+	for i, f := range fileDiffs {
 		name := diffDisplayName(f)
+
+		fileNames[i] = name
 
 		if len(name) > maxFilenameLen {
 			maxFilenameLen = len(name)
@@ -329,8 +329,11 @@ func verboseDiffSummary(fileDiffs []*diff.FileDiff) ([]string, error) {
 		fileStats[name] = fmt.Sprintf("%d %s", num, diffStatDiagram(stat))
 	}
 
-	for file, stats := range fileStats {
-		lines = append(lines, fmt.Sprintf("\t%-*s | %s", maxFilenameLen, file, stats))
+	sort.Slice(fileNames, func(i, j int) bool { return fileNames[i] < fileNames[j] })
+
+	for _, name := range fileNames {
+		stats := fileStats[name]
+		lines = append(lines, fmt.Sprintf("\t%-*s | %s", maxFilenameLen, name, stats))
 	}
 
 	var insertionsPlural string

--- a/cmd/src/campaign_progress_printer.go
+++ b/cmd/src/campaign_progress_printer.go
@@ -29,6 +29,9 @@ func newCampaignProgressPrinter(out *output.Output, verbose bool, numParallelism
 }
 
 type campaignProgressPrinter struct {
+	// Used in tests only
+	forceNoSpinner bool
+
 	out *output.Output
 
 	sem *semaphore.Weighted
@@ -62,7 +65,13 @@ func (p *campaignProgressPrinter) initProgressBar(statuses []*campaigns.TaskStat
 	p.progress = p.out.ProgressWithStatusBars([]output.ProgressBar{{
 		Label: fmt.Sprintf("Executing ... (0/%d, 0 errored)", len(statuses)),
 		Max:   float64(len(statuses)),
-	}}, statusBars, nil)
+	}}, statusBars, &output.ProgressOpts{
+		// TODO: Hacky, only for testing
+		ForceNoSpinner: p.forceNoSpinner,
+		SuccessEmoji:   "\u2705",
+		SuccessStyle:   output.StyleSuccess,
+		PendingStyle:   output.StylePending,
+	})
 
 	return numStatusBars
 }

--- a/cmd/src/campaign_progress_printer_test.go
+++ b/cmd/src/campaign_progress_printer_test.go
@@ -81,6 +81,7 @@ func TestCampaignProgressPrinterIntegration(t *testing.T) {
 		"├── github.com/sourcegraph/sourcegraph  echo Hello World > README.md          0s",
 		"├── github.com/sourcegraph/src-cli      Downloading archive                   0s",
 		"└── github.com/sourcegraph/automati...  echo Hello World > README.md          0s",
+		"",
 	}
 	if !cmp.Equal(want, have) {
 		t.Fatalf("wrong output:\n%s", cmp.Diff(want, have))
@@ -128,6 +129,7 @@ func TestCampaignProgressPrinterIntegration(t *testing.T) {
 		"├── github.com/sourcegraph/sourcegraph  echo Hello World > README.md          0s",
 		"├── github.com/sourcegraph/src-cli      Downloading archive                   0s",
 		"└── github.com/sourcegraph/automati...  3 files changed ++++               0s",
+		"",
 	}
 	if !cmp.Equal(want, have) {
 		t.Fatalf("wrong output:\n%s", cmp.Diff(want, have))
@@ -157,6 +159,11 @@ func (t *ttyBuf) Write(b []byte) (int, error) {
 		case '\n':
 			t.line++
 			t.column = 0
+
+			if len(t.lines) == t.line {
+				t.lines = append(t.lines, []byte{})
+			}
+
 		case '\x1b':
 			// First of all: forgive me.
 			//

--- a/cmd/src/campaign_progress_printer_test.go
+++ b/cmd/src/campaign_progress_printer_test.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/sourcegraph/src-cli/internal/campaigns"
+	"github.com/sourcegraph/src-cli/internal/output"
+)
+
+func TestCampaignProgressPrinterIntegration(t *testing.T) {
+	buf := &ttyBuf{}
+
+	out := output.NewOutput(buf, output.OutputOpts{
+		ForceTTY:   true,
+		ForceColor: true,
+		Verbose:    true,
+	})
+
+	printer := newCampaignProgressPrinter(out, true, 4)
+	printer.forceNoSpinner = true
+
+	printer.PrintStatuses([]*campaigns.TaskStatus{
+		{
+			RepoName:           "github.com/sourcegraph/sourcegraph",
+			StartedAt:          time.Now(),
+			CurrentlyExecuting: "echo Hello World > README.md",
+		},
+		{
+			RepoName:           "github.com/sourcegraph/src-cli",
+			StartedAt:          time.Now().Add(time.Duration(-5) * time.Second),
+			CurrentlyExecuting: "Downloading archive",
+		},
+	})
+
+	have := buf.Lines()
+	want := []string{
+		"⠋  Executing... (0/2, 0 errored)  ",
+		"│                                                                                                                     ",
+		"├── github.com/sourcegraph/sourcegraph  echo Hello World > README.md                                                0s",
+		"└── github.com/sourcegraph/src-cli      Downloading archive                                                         0s",
+	}
+
+	if !cmp.Equal(want, have) {
+		t.Fatalf("wrong output:\n%s", cmp.Diff(want, have))
+	}
+
+}
+
+type ttyBuf struct {
+	lines [][]byte
+
+	line   int
+	column int
+}
+
+func (t *ttyBuf) Write(b []byte) (int, error) {
+	var cur int
+
+	for cur < len(b) {
+		switch b[cur] {
+		case '\n':
+			t.line++
+			t.column = 0
+		case '\x1b':
+			// First of all: forgive me.
+			//
+			// Now. Looks like we ran into a VT100 escape code.
+			// They follow this structure:
+			//
+			//      \x1b [ <digit> <command>
+			//
+			// So we jump over the \x1b[ and try to parse the digit.
+
+			digitStart := cur + 2 // cur == '\x1b', cur + 1 == '['
+			digitIndex := cur + 2
+			for isDigit(b[digitIndex]) {
+				digitIndex++
+			}
+
+			rawDigit := string(b[digitStart:digitIndex])
+			digit, err := strconv.ParseInt(rawDigit, 0, 64)
+			if err != nil {
+				return 0, err
+			}
+
+			command := b[digitIndex]
+
+			switch command {
+			case 'K':
+				// reset current line
+				if len(t.lines) > t.line {
+					t.lines[t.line] = []byte{}
+					t.column = 0
+				}
+			case 'A':
+				// move line up by <digit>
+				t.line = t.line - int(digit)
+
+			case 'D':
+				// *d*elete cursor by <digit> amount
+				t.column = t.column - int(digit)
+
+			case 'm':
+				// noop
+
+			case ';':
+				// color, skip over until end of color command
+				for b[digitIndex] != 'm' {
+					digitIndex++
+				}
+			}
+			cur = digitIndex + 1
+			continue
+
+		default:
+			t.writeToCurrentLine(b[cur])
+		}
+
+		cur++
+	}
+
+	return len(b), nil
+}
+
+func (t *ttyBuf) writeToCurrentLine(b byte) {
+	if len(t.lines) == t.line {
+		t.lines = append(t.lines, []byte{})
+	}
+
+	if len(t.lines[t.line]) <= t.column {
+		t.lines[t.line] = append(t.lines[t.line], b)
+	} else {
+		t.lines[t.line][t.column] = b
+	}
+	t.column++
+}
+
+func (t *ttyBuf) Lines() []string {
+	var lines []string
+	for _, l := range t.lines {
+		lines = append(lines, string(l))
+	}
+	return lines
+}
+
+func isDigit(ch byte) bool {
+	return '0' <= ch && ch <= '9'
+}

--- a/cmd/src/campaign_progress_printer_test.go
+++ b/cmd/src/campaign_progress_printer_test.go
@@ -165,6 +165,13 @@ func (t *ttyBuf) Write(b []byte) (int, error) {
 			}
 
 		case '\x1b':
+			// Check if we're looking at a VT100 escape code.
+			if len(b) <= cur || b[cur+1] != '[' {
+				t.writeToCurrentLine(b[cur])
+				cur++
+				continue
+			}
+
 			// First of all: forgive me.
 			//
 			// Now. Looks like we ran into a VT100 escape code.

--- a/cmd/src/campaign_progress_printer_test.go
+++ b/cmd/src/campaign_progress_printer_test.go
@@ -14,9 +14,11 @@ func TestCampaignProgressPrinterIntegration(t *testing.T) {
 	buf := &ttyBuf{}
 
 	out := output.NewOutput(buf, output.OutputOpts{
-		ForceTTY:   true,
-		ForceColor: true,
-		Verbose:    true,
+		ForceTTY:    true,
+		ForceColor:  true,
+		ForceHeight: 25,
+		ForceWidth:  80,
+		Verbose:     true,
 	})
 
 	printer := newCampaignProgressPrinter(out, true, 4)
@@ -38,9 +40,9 @@ func TestCampaignProgressPrinterIntegration(t *testing.T) {
 	have := buf.Lines()
 	want := []string{
 		"⠋  Executing... (0/2, 0 errored)  ",
-		"│                                                                                                                     ",
-		"├── github.com/sourcegraph/sourcegraph  echo Hello World > README.md                                                0s",
-		"└── github.com/sourcegraph/src-cli      Downloading archive                                                         0s",
+		"│                                                                               ",
+		"├── github.com/sourcegraph/sourcegraph  echo Hello World > README.md          0s",
+		"└── github.com/sourcegraph/src-cli      Downloading archive                   0s",
 	}
 
 	if !cmp.Equal(want, have) {

--- a/cmd/src/campaign_progress_printer_test.go
+++ b/cmd/src/campaign_progress_printer_test.go
@@ -133,6 +133,13 @@ func TestCampaignProgressPrinterIntegration(t *testing.T) {
 		t.Fatalf("wrong output:\n%s", cmp.Diff(want, have))
 	}
 
+	// Print again to make sure we get the same result
+	printer.PrintStatuses(statuses)
+	have = buf.Lines()
+	if !cmp.Equal(want, have) {
+		t.Fatalf("wrong output:\n%s", cmp.Diff(want, have))
+	}
+
 }
 
 type ttyBuf struct {

--- a/cmd/src/campaign_progress_printer_test.go
+++ b/cmd/src/campaign_progress_printer_test.go
@@ -11,6 +11,31 @@ import (
 	"github.com/sourcegraph/src-cli/internal/output"
 )
 
+const progressPrinterDiff = `diff --git README.md README.md
+new file mode 100644
+index 0000000..3363c39
+--- /dev/null
++++ README.md
+@@ -0,0 +1,3 @@
++# README
++
++This is the readme
+diff --git a/b/c/c.txt a/b/c/c.txt
+deleted file mode 100644
+index 5da75cf..0000000
+--- a/b/c/c.txt
++++ /dev/null
+@@ -1 +0,0 @@
+-this is c
+diff --git x/x.txt x/x.txt
+index 627c2ae..88f1836 100644
+--- x/x.txt
++++ x/x.txt
+@@ -1 +1 @@
+-this is x
++this is x (or is it?)
+`
+
 func TestCampaignProgressPrinterIntegration(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Something emits different escape codes on windows.")
@@ -26,10 +51,7 @@ func TestCampaignProgressPrinterIntegration(t *testing.T) {
 		Verbose:     true,
 	})
 
-	printer := newCampaignProgressPrinter(out, true, 4)
-	printer.forceNoSpinner = true
-
-	printer.PrintStatuses([]*campaigns.TaskStatus{
+	statuses := []*campaigns.TaskStatus{
 		{
 			RepoName:           "github.com/sourcegraph/sourcegraph",
 			StartedAt:          time.Now(),
@@ -40,16 +62,73 @@ func TestCampaignProgressPrinterIntegration(t *testing.T) {
 			StartedAt:          time.Now().Add(time.Duration(-5) * time.Second),
 			CurrentlyExecuting: "Downloading archive",
 		},
-	})
-
-	have := buf.Lines()
-	want := []string{
-		"⠋  Executing... (0/2, 0 errored)  ",
-		"│                                                                               ",
-		"├── github.com/sourcegraph/sourcegraph  echo Hello World > README.md          0s",
-		"└── github.com/sourcegraph/src-cli      Downloading archive                   0s",
+		{
+			RepoName:           "github.com/sourcegraph/automation-testing",
+			StartedAt:          time.Now().Add(time.Duration(-5) * time.Second),
+			CurrentlyExecuting: "echo Hello World > README.md",
+		},
 	}
 
+	printer := newCampaignProgressPrinter(out, true, 4)
+	printer.forceNoSpinner = true
+
+	// Print with all three tasks running
+	printer.PrintStatuses(statuses)
+	have := buf.Lines()
+	want := []string{
+		"⠋  Executing... (0/3, 0 errored)  ",
+		"│                                                                               ",
+		"├── github.com/sourcegraph/sourcegraph  echo Hello World > README.md          0s",
+		"├── github.com/sourcegraph/src-cli      Downloading archive                   0s",
+		"└── github.com/sourcegraph/automati...  echo Hello World > README.md          0s",
+	}
+	if !cmp.Equal(want, have) {
+		t.Fatalf("wrong output:\n%s", cmp.Diff(want, have))
+	}
+
+	// Now mark the last task as completed
+	statuses[len(statuses)-1] = &campaigns.TaskStatus{
+		RepoName:           "github.com/sourcegraph/automation-testing",
+		StartedAt:          time.Now().Add(time.Duration(-5) * time.Second),
+		FinishedAt:         time.Now().Add(time.Duration(5) * time.Second),
+		CurrentlyExecuting: "",
+		Err:                nil,
+		ChangesetSpec: &campaigns.ChangesetSpec{
+			BaseRepository: "graphql-id",
+			CreatedChangeset: &campaigns.CreatedChangeset{
+				BaseRef:        "refs/heads/main",
+				BaseRev:        "d34db33f",
+				HeadRepository: "graphql-id",
+				HeadRef:        "refs/heads/my-campaign",
+				Title:          "This is my campaign",
+				Body:           "This is my campaign",
+				Commits: []campaigns.GitCommitDescription{
+					{
+						Message: "This is my campaign",
+						Diff:    progressPrinterDiff,
+					},
+				},
+				Published: false,
+			},
+		},
+	}
+
+	printer.PrintStatuses(statuses)
+	have = buf.Lines()
+	want = []string{
+		"github.com/sourcegraph/automation-testing",
+		"\tREADME.md   | 3 +++",
+		"\ta/b/c/c.txt | 1 -",
+		"\tx/x.txt     | 2 +-",
+		"  3 files changed, 4 insertions, 2 deletions",
+		"  Execution took 10s",
+		"",
+		"⠋  Executing... (1/3, 0 errored)  ███████████████▍",
+		"│                                                                                 0s", // Not sure why this is here, bug?
+		"├── github.com/sourcegraph/sourcegraph  echo Hello World > README.md          0s",
+		"├── github.com/sourcegraph/src-cli      Downloading archive                   0s",
+		"└── github.com/sourcegraph/automati...  3 files changed ++++               0s",
+	}
 	if !cmp.Equal(want, have) {
 		t.Fatalf("wrong output:\n%s", cmp.Diff(want, have))
 	}

--- a/cmd/src/campaign_progress_printer_test.go
+++ b/cmd/src/campaign_progress_printer_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"runtime"
 	"strconv"
 	"testing"
 	"time"
@@ -11,6 +12,10 @@ import (
 )
 
 func TestCampaignProgressPrinterIntegration(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Something emits different escape codes on windows.")
+	}
+
 	buf := &ttyBuf{}
 
 	out := output.NewOutput(buf, output.OutputOpts{

--- a/cmd/src/campaign_progress_printer_test.go
+++ b/cmd/src/campaign_progress_printer_test.go
@@ -124,7 +124,7 @@ func TestCampaignProgressPrinterIntegration(t *testing.T) {
 		"  Execution took 10s",
 		"",
 		"⠋  Executing... (1/3, 0 errored)  ███████████████▍",
-		"│                                                                                 0s", // Not sure why this is here, bug?
+		"│                                                                               ",
 		"├── github.com/sourcegraph/sourcegraph  echo Hello World > README.md          0s",
 		"├── github.com/sourcegraph/src-cli      Downloading archive                   0s",
 		"└── github.com/sourcegraph/automati...  3 files changed ++++               0s",

--- a/cmd/src/campaign_progress_printer_test.go
+++ b/cmd/src/campaign_progress_printer_test.go
@@ -51,20 +51,21 @@ func TestCampaignProgressPrinterIntegration(t *testing.T) {
 		Verbose:     true,
 	})
 
+	now := time.Now()
 	statuses := []*campaigns.TaskStatus{
 		{
 			RepoName:           "github.com/sourcegraph/sourcegraph",
-			StartedAt:          time.Now(),
+			StartedAt:          now,
 			CurrentlyExecuting: "echo Hello World > README.md",
 		},
 		{
 			RepoName:           "github.com/sourcegraph/src-cli",
-			StartedAt:          time.Now().Add(time.Duration(-5) * time.Second),
+			StartedAt:          now.Add(time.Duration(-5) * time.Second),
 			CurrentlyExecuting: "Downloading archive",
 		},
 		{
 			RepoName:           "github.com/sourcegraph/automation-testing",
-			StartedAt:          time.Now().Add(time.Duration(-5) * time.Second),
+			StartedAt:          now.Add(time.Duration(-5) * time.Second),
 			CurrentlyExecuting: "echo Hello World > README.md",
 		},
 	}
@@ -90,8 +91,8 @@ func TestCampaignProgressPrinterIntegration(t *testing.T) {
 	// Now mark the last task as completed
 	statuses[len(statuses)-1] = &campaigns.TaskStatus{
 		RepoName:           "github.com/sourcegraph/automation-testing",
-		StartedAt:          time.Now().Add(time.Duration(-5) * time.Second),
-		FinishedAt:         time.Now().Add(time.Duration(5) * time.Second),
+		StartedAt:          now.Add(time.Duration(-5) * time.Second),
+		FinishedAt:         now.Add(time.Duration(5) * time.Second),
 		CurrentlyExecuting: "",
 		Err:                nil,
 		ChangesetSpec: &campaigns.ChangesetSpec{
@@ -141,7 +142,6 @@ func TestCampaignProgressPrinterIntegration(t *testing.T) {
 	if !cmp.Equal(want, have) {
 		t.Fatalf("wrong output:\n%s", cmp.Diff(want, have))
 	}
-
 }
 
 type ttyBuf struct {

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -53,6 +53,11 @@ type OutputOpts struct {
 	// ForceTTY ignores all terminal detection and enables TTY output.
 	ForceTTY bool
 
+	// ForceHeight ignores all terminal detection and sets the height to this value.
+	ForceHeight int
+	// ForceWidth ignores all terminal detection and sets the width to this value.
+	ForceWidth int
+
 	Verbose bool
 }
 
@@ -67,6 +72,12 @@ func NewOutput(w io.Writer, opts OutputOpts) *Output {
 	}
 	if opts.ForceTTY {
 		caps.Isatty = true
+	}
+	if opts.ForceHeight != 0 {
+		caps.Height = opts.ForceHeight
+	}
+	if opts.ForceWidth != 0 {
+		caps.Width = opts.ForceWidth
 	}
 
 	o := &Output{caps: caps, opts: opts, w: w}

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -50,7 +50,10 @@ type Output struct {
 type OutputOpts struct {
 	// ForceColor ignores all terminal detection and enabled coloured output.
 	ForceColor bool
-	Verbose    bool
+	// ForceTTY ignores all terminal detection and enables TTY output.
+	ForceTTY bool
+
+	Verbose bool
 }
 
 // newOutputPlatformQuirks provides a way for conditionally compiled code to
@@ -61,6 +64,9 @@ func NewOutput(w io.Writer, opts OutputOpts) *Output {
 	caps := detectCapabilities()
 	if opts.ForceColor {
 		caps.Color = true
+	}
+	if opts.ForceTTY {
+		caps.Isatty = true
 	}
 
 	o := &Output{caps: caps, opts: opts, w: w}

--- a/internal/output/progress.go
+++ b/internal/output/progress.go
@@ -33,6 +33,11 @@ type ProgressOpts struct {
 	PendingStyle Style
 	SuccessEmoji string
 	SuccessStyle Style
+
+	// ForceNoSpinner turns of the automatic updating of the progress bar and
+	// spinner in a background goroutine.
+	// Used for testing only!
+	ForceNoSpinner bool
 }
 
 func newProgress(bars []ProgressBar, o *Output, opts *ProgressOpts) Progress {

--- a/internal/output/progress.go
+++ b/internal/output/progress.go
@@ -34,15 +34,15 @@ type ProgressOpts struct {
 	SuccessEmoji string
 	SuccessStyle Style
 
-	// ForceNoSpinner turns of the automatic updating of the progress bar and
+	// NoSpinner turns of the automatic updating of the progress bar and
 	// spinner in a background goroutine.
 	// Used for testing only!
-	ForceNoSpinner bool
+	NoSpinner bool
 }
 
-func (opt *ProgressOpts) WithForceNoSpinner(forceNoSpinner bool) *ProgressOpts {
+func (opt *ProgressOpts) WithoutSpinner() *ProgressOpts {
 	c := *opt
-	c.ForceNoSpinner = forceNoSpinner
+	c.NoSpinner = true
 	return &c
 }
 
@@ -53,7 +53,7 @@ func newProgress(bars []ProgressBar, o *Output, opts *ProgressOpts) Progress {
 	}
 
 	if !o.caps.Isatty {
-		return newProgressSimple(barPtrs, o)
+		return newProgressSimple(barPtrs, o, opts)
 	}
 
 	return newProgressTTY(barPtrs, o, opts)

--- a/internal/output/progress.go
+++ b/internal/output/progress.go
@@ -40,6 +40,12 @@ type ProgressOpts struct {
 	ForceNoSpinner bool
 }
 
+func (opt *ProgressOpts) WithForceNoSpinner(forceNoSpinner bool) *ProgressOpts {
+	c := *opt
+	c.ForceNoSpinner = forceNoSpinner
+	return &c
+}
+
 func newProgress(bars []ProgressBar, o *Output, opts *ProgressOpts) Progress {
 	barPtrs := make([]*ProgressBar, len(bars))
 	for i := range bars {

--- a/internal/output/progress_simple.go
+++ b/internal/output/progress_simple.go
@@ -38,11 +38,18 @@ func (p *progressSimple) stop() {
 	<-c
 }
 
-func newProgressSimple(bars []*ProgressBar, o *Output) *progressSimple {
+func newProgressSimple(bars []*ProgressBar, o *Output, opts *ProgressOpts) *progressSimple {
 	p := &progressSimple{
 		Output: o,
 		bars:   bars,
 		done:   make(chan chan struct{}),
+	}
+
+	if opts.NoSpinner {
+		if p.Output.opts.Verbose {
+			writeBars(p.Output, p.bars)
+		}
+		return p
 	}
 
 	go func() {

--- a/internal/output/progress_tty.go
+++ b/internal/output/progress_tty.go
@@ -156,6 +156,10 @@ func newProgressTTY(bars []*ProgressBar, o *Output, opts *ProgressOpts) *progres
 
 	p.draw()
 
+	if opts.NoSpinner {
+		return p
+	}
+
 	go func() {
 		for s := range p.spinner.C {
 			func() {

--- a/internal/output/progress_tty.go
+++ b/internal/output/progress_tty.go
@@ -9,7 +9,7 @@ import (
 	"github.com/mattn/go-runewidth"
 )
 
-var defaultProgressTTYOpts = ProgressOpts{
+var DefaultProgressTTYOpts = &ProgressOpts{
 	SuccessEmoji: "\u2705",
 	SuccessStyle: StyleSuccess,
 	PendingStyle: StylePending,
@@ -145,7 +145,7 @@ func newProgressTTY(bars []*ProgressBar, o *Output, opts *ProgressOpts) *progres
 	if opts != nil {
 		p.opts = *opts
 	} else {
-		p.opts = defaultProgressTTYOpts
+		p.opts = *DefaultProgressTTYOpts
 	}
 
 	p.determineEmojiWidth()

--- a/internal/output/progress_with_status_bars.go
+++ b/internal/output/progress_with_status_bars.go
@@ -16,7 +16,7 @@ func newProgressWithStatusBars(bars []ProgressBar, statusBars []*StatusBar, o *O
 	}
 
 	if !o.caps.Isatty {
-		return newProgressWithStatusBarsSimple(barPtrs, statusBars, o)
+		return newProgressWithStatusBarsSimple(barPtrs, statusBars, o, opts)
 	}
 
 	return newProgressWithStatusBarsTTY(barPtrs, statusBars, o, opts)

--- a/internal/output/progress_with_status_bars_simple.go
+++ b/internal/output/progress_with_status_bars_simple.go
@@ -48,7 +48,7 @@ func (p *progressWithStatusBarsSimple) StatusBarResetf(i int, label, format stri
 	}
 }
 
-func newProgressWithStatusBarsSimple(bars []*ProgressBar, statusBars []*StatusBar, o *Output) *progressWithStatusBarsSimple {
+func newProgressWithStatusBarsSimple(bars []*ProgressBar, statusBars []*StatusBar, o *Output, opts *ProgressOpts) *progressWithStatusBarsSimple {
 	p := &progressWithStatusBarsSimple{
 		progressSimple: &progressSimple{
 			Output: o,
@@ -56,6 +56,14 @@ func newProgressWithStatusBarsSimple(bars []*ProgressBar, statusBars []*StatusBa
 			done:   make(chan chan struct{}),
 		},
 		statusBars: statusBars,
+	}
+
+	if opts.NoSpinner {
+		if p.Output.opts.Verbose {
+			writeBars(p.Output, p.bars)
+			writeStatusBars(p.Output, p.statusBars)
+		}
+		return p
 	}
 
 	go func() {

--- a/internal/output/progress_with_status_bars_tty.go
+++ b/internal/output/progress_with_status_bars_tty.go
@@ -174,6 +174,7 @@ func (p *progressWithStatusBarsTTY) draw() {
 	}
 
 	if len(p.statusBars) > 0 {
+		p.o.clearCurrentLine()
 		fmt.Fprint(p.o.w, StylePending, "│", runewidth.FillLeft("\n", p.o.caps.Width-1))
 
 	}

--- a/internal/output/progress_with_status_bars_tty.go
+++ b/internal/output/progress_with_status_bars_tty.go
@@ -34,7 +34,7 @@ func newProgressWithStatusBarsTTY(bars []*ProgressBar, statusBars []*StatusBar, 
 
 	p.draw()
 
-	if opts.ForceNoSpinner {
+	if opts.NoSpinner {
 		return p
 	}
 

--- a/internal/output/progress_with_status_bars_tty.go
+++ b/internal/output/progress_with_status_bars_tty.go
@@ -34,6 +34,10 @@ func newProgressWithStatusBarsTTY(bars []*ProgressBar, statusBars []*StatusBar, 
 
 	p.draw()
 
+	if opts.ForceNoSpinner {
+		return p
+	}
+
 	go func() {
 		for s := range p.spinner.C {
 			func() {

--- a/internal/output/progress_with_status_bars_tty.go
+++ b/internal/output/progress_with_status_bars_tty.go
@@ -22,7 +22,7 @@ func newProgressWithStatusBarsTTY(bars []*ProgressBar, statusBars []*StatusBar, 
 	if opts != nil {
 		p.opts = *opts
 	} else {
-		p.opts = defaultProgressTTYOpts
+		p.opts = *DefaultProgressTTYOpts
 	}
 
 	p.determineEmojiWidth()


### PR DESCRIPTION
I started with one thought: "I just wish I had _one_ test to make sure that this whole thing [the terminal UI] doesn't blow up every time I make a change" What I ended with is this. It includes a tiny VT100 "emulator".

And here's the kicker: I actually like this. It's fast to run and easy to extend and it gives me confidence that the basic rendering functionality works. Of course, the hacky injections need to be cleaned up before merging. And maybe we can get it to pass on Windows.

Opinions?

(This fixes https://github.com/sourcegraph/sourcegraph/issues/16330)