### PR TITLE
config: fix subjects flag, add example for editing global config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ All notable changes to `src-cli` are documented in this file.
 
 ### Fixed
 
+- `src config` now works correctly when provided a subject.
+
 ### Removed
 
 ## 3.23.1

--- a/cmd/src/config.go
+++ b/cmd/src/config.go
@@ -158,7 +158,9 @@ query SettingsSubjectLatestSettingsID($subject: ID!) {
 		}
 	}
 
-	if _, err := client.NewQuery(query).Do(ctx, &result); err != nil {
+	if _, err := client.NewRequest(query, map[string]interface{}{
+		"subject": subjectID,
+	}).Do(ctx, &result); err != nil {
 		return nil, err
 	}
 

--- a/cmd/src/config_edit.go
+++ b/cmd/src/config_edit.go
@@ -34,8 +34,8 @@ Examples:
 
     	$ src config edit -subject=$(src orgs get -f '{{.ID}}' -name=abc-org) -overwrite -value '{"motd":["Hello!"]}'
 
-
   Change global settings:
+
     	$ src config edit -subject=$(echo 'query { site { id } }' | src api | jq .data.site.id --raw-output)
 `
 

--- a/cmd/src/config_edit.go
+++ b/cmd/src/config_edit.go
@@ -36,7 +36,7 @@ Examples:
 
   Change global settings:
 		
-        $ src config edit -subject=$(echo 'query { site { id } }' | src api | jq .data.site.id --raw-output)
+      $ src config edit -subject=$(echo 'query { site { id } }' | src api | jq .data.site.id --raw-output)
 `
 
 	flagSet := flag.NewFlagSet("edit", flag.ExitOnError)

--- a/cmd/src/config_edit.go
+++ b/cmd/src/config_edit.go
@@ -35,7 +35,6 @@ Examples:
     	$ src config edit -subject=$(src orgs get -f '{{.ID}}' -name=abc-org) -overwrite -value '{"motd":["Hello!"]}'
 
   Change global settings:
-		
     	$ src config edit -subject=$(echo 'query { site { id } }' | src api | jq .data.site.id --raw-output)
 `
 

--- a/cmd/src/config_edit.go
+++ b/cmd/src/config_edit.go
@@ -36,7 +36,7 @@ Examples:
 
   Change global settings:
 		
-      $ src config edit -subject=$(echo 'query { site { id } }' | src api | jq .data.site.id --raw-output)
+    	$ src config edit -subject=$(echo 'query { site { id } }' | src api | jq .data.site.id --raw-output)
 `
 
 	flagSet := flag.NewFlagSet("edit", flag.ExitOnError)

--- a/cmd/src/config_edit.go
+++ b/cmd/src/config_edit.go
@@ -34,6 +34,7 @@ Examples:
 
     	$ src config edit -subject=$(src orgs get -f '{{.ID}}' -name=abc-org) -overwrite -value '{"motd":["Hello!"]}'
 
+
   Change global settings:
     	$ src config edit -subject=$(echo 'query { site { id } }' | src api | jq .data.site.id --raw-output)
 `

--- a/cmd/src/config_edit.go
+++ b/cmd/src/config_edit.go
@@ -34,6 +34,9 @@ Examples:
 
     	$ src config edit -subject=$(src orgs get -f '{{.ID}}' -name=abc-org) -overwrite -value '{"motd":["Hello!"]}'
 
+  Change global settings:
+		
+        $ src config edit -subject=$(echo 'query { site { id } }' | src api | jq .data.site.id --raw-output)
 `
 
 	flagSet := flag.NewFlagSet("edit", flag.ExitOnError)


### PR DESCRIPTION
Currently, providing a `-subject` flag to `src config` does not apply it.

```
+ src config edit -subject=U2l0ZToic2l0ZSI= -property=notices '-value=[]'
GraphQL errors: 1 error occurred:
        * {
  "locations": [
    {
      "column": 39,
      "line": 2
    }
  ],
  "message": "Variable \"subject\" has invalid value null.\nExpected type \"ID!\", found null."
}
```

Also, the docs state that this command can edit global config, but does not imply how, so I added an example with a workaround - let me know if there's a proper way to do this!