### PR TITLE
Actually skip unsupported repos if -allow-unsupported is not set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ All notable changes to `src-cli` are documented in this file.
 ### Fixed
 
 - Two race conditions in the terminal UI of `src campaign [apply|preview]` have been fixed. [#399](https://github.com/sourcegraph/src-cli/pull/399)
-- A regression caused repositories on unsupported code host to not be skipped by `src campaign [apply|preview]`, regardless of whether `-allow-unsupported` was set or not.
+- A regression caused repositories on unsupported code host to not be skipped by `src campaign [apply|preview]`, regardless of whether `-allow-unsupported` was set or not. [#403](https://github.com/sourcegraph/src-cli/pull/403)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to `src-cli` are documented in this file.
 ### Fixed
 
 - Two race conditions in the terminal UI of `src campaign [apply|preview]` have been fixed. [#399](https://github.com/sourcegraph/src-cli/pull/399)
+- A regression caused repositories on unsupported code host to not be skipped by `src campaign [apply|preview]`, regardless of whether `-allow-unsupported` was set or not.
 
 ### Removed
 

--- a/internal/campaigns/errors.go
+++ b/internal/campaigns/errors.go
@@ -12,6 +12,11 @@ import (
 // returned directly as an error value if needed.
 type UnsupportedRepoSet map[*graphql.Repository]struct{}
 
+func (e UnsupportedRepoSet) includes(r *graphql.Repository) bool {
+	_, ok := e[r]
+	return ok
+}
+
 func (e UnsupportedRepoSet) Error() string {
 	repos := []string{}
 	typeSet := map[string]struct{}{}

--- a/internal/campaigns/service.go
+++ b/internal/campaigns/service.go
@@ -391,12 +391,12 @@ func (svc *Service) ResolveRepositories(ctx context.Context, spec *CampaignSpec)
 
 			if other, ok := seen[repo.ID]; !ok {
 				seen[repo.ID] = repo
+
 				switch st := strings.ToLower(repo.ExternalRepository.ServiceType); st {
 				case "github", "gitlab", "bitbucketserver":
 				default:
-					unsupported.appendRepo(repo)
 					if !svc.allowUnsupported {
-						continue
+						unsupported.appendRepo(repo)
 					}
 				}
 			} else {
@@ -410,10 +410,12 @@ func (svc *Service) ResolveRepositories(ctx context.Context, spec *CampaignSpec)
 
 	final := make([]*graphql.Repository, 0, len(seen))
 	for _, repo := range seen {
-		final = append(final, repo)
+		if !unsupported.includes(repo) {
+			final = append(final, repo)
+		}
 	}
 
-	if unsupported.hasUnsupported() && !svc.allowUnsupported {
+	if unsupported.hasUnsupported() {
 		return final, unsupported
 	}
 


### PR DESCRIPTION
I think multiple changes to this method lead to a regression where
unsupported repositories were correctly being reported as unsupported
but were still added to the final list of repositories, regardless of
whether `-allow-unsupported` was set or not.