### PR TITLE
campaigns: add -vv to show executed commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to `src-cli` are documented in this file.
 
 ### Added
 
+- `src campaign [apply|preview]` now accept a `-vv` option to display even more verbose output, most notably every command being spawned during execution. [#402](https://github.com/sourcegraph/src-cli/pull/402)
+
 ### Changed
 
 - `src campaign [apply|preview]` now show the current execution progress in numbers next to the progress bar. [#396](https://github.com/sourcegraph/src-cli/pull/396)

--- a/cmd/src/campaigns_apply.go
+++ b/cmd/src/campaigns_apply.go
@@ -62,6 +62,11 @@ Examples:
 			return &usageError{errors.New("additional arguments not allowed")}
 		}
 
+		// -vv implies -v.
+		if flags.superVerbose {
+			*verbose = true
+		}
+
 		out := output.NewOutput(flagSet.Output(), output.OutputOpts{Verbose: *verbose})
 
 		ctx, cancel := contextCancelOnInterrupt(context.Background())
@@ -70,6 +75,7 @@ Examples:
 		svc := campaigns.NewService(&campaigns.ServiceOpts{
 			AllowUnsupported: flags.allowUnsupported,
 			Client:           cfg.apiClient(flags.api, flagSet.Output()),
+			OnCommand:        campaignsOnCommand(out, flags.superVerbose),
 		})
 
 		if err := svc.DetermineFeatureFlags(ctx); err != nil {

--- a/cmd/src/campaigns_common.go
+++ b/cmd/src/campaigns_common.go
@@ -39,6 +39,7 @@ type campaignsApplyFlags struct {
 	keepLogs         bool
 	namespace        string
 	parallelism      int
+	superVerbose     bool
 	timeout          time.Duration
 	cleanArchives    bool
 	skipErrors       bool
@@ -101,6 +102,8 @@ func newCampaignsApplyFlags(flagSet *flag.FlagSet, cacheDir, tempDir string) *ca
 	)
 
 	flagSet.BoolVar(verbose, "v", false, "print verbose output")
+
+	flagSet.BoolVar(&caf.superVerbose, "vv", false, "print more verbose output")
 
 	return caf
 }
@@ -462,4 +465,14 @@ func contextCancelOnInterrupt(parent context.Context) (context.Context, func()) 
 		signal.Stop(c)
 		ctxCancel()
 	}
+}
+
+func campaignsOnCommand(out *output.Output, superVerbose bool) campaigns.OnCommand {
+	if superVerbose {
+		return func(cmd *exec.Cmd) {
+			out.VerboseLine(output.Line("🚀", output.Fg256Color(184), cmd.String()))
+		}
+	}
+
+	return nil
 }

--- a/cmd/src/campaigns_preview.go
+++ b/cmd/src/campaigns_preview.go
@@ -37,6 +37,11 @@ Examples:
 			return &usageError{errors.New("additional arguments not allowed")}
 		}
 
+		// -vv implies -v.
+		if flags.superVerbose {
+			*verbose = true
+		}
+
 		out := output.NewOutput(flagSet.Output(), output.OutputOpts{Verbose: *verbose})
 
 		ctx, cancel := contextCancelOnInterrupt(context.Background())
