### PR TITLE
goreleaser: update to latest schema

### DIFF
--- a/.github/workflows/goreleaser-check.yml
+++ b/.github/workflows/goreleaser-check.yml
@@ -1,0 +1,22 @@
+name: GoReleaser
+
+on:
+  - push
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.15
+      - name: Check GoReleaser config
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: check

--- a/.github/workflows/goreleaser-check.yml
+++ b/.github/workflows/goreleaser-check.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   goreleaser:
+    name: check
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   goreleaser:
-    name: check
+    name: release
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   goreleaser:
+    name: check
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -31,16 +31,14 @@ brews:
     name: src-cli
     homepage: "https://sourcegraph.com/"
     description: "Sourcegraph CLI"
-    github:
+    tap:
       owner: sourcegraph
       name: homebrew-src-cli
     # Folder inside the repository to put the formula.
     # Default is the root folder.
     folder: Formula
 dockers:
-  - binaries:
-    - src
-    image_templates:
+  - image_templates:
     - "sourcegraph/src-cli:{{ .Tag }}"
     - "sourcegraph/src-cli:{{ .Major }}"
     - "sourcegraph/src-cli:{{ .Major }}.{{ .Minor }}"


### PR DESCRIPTION
This broke the 3.23.2 release, which was fun.

Specifically, we need to handle the deprecations of [`brews.github`](https://goreleaser.com/deprecations#brewsgithub) and [`docker.builds`](https://goreleaser.com/deprecations#dockerbuilds).

This PR also adds a new CI job to check the validity of the GoReleaser configuration, since breaking changes are apparently a Thing.