### PR TITLE
Validate spec contains changesetTemplate if steps are set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to `src-cli` are documented in this file.
 
 - Two race conditions in the terminal UI of `src campaign [apply|preview]` have been fixed. [#399](https://github.com/sourcegraph/src-cli/pull/399)
 - A regression caused repositories on unsupported code host to not be skipped by `src campaign [apply|preview]`, regardless of whether `-allow-unsupported` was set or not. [#403](https://github.com/sourcegraph/src-cli/pull/403)
+- Previously `src campaign [apply|preview]` would crash when executing a campaign spec that contained `steps` but no `changesetTemplate`. [#406](https://github.com/sourcegraph/src-cli/issues/406)
 
 ### Removed
 

--- a/internal/campaigns/campaign_spec.go
+++ b/internal/campaigns/campaign_spec.go
@@ -101,6 +101,10 @@ func ParseCampaignSpec(data []byte, features featureFlags) (*CampaignSpec, error
 		}
 	}
 
+	if len(spec.Steps) != 0 && spec.ChangesetTemplate == nil {
+		errs = multierror.Append(errs, errors.New("campaign spec includes steps but no changesetTemplate"))
+	}
+
 	if spec.TransformChanges != nil && !features.allowtransformChanges {
 		errs = multierror.Append(errs, errors.New("campaign spec includes transformChanges, which is not supported in this Sourcegraph version"))
 	}

--- a/internal/campaigns/campaign_spec_test.go
+++ b/internal/campaigns/campaign_spec_test.go
@@ -1,0 +1,55 @@
+package campaigns
+
+import "testing"
+
+func TestParseCampaignSpec(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		const spec = `
+name: hello-world
+description: Add Hello World to READMEs
+on:
+  - repositoriesMatchingQuery: file:README.md
+steps:
+  - run: echo Hello World | tee -a $(find -name README.md)
+    container: alpine:3
+changesetTemplate:
+  title: Hello World
+  body: My first campaign!
+  branch: hello-world
+  commit:
+    message: Append Hello World to all README.md files
+  published: false
+`
+
+		_, err := ParseCampaignSpec([]byte(spec), featureFlags{})
+		if err != nil {
+			t.Fatalf("parsing valid spec returned error: %s", err)
+		}
+	})
+
+	t.Run("missing changesetTemplate", func(t *testing.T) {
+		const spec = `
+name: hello-world
+description: Add Hello World to READMEs
+on:
+  - repositoriesMatchingQuery: file:README.md
+steps:
+  - run: echo Hello World | tee -a $(find -name README.md)
+    container: alpine:3
+`
+
+		_, err := ParseCampaignSpec([]byte(spec), featureFlags{})
+		if err == nil {
+			t.Fatal("no error returned")
+		}
+
+		wantErr := `1 error occurred:
+	* campaign spec includes steps but no changesetTemplate
+
+`
+		haveErr := err.Error()
+		if haveErr != wantErr {
+			t.Fatalf("wrong error. want=%q, have=%q", wantErr, haveErr)
+		}
+	})
+}


### PR DESCRIPTION
This fixes https://github.com/sourcegraph/src-cli/issues/406 and
https://github.com/sourcegraph/src-cli/issues/404 by making sure that a
`changesetTemplate` is defined when `steps` are set.

(Since we allow using only `importChangesets` in a campaign spec, we need
to make this conditional on whether steps are set or not)