### PR TITLE
campaigns: suggest alternatives when campaigns are unlicensed

### DIFF
--- a/cmd/src/campaigns_common.go
+++ b/cmd/src/campaigns_common.go
@@ -436,10 +436,16 @@ func prettyPrintCampaignsUnlicensedError(out *output.Output, err error) error {
 			} else if code == "ErrCampaignsUnlicensed" {
 				// OK, let's print a better message, then return an
 				// exitCodeError to suppress the normal automatic error block.
-				block := out.Block(output.Line("🪙", output.StyleWarning, "Campaigns is a paid feature of Sourcegraph. All users can create sample campaigns with up to 5 changesets without a license."))
-				block.WriteLine(output.Linef("", output.StyleWarning, "Contact Sourcegraph sales at %shttps://about.sourcegraph.com/contact/sales/%s to obtain a trial license.", output.StyleSearchLink, output.StyleWarning))
+				// Note that we have hand wrapped the output at 80 (printable)
+				// characters: having automatic wrapping some day would be nice,
+				// but this should be sufficient for now.
+				block := out.Block(output.Line("🪙", output.StyleWarning, "Campaigns is a paid feature of Sourcegraph. All users can create sample"))
+				block.WriteLine(output.Linef("", output.StyleWarning, "campaigns with up to 5 changesets without a license. Contact Sourcegraph sales"))
+				block.WriteLine(output.Linef("", output.StyleWarning, "at %shttps://about.sourcegraph.com/contact/sales/%s to obtain a trial license.", output.StyleSearchLink, output.StyleWarning))
 				block.Write("")
-				block.WriteLine(output.Linef("", output.StyleWarning, "To proceed with this campaign, you will need to create five or fewer changesets. To do so, you could try adding %scount:5%s to your %srepositoriesMatchingQuery%s search, or reduce the number of changesets in %simportChangesets%s.", output.StyleSearchAlertProposedQuery, output.StyleWarning, output.StyleReset, output.StyleWarning, output.StyleReset, output.StyleWarning))
+				block.WriteLine(output.Linef("", output.StyleWarning, "To proceed with this campaign, you will need to create 5 or fewer changesets."))
+				block.WriteLine(output.Linef("", output.StyleWarning, "To do so, you could try adding %scount:5%s to your %srepositoriesMatchingQuery%s search,", output.StyleSearchAlertProposedQuery, output.StyleWarning, output.StyleReset, output.StyleWarning))
+				block.WriteLine(output.Linef("", output.StyleWarning, "or reduce the number of changesets in %simportChangesets%s.", output.StyleReset, output.StyleWarning))
 				block.Close()
 				return &exitCodeError{exitCode: graphqlErrorsExitCode}
 			}