@@ -45,6 +50,7 @@ Examples:
 		svc := campaigns.NewService(&campaigns.ServiceOpts{
 			AllowUnsupported: flags.allowUnsupported,
 			Client:           cfg.apiClient(flags.api, flagSet.Output()),
+			OnCommand:        campaignsOnCommand(out, flags.superVerbose),
 		})
 
 		if err := svc.DetermineFeatureFlags(ctx); err != nil {

--- a/internal/campaigns/action.go
+++ b/internal/campaigns/action.go
@@ -20,7 +20,7 @@ func getDockerImageContentDigest(ctx context.Context, image string) (string, err
 	// digest. but the digest is not calculated for all images (unless they are
 	// pulled/pushed from/to a registry), see
 	// https://github.com/moby/moby/issues/32016.
-	out, err := exec.CommandContext(ctx, "docker", "image", "inspect", "--format", "{{.Id}}", "--", image).CombinedOutput()
+	out, err := noticeCommand(ctx, exec.CommandContext(ctx, "docker", "image", "inspect", "--format", "{{.Id}}", "--", image)).CombinedOutput()
 	if err != nil {
 		if !strings.Contains(string(out), "No such image") {
 			return "", fmt.Errorf("error inspecting docker image %q: %s", image, bytes.TrimSpace(out))

--- a/internal/campaigns/command.go
+++ b/internal/campaigns/command.go
@@ -1,0 +1,18 @@
+package campaigns
+
+import (
+	"context"
+	"os/exec"
+)
+
+type OnCommand func(*exec.Cmd)
+
+const onCommandContextKey = "campaigns.onCommand"
+
+func noticeCommand(ctx context.Context, cmd *exec.Cmd) *exec.Cmd {
+	if onCommand, ok := ctx.Value(onCommandContextKey).(OnCommand); onCommand != nil && ok {
+		onCommand(cmd)
+	}
+
+	return cmd
+}

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -111,12 +111,18 @@ func (o *Output) VerboseLine(line FancyLine) {
 func (o *Output) Write(s string) {
 	o.lock.Lock()
 	defer o.lock.Unlock()
+	if o.caps.Isatty {
+		o.clearCurrentLine()
+	}
 	fmt.Fprintln(o.w, s)
 }
 
 func (o *Output) Writef(format string, args ...interface{}) {
 	o.lock.Lock()
 	defer o.lock.Unlock()
+	if o.caps.Isatty {
+		o.clearCurrentLine()
+	}
 	fmt.Fprintf(o.w, format, o.caps.formatArgs(args)...)
 	fmt.Fprint(o.w, "\n")
 }
@@ -124,6 +130,9 @@ func (o *Output) Writef(format string, args ...interface{}) {
 func (o *Output) WriteLine(line FancyLine) {
 	o.lock.Lock()
 	defer o.lock.Unlock()
+	if o.caps.Isatty {
+		o.clearCurrentLine()
+	}
 	line.write(o.w, o.caps)
 }
 

--- a/internal/output/progress_simple.go
+++ b/internal/output/progress_simple.go
@@ -33,16 +33,17 @@ func (p *progressSimple) SetValue(i int, v float64) {
 }
 
 func (p *progressSimple) stop() {
-	c := make(chan struct{})
-	p.done <- c
-	<-c
+	if p.done != nil {
+		c := make(chan struct{})
+		p.done <- c
+		<-c
+	}
 }
 
 func newProgressSimple(bars []*ProgressBar, o *Output, opts *ProgressOpts) *progressSimple {
 	p := &progressSimple{
 		Output: o,
 		bars:   bars,
-		done:   make(chan chan struct{}),
 	}
 
 	if opts != nil && opts.NoSpinner {
@@ -52,6 +53,7 @@ func newProgressSimple(bars []*ProgressBar, o *Output, opts *ProgressOpts) *prog
 		return p
 	}
 
+	p.done = make(chan chan struct{})
 	go func() {
 		ticker := time.NewTicker(1 * time.Second)
 		defer ticker.Stop()

--- a/internal/output/progress_with_status_bars_simple.go
+++ b/internal/output/progress_with_status_bars_simple.go
@@ -53,7 +53,6 @@ func newProgressWithStatusBarsSimple(bars []*ProgressBar, statusBars []*StatusBa
 		progressSimple: &progressSimple{
 			Output: o,
 			bars:   bars,
-			done:   make(chan chan struct{}),
 		},
 		statusBars: statusBars,
 	}
@@ -66,6 +65,7 @@ func newProgressWithStatusBarsSimple(bars []*ProgressBar, statusBars []*StatusBa
 		return p
 	}
 
+	p.done = make(chan chan struct{})
 	go func() {
 		ticker := time.NewTicker(1 * time.Second)
 		defer ticker.Stop()


### PR DESCRIPTION
This PR adds a new flag — `-vv` — to show every command that is spawned while executing a campaign. Here it is in action:

![out](https://user-images.githubusercontent.com/229984/101564196-8af6ec00-397f-11eb-8500-76c89eec4e8f.gif)

If only the implementation was that simple...

Unfortunately, printing log messages via `Verbose*` and `Write*` is a bit fraught right now in `internal/output`: the only safe way to do it is on the active "widget" (ie `Progress`, or `Pending`, or whatever), lest your message be overwritten the next time the widget is drawn. However, actually tracking what the current widget is not terribly easy, and that's only exacerbated when it's being handled in a callback from the service type.

The naïve solution here would be to track the current widget in `Output` and delegate to that widget's equivalent function for `Verbose*` and `Write*` calls, but that is also problematic, since they may recursively call `Output.Write` and friends. (And they do.) The architectural problem here is that `Output` really addresses two or three separate concerns: providing an API for external users, providing an API for internal users, and handling a lot of the quirks of outputting things to various terminal types.

I had about four attempts at splitting it up today, and just couldn't get it. It's a ball of yarn, and every time I thought I had the boundaries sketched out, I found something else that needed to cross those boundaries: how the output behaves has to depend on the terminal capabilities, and the output options, and has to be lockable at the entry point into the output package so that widgets can make atomic updates. The real fix here is probably to redesign how we get characters and control codes to the screen with something like a command list that can write to a buffer and then flush to the terminal asynchronously. (This would also fix some flicker issues we have that are more noticeable on Windows.)

So, instead, here's a much hackier approach. The progress bar widgets currently draw and leave the cursor at the bottom of the drawn content, but there's no particular reason this has to be the case. If we switch them to leave the cursor at the top of the drawn content after a draw, then a verbose log line can simply overwrite that line, and then the next widget draw will put everything back the way it should be. Those tend to be common, particularly when spinners are enabled, but it does increase flickering. (Of course, that's only if `-v` is enabled, and it's only really bad if `-vv` is enabled.)