--- a/cmd/src/campaigns_common.go
+++ b/cmd/src/campaigns_common.go
@@ -242,7 +242,6 @@ func campaignsExecute(ctx context.Context, out *output.Output, svc *campaigns.Se
 	specs, err := svc.ExecuteCampaignSpec(ctx, repos, executor, campaignSpec, p.PrintStatuses, flags.skipErrors)
 	if err != nil && !flags.skipErrors {
 		return "", "", err
-
 	}
 	p.Complete()
 	if err != nil && flags.skipErrors {
@@ -293,7 +292,7 @@ func campaignsExecute(ctx context.Context, out *output.Output, svc *campaigns.Se
 	pending = campaignsCreatePending(out, "Creating campaign spec on Sourcegraph")
 	id, url, err := svc.CreateCampaignSpec(ctx, namespace, rawSpec, ids)
 	if err != nil {
-		return "", "", err
+		return "", "", prettyPrintCampaignsUnlicensedError(out, err)
 	}
 	campaignsCompletePending(pending, "Creating campaign spec on Sourcegraph")
 
@@ -331,6 +330,12 @@ func campaignsParseSpec(out *output.Output, svc *campaigns.Service, input io.Rea
 // printExecutionError is used to print the possible error returned by
 // campaignsExecute.
 func printExecutionError(out *output.Output, err error) {
+	// exitCodeError shouldn't generate any specific output, since it indicates
+	// that this was done deeper in the call stack.
+	if _, ok := err.(*exitCodeError); ok {
+		return
+	}
+
 	out.Write("")
 
 	writeErrs := func(errs []error) {
@@ -356,7 +361,7 @@ func printExecutionError(out *output.Output, err error) {
 	}
 
 	switch err := err.(type) {
-	case parallel.Errors, *multierror.Error:
+	case parallel.Errors, *multierror.Error, api.GraphQlErrors:
 		writeErrs(flattenErrs(err))
 
 	default:
@@ -376,6 +381,12 @@ func flattenErrs(err error) (result []error) {
 		for _, e := range errs.Errors {
 			result = append(result, flattenErrs(e)...)
 		}
+
+	case api.GraphQlErrors:
+		for _, e := range errs {
+			result = append(result, flattenErrs(e)...)
+		}
+
 	default:
 		result = append(result, errs)
 	}
@@ -401,6 +412,38 @@ func formatTaskExecutionErr(err campaigns.TaskExecutionErr) string {
 		err.Err,
 		err.Logfile,
 	)
+}
+
+// prettyPrintCampaignsUnlicensedError introspects the given error returned when
+// creating a campaign spec and ascertains whether it's a licensing error. If it
+// is, then a better message is output. Regardless, the return value of this
+// function should be used to replace the original error passed in to ensure
+// that the displayed output is sensible.
+func prettyPrintCampaignsUnlicensedError(out *output.Output, err error) error {
+	// Pull apart the error to see if it's a licensing error: if so, we should
+	// display a friendlier and more actionable message than the usual GraphQL
+	// error output.
+	if gerrs, ok := err.(api.GraphQlErrors); ok {
+		// A licensing error should be the sole error returned, so we'll only
+		// pretty print if there's one error.
+		if len(gerrs) == 1 {
+			if code, cerr := gerrs[0].Code(); cerr != nil {
+				// We got a malformed value in the error extensions; at this
+				// point, there's not much sensible we can do. Let's log this in
+				// verbose mode, but let the original error bubble up rather
+				// than this one.
+				out.Verbosef("Unexpected error parsing the GraphQL error: %v", cerr)
+			} else if code == "ErrCampaignsUnlicensed" {
+				// OK, let's print a better message, then return an
+				// exitCodeError to suppress the normal automatic error block.
+				out.WriteLine(output.Line("🪙", output.StyleWarning, "Campaigns are a paid feature. Please contact Sourcegraph to purchase a license."))
+				return &exitCodeError{exitCode: graphqlErrorsExitCode}
+			}
+		}
+	}
+
+	// In all other cases, we'll just return the original error.
+	return err
 }
 
 func sumDiffStats(fileDiffs []*diff.FileDiff) diff.Stat {

--- a/cmd/src/campaigns_common.go
+++ b/cmd/src/campaigns_common.go
@@ -291,10 +291,10 @@ func campaignsExecute(ctx context.Context, out *output.Output, svc *campaigns.Se
 
 	pending = campaignsCreatePending(out, "Creating campaign spec on Sourcegraph")
 	id, url, err := svc.CreateCampaignSpec(ctx, namespace, rawSpec, ids)
+	campaignsCompletePending(pending, "Creating campaign spec on Sourcegraph")
 	if err != nil {
 		return "", "", prettyPrintCampaignsUnlicensedError(out, err)
 	}
-	campaignsCompletePending(pending, "Creating campaign spec on Sourcegraph")
 
 	return id, url, nil
 }
@@ -436,7 +436,11 @@ func prettyPrintCampaignsUnlicensedError(out *output.Output, err error) error {
 			} else if code == "ErrCampaignsUnlicensed" {
 				// OK, let's print a better message, then return an
 				// exitCodeError to suppress the normal automatic error block.
-				out.WriteLine(output.Line("🪙", output.StyleWarning, "Campaigns are a paid feature. Please contact Sourcegraph to purchase a license."))
+				block := out.Block(output.Line("🪙", output.StyleWarning, "Campaigns is a paid feature of Sourcegraph. All users can create sample campaigns with up to 5 changesets without a license."))
+				block.WriteLine(output.Linef("", output.StyleWarning, "Contact Sourcegraph sales at %shttps://about.sourcegraph.com/contact/sales/%s to obtain a trial license.", output.StyleSearchLink, output.StyleWarning))
+				block.Write("")
+				block.WriteLine(output.Linef("", output.StyleWarning, "To proceed with this campaign, you will need to create five or fewer changesets. To do so, you could try adding %scount:5%s to your %srepositoriesMatchingQuery%s search, or reduce the number of changesets in %simportChangesets%s.", output.StyleSearchAlertProposedQuery, output.StyleWarning, output.StyleReset, output.StyleWarning, output.StyleReset, output.StyleWarning))
+				block.Close()
 				return &exitCodeError{exitCode: graphqlErrorsExitCode}
 			}
 		}

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -1,0 +1,3 @@
+package api
+
+// TODO: implement a super basic GraphQL server that can return canned results.

--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -1,11 +1,76 @@
 package api
 
-import "encoding/json"
+import (
+	"encoding/json"
 
-// graphqlError wraps a raw JSON error returned from a GraphQL endpoint.
-type graphqlError struct{ v interface{} }
+	"github.com/hashicorp/go-multierror"
+	"github.com/pkg/errors"
+)
 
-func (g *graphqlError) Error() string {
+// GraphQlErrors contains one or more GraphQlError instances.
+type GraphQlErrors []*GraphQlError
+
+func (gg GraphQlErrors) Error() string {
+	// This slightly convoluted implementation is used to ensure that output
+	// remains stable with earlier versions of src-cli, which returned a wrapped
+	// *multierror.Error when GraphQL errors were returned from the API.
+
+	if len(gg) == 0 {
+		// This shouldn't really happen, but let's handle it gracefully anyway.
+		return ""
+	}
+
+	var errs *multierror.Error
+	for _, err := range gg {
+		errs = multierror.Append(errs, err)
+	}
+
+	return errors.Wrap(errs.ErrorOrNil(), "GraphQL errors").Error()
+}
+
+// GraphQlError wraps a raw JSON error returned from a GraphQL endpoint.
+type GraphQlError struct{ v interface{} }
+
+// Code returns the GraphQL error code, if one was set on the error.
+func (g *GraphQlError) Code() (string, error) {
+	ext, err := g.Extensions()
+	if err != nil {
+		return "", errors.Wrap(err, "getting error extensions")
+	}
+
+	if ext != nil {
+		if ext["code"] == nil {
+			return "", nil
+		} else if code, ok := ext["code"].(string); ok {
+			return code, nil
+		}
+		return "", errors.Errorf("unexpected code of type %T", ext["code"])
+	}
+	return "", nil
+}
+
+func (g *GraphQlError) Error() string {
 	j, _ := json.MarshalIndent(g.v, "", "  ")
 	return string(j)
 }
+
+// Extensions returns the GraphQL error extensions, if set, or nil if no
+// extensions were set on the error.
+func (g *GraphQlError) Extensions() (map[string]interface{}, error) {
+	e, ok := g.v.(map[string]interface{})
+	if !ok {
+		return nil, errors.Errorf("unexpected GraphQL error of type %T", g.v)
+	}
+
+	if e["extensions"] == nil {
+		return nil, nil
+	} else if me, ok := e["extensions"].(map[string]interface{}); ok {
+		return me, nil
+	}
+	return nil, errors.Errorf("unexpected extensions of type %T", e["extensions"])
+}
+
+var (
+	_ error = &GraphQlError{}
+	_ error = GraphQlErrors{}
+)

--- a/internal/api/errors_test.go
+++ b/internal/api/errors_test.go
@@ -1,0 +1,119 @@
+package api
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestGraphQLError_Code(t *testing.T) {
+	for name, tc := range map[string]struct {
+		in      string
+		want    string
+		wantErr bool
+	}{
+		"invalid code": {
+			in: `{
+				"errors": [
+					{
+						"message": "The feature \"campaigns\" is not activated because it requires a valid Sourcegraph license. Purchase a Sourcegraph subscription to activate this feature.",
+						"path": [
+							"createCampaignSpec"
+						],
+						"extensions": {
+							"code": 42
+						}
+					}
+				],
+				"data": null
+			}`,
+			wantErr: true,
+		},
+		"invalid extensions": {
+			in: `{
+				"errors": [
+					{
+						"message": "The feature \"campaigns\" is not activated because it requires a valid Sourcegraph license. Purchase a Sourcegraph subscription to activate this feature.",
+						"path": [
+							"createCampaignSpec"
+						],
+						"extensions": 42
+					}
+				],
+				"data": null
+			}`,
+			wantErr: true,
+		},
+		"no code": {
+			in: `{
+				"errors": [
+					{
+						"message": "The feature \"campaigns\" is not activated because it requires a valid Sourcegraph license. Purchase a Sourcegraph subscription to activate this feature.",
+						"path": [
+							"createCampaignSpec"
+						],
+						"extensions": {}
+					}
+				],
+				"data": null
+			}`,
+			want: "",
+		},
+		"no extensions": {
+			in: `{
+				"errors": [
+					{
+						"message": "The feature \"campaigns\" is not activated because it requires a valid Sourcegraph license. Purchase a Sourcegraph subscription to activate this feature.",
+						"path": [
+							"createCampaignSpec"
+						]
+					}
+				],
+				"data": null
+			}`,
+			want: "",
+		},
+		"valid code": {
+			in: `{
+				"errors": [
+					{
+						"message": "The feature \"campaigns\" is not activated because it requires a valid Sourcegraph license. Purchase a Sourcegraph subscription to activate this feature.",
+						"path": [
+							"createCampaignSpec"
+						],
+						"extensions": {
+							"code": "ErrCampaignsUnlicensed"
+						}
+					}
+				],
+				"data": null
+			}`,
+			want: "ErrCampaignsUnlicensed",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			var result rawResult
+			if err := json.Unmarshal([]byte(tc.in), &result); err != nil {
+				t.Fatal(err)
+			}
+			if ne := len(result.Errors); ne != 1 {
+				t.Fatalf("unexpected number of GraphQL errors (this test can only handle one!): %d", ne)
+			}
+
+			ge := &GraphQlError{result.Errors[0]}
+			have, err := ge.Code()
+			if tc.wantErr {
+				if err == nil {
+					t.Errorf("unexpected nil error")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %+v", err)
+				}
+				if have != tc.want {
+					t.Errorf("unexpected code: have=%q want=%q", have, tc.want)
+				}
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
In and around sourcegraph/sourcegraph#16687, we had a fairly lengthy discussion around how to present licensing errors to the user. Doing it in a way that is actionable for the user is fairly tricky: we don't have a simple limit directive that could be applied to the repository search, so the user is left with a campaign spec that they might still want to trial but don't know how to get to a trialable state.

This PR uses the new error code returned from sourcegraph/sourcegraph#16687 to special case licensing errors. When those are detected, a suggestion is made for how the campaign spec could be modified to be compliant with the unlicensed behaviour.

Here's how it looks:

![image](https://user-images.githubusercontent.com/229984/102298008-331f2e80-3f05-11eb-9402-4af9959db0b5.png)

Linked to sourcegraph/sourcegraph#15715, but it's more a bonus adventure than that issue.