### PR TITLE
campaigns: fall back to bind workspaces when running steps with mixed users

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,7 +12,7 @@ builds:
   main: ./cmd/src/
   binary: src
   ldflags:
-    - -X main.buildTag={{.Version}}
+    - -X github.com/sourcegraph/src-cli/internal/version.BuildTag={{.Version}}
   goos:
     - linux
     - windows

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ All notable changes to `src-cli` are documented in this file.
 
 ### Added
 
-- `src campaign [apply|preview]` can now make use of Docker volumes, rather than bind-mounting the host filesystem. This is now the default on macOS, as volume mounts have generally better performance there. The optional `-workspace` flag can be used to override the default. [#412](https://github.com/sourcegraph/src-cli/pull/412)
+- `src campaign [apply|preview]` can now make use of Docker volumes, rather than bind-mounting the host filesystem. This is now the default on Intel macOS so long as the Docker images used in the campaign steps run as the same user, as volume mounts have generally better performance there. The optional `-workspace` flag can be used to override the default. [#412](https://github.com/sourcegraph/src-cli/pull/412)
 
 ### Changed
 

--- a/cmd/src/campaigns_common.go
+++ b/cmd/src/campaigns_common.go
@@ -102,8 +102,8 @@ func newCampaignsApplyFlags(flagSet *flag.FlagSet, cacheDir, tempDir string) *ca
 	)
 
 	flagSet.StringVar(
-		&caf.workspace, "workspace", "default",
-		`Workspace mode to use ("default", "bind", or "volume")`,
+		&caf.workspace, "workspace", "auto",
+		`Workspace mode to use ("auto", "bind", or "volume")`,
 	)
 
 	flagSet.BoolVar(verbose, "v", false, "print verbose output")

--- a/cmd/src/campaigns_common.go
+++ b/cmd/src/campaigns_common.go
@@ -101,18 +101,9 @@ func newCampaignsApplyFlags(flagSet *flag.FlagSet, cacheDir, tempDir string) *ca
 		"If true, errors encountered while executing steps in a repository won't stop the execution of the campaign spec but only cause that repository to be skipped.",
 	)
 
-	// We default to bind workspaces on everything except ARM64 macOS at
-	// present. In the future, we'll likely want to switch the default for ARM64
-	// macOS as well, but this requires access to the hardware for testing.
-	var defaultWorkspace string
-	if runtime.GOOS == "darwin" && runtime.GOARCH == "amd64" {
-		defaultWorkspace = "volume"
-	} else {
-		defaultWorkspace = "bind"
-	}
 	flagSet.StringVar(
-		&caf.workspace, "workspace", defaultWorkspace,
-		`Workspace mode to use ("bind" or "volume")`,
+		&caf.workspace, "workspace", "default",
+		`Workspace mode to use ("default", "bind", or "volume")`,
 	)
 
 	flagSet.BoolVar(verbose, "v", false, "print verbose output")
@@ -180,36 +171,13 @@ func campaignsExecute(ctx context.Context, out *output.Output, svc *campaigns.Se
 		return "", "", err
 	}
 
-	// Parse flags and build up our service options.
-	var errs *multierror.Error
+	// Parse flags and build up our service and executor options.
 
 	specFile, err := campaignsOpenFileFlag(&flags.file)
 	if err != nil {
-		errs = multierror.Append(errs, err)
-	} else {
-		defer specFile.Close()
+		return "", "", err
 	}
-
-	opts := campaigns.ExecutorOpts{
-		Cache:       svc.NewExecutionCache(flags.cacheDir),
-		Creator:     svc.NewWorkspaceCreator(flags.cacheDir),
-		RepoFetcher: svc.NewRepoFetcher(flags.cacheDir, flags.cleanArchives),
-		ClearCache:  flags.clearCache,
-		KeepLogs:    flags.keepLogs,
-		Timeout:     flags.timeout,
-		TempDir:     flags.tempDir,
-	}
-	if flags.parallelism <= 0 {
-		opts.Parallelism = runtime.GOMAXPROCS(0)
-	} else {
-		opts.Parallelism = flags.parallelism
-	}
-	out.VerboseLine(output.Linef("🚧", output.StyleSuccess, "Workspace creator: %T", opts.Creator))
-	executor := svc.NewExecutor(opts)
-
-	if errs != nil {
-		return "", "", errs
-	}
+	defer specFile.Close()
 
 	pending := campaignsCreatePending(out, "Parsing campaign spec")
 	campaignSpec, rawSpec, err := campaignsParseSpec(out, svc, specFile)
@@ -229,7 +197,7 @@ func campaignsExecute(ctx context.Context, out *output.Output, svc *campaigns.Se
 		Label: "Preparing container images",
 		Max:   1.0,
 	}}, nil)
-	err = svc.SetDockerImages(ctx, opts.Creator, campaignSpec, func(perc float64) {
+	err = svc.SetDockerImages(ctx, campaignSpec, func(perc float64) {
 		imageProgress.SetValue(0, perc)
 	})
 	if err != nil {
@@ -255,6 +223,27 @@ func campaignsExecute(ctx context.Context, out *output.Output, svc *campaigns.Se
 		campaignsCompletePending(pending, "Resolved repositories")
 	}
 
+	pending = campaignsCreatePending(out, "Preparing workspaces")
+	workspaceCreator := svc.NewWorkspaceCreator(ctx, flags.cacheDir, campaignSpec.Steps)
+	pending.VerboseLine(output.Linef("🚧", output.StyleSuccess, "Workspace creator: %T", workspaceCreator))
+	campaignsCompletePending(pending, "Prepared workspaces")
+
+	opts := campaigns.ExecutorOpts{
+		Cache:       svc.NewExecutionCache(flags.cacheDir),
+		Creator:     workspaceCreator,
+		RepoFetcher: svc.NewRepoFetcher(flags.cacheDir, flags.cleanArchives),
+		ClearCache:  flags.clearCache,
+		KeepLogs:    flags.keepLogs,
+		Timeout:     flags.timeout,
+		TempDir:     flags.tempDir,
+	}
+	if flags.parallelism <= 0 {
+		opts.Parallelism = runtime.GOMAXPROCS(0)
+	} else {
+		opts.Parallelism = flags.parallelism
+	}
+
+	executor := svc.NewExecutor(opts)
 	p := newCampaignProgressPrinter(out, *verbose, opts.Parallelism)
 	specs, err := svc.ExecuteCampaignSpec(ctx, repos, executor, campaignSpec, p.PrintStatuses, flags.skipErrors)
 	if err != nil && !flags.skipErrors {

--- a/cmd/src/version.go
+++ b/cmd/src/version.go
@@ -9,12 +9,8 @@ import (
 	"net/http"
 
 	"github.com/sourcegraph/src-cli/internal/api"
+	"github.com/sourcegraph/src-cli/internal/version"
 )
-
-// buildTag is the git tag at the time of build and is used to
-// denote the binary's current version. This value is supplied
-// as an ldflag at compile time in travis.
-var buildTag = "dev"
 
 func init() {
 	usage := `
@@ -30,7 +26,7 @@ Examples:
 	var apiFlags = api.NewFlags(flagSet)
 
 	handler := func(args []string) error {
-		fmt.Printf("Current version: %s\n", buildTag)
+		fmt.Printf("Current version: %s\n", version.BuildTag)
 
 		client := cfg.apiClient(apiFlags, flagSet.Output())
 		recommendedVersion, err := getRecommendedVersion(context.Background(), client)

--- a/internal/campaigns/bind_workspace.go
+++ b/internal/campaigns/bind_workspace.go
@@ -30,8 +30,6 @@ func (wc *dockerBindWorkspaceCreator) Create(ctx context.Context, repo *graphql.
 	return w, errors.Wrap(wc.prepareGitRepo(ctx, w), "preparing local git repo")
 }
 
-func (*dockerBindWorkspaceCreator) DockerImages() []string { return []string{} }
-
 func (*dockerBindWorkspaceCreator) prepareGitRepo(ctx context.Context, w *dockerBindWorkspace) error {
 	if _, err := runGitCmd(ctx, w.dir, "init"); err != nil {
 		return errors.Wrap(err, "git init failed")

--- a/internal/campaigns/service.go
+++ b/internal/campaigns/service.go
@@ -211,8 +211,17 @@ func (svc *Service) NewRepoFetcher(dir string, cleanArchives bool) RepoFetcher {
 	}
 }
 
-func (svc *Service) NewWorkspaceCreator(dir string) WorkspaceCreator {
+func (svc *Service) NewWorkspaceCreator(ctx context.Context, dir string, steps []Step) WorkspaceCreator {
+	var workspace workspaceCreatorType
 	if svc.workspace == "volume" {
+		workspace = workspaceCreatorVolume
+	} else if svc.workspace == "bind" {
+		workspace = workspaceCreatorBind
+	} else {
+		workspace = bestWorkspaceCreator(ctx, steps)
+	}
+
+	if workspace == workspaceCreatorVolume {
 		return &dockerVolumeWorkspaceCreator{}
 	}
 	return &dockerBindWorkspaceCreator{dir: dir}

--- a/internal/campaigns/service.go
+++ b/internal/campaigns/service.go
@@ -243,20 +243,18 @@ func (dis dockerImageSet) add(image string, digestPtr *string) {
 
 // SetDockerImages updates the steps within the campaign spec to include the
 // exact content digest to be used when running each step, and ensures that all
-// Docker images are available, including any required by the workspace creator.
+// Docker images are available, including any required by the service itself.
 //
 // Progress information is reported back to the given progress function: perc
 // will be a value between 0.0 and 1.0, inclusive.
-func (svc *Service) SetDockerImages(ctx context.Context, creator WorkspaceCreator, spec *CampaignSpec, progress func(perc float64)) error {
+func (svc *Service) SetDockerImages(ctx context.Context, spec *CampaignSpec, progress func(perc float64)) error {
 	images := dockerImageSet{}
 	for i, step := range spec.Steps {
 		images.add(step.Container, &spec.Steps[i].image)
 	}
 
-	// The workspace creator may have its own dependencies.
-	for _, image := range creator.DockerImages() {
-		images.add(image, nil)
-	}
+	// We also need to ensure we have our own utility images available.
+	images.add(dockerVolumeWorkspaceImage, nil)
 
 	progress(0)
 	i := 0

--- a/internal/campaigns/volume_workspace.go
+++ b/internal/campaigns/volume_workspace.go
@@ -12,7 +12,6 @@ import (
 	"github.com/sourcegraph/src-cli/internal/exec"
 )
 
-// dockerVolumeWorkspaceCreator creates dockerVolumeWorkspace instances.
 type dockerVolumeWorkspaceCreator struct{}
 
 var _ WorkspaceCreator = &dockerVolumeWorkspaceCreator{}

--- a/internal/campaigns/volume_workspace.go
+++ b/internal/campaigns/volume_workspace.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/sourcegraph/src-cli/internal/campaigns/graphql"
 	"github.com/sourcegraph/src-cli/internal/exec"
+	"github.com/sourcegraph/src-cli/internal/version"
 )
 
 type dockerVolumeWorkspaceCreator struct{}
@@ -149,7 +150,16 @@ exec git diff --cached --no-prefix --binary
 // dockerVolumeWorkspaceImage is the Docker image we'll run our unzip and git
 // commands in. This needs to match the name defined in
 // .github/workflows/docker.yml.
-const dockerVolumeWorkspaceImage = "sourcegraph/src-campaign-volume-workspace"
+var dockerVolumeWorkspaceImage = "sourcegraph/src-campaign-volume-workspace"
+
+func init() {
+	dockerTag := version.BuildTag
+	if version.BuildTag == version.DefaultBuildTag {
+		dockerTag = "latest"
+	}
+
+	dockerVolumeWorkspaceImage = dockerVolumeWorkspaceImage + ":" + dockerTag
+}
 
 // runScript is a utility function to mount the given shell script into a Docker
 // container started from the dockerWorkspaceImage, then run it and return the

--- a/internal/campaigns/volume_workspace_test.go
+++ b/internal/campaigns/volume_workspace_test.go
@@ -51,7 +51,7 @@ func TestVolumeWorkspaceCreator(t *testing.T) {
 				"docker", "run", "--rm", "--init", "--workdir", "/work",
 				"--mount", "type=bind,source=*,target=/tmp/zip,ro",
 				"--mount", "type=volume,source="+volumeID+",target=/work",
-				dockerWorkspaceImage,
+				dockerVolumeWorkspaceImage,
 				"unzip", "/tmp/zip",
 			),
 			expect.NewGlob(
@@ -59,7 +59,7 @@ func TestVolumeWorkspaceCreator(t *testing.T) {
 				"docker", "run", "--rm", "--init", "--workdir", "/work",
 				"--mount", "type=bind,source=*,target=/run.sh,ro",
 				"--mount", "type=volume,source="+volumeID+",target=/work",
-				dockerWorkspaceImage,
+				dockerVolumeWorkspaceImage,
 				"sh", "/run.sh",
 			),
 		)
@@ -97,7 +97,7 @@ func TestVolumeWorkspaceCreator(t *testing.T) {
 				"docker", "run", "--rm", "--init", "--workdir", "/work",
 				"--mount", "type=bind,source=*,target=/tmp/zip,ro",
 				"--mount", "type=volume,source="+volumeID+",target=/work",
-				dockerWorkspaceImage,
+				dockerVolumeWorkspaceImage,
 				"unzip", "/tmp/zip",
 			),
 		)
@@ -119,7 +119,7 @@ func TestVolumeWorkspaceCreator(t *testing.T) {
 				"docker", "run", "--rm", "--init", "--workdir", "/work",
 				"--mount", "type=bind,source=*,target=/tmp/zip,ro",
 				"--mount", "type=volume,source="+volumeID+",target=/work",
-				dockerWorkspaceImage,
+				dockerVolumeWorkspaceImage,
 				"unzip", "/tmp/zip",
 			),
 			expect.NewGlob(
@@ -127,7 +127,7 @@ func TestVolumeWorkspaceCreator(t *testing.T) {
 				"docker", "run", "--rm", "--init", "--workdir", "/work",
 				"--mount", "type=bind,source=*,target=/run.sh,ro",
 				"--mount", "type=volume,source="+volumeID+",target=/work",
-				dockerWorkspaceImage,
+				dockerVolumeWorkspaceImage,
 				"sh", "/run.sh",
 			),
 		)
@@ -232,7 +232,7 @@ M  internal/campaigns/volume_workspace_test.go
 						"docker", "run", "--rm", "--init", "--workdir", "/work",
 						"--mount", "type=bind,source=*,target=/run.sh,ro",
 						"--mount", "type=volume,source="+volumeID+",target=/work",
-						dockerWorkspaceImage,
+						dockerVolumeWorkspaceImage,
 						"sh", "/run.sh",
 					),
 				)
@@ -263,7 +263,7 @@ M  internal/campaigns/volume_workspace_test.go
 						"docker", "run", "--rm", "--init", "--workdir", "/work",
 						"--mount", "type=bind,source=*,target=/run.sh,ro",
 						"--mount", "type=volume,source="+volumeID+",target=/work",
-						dockerWorkspaceImage,
+						dockerVolumeWorkspaceImage,
 						"sh", "/run.sh",
 					),
 				)
@@ -308,7 +308,7 @@ index 06471f4..5f9d3fa 100644
 						"docker", "run", "--rm", "--init", "--workdir", "/work",
 						"--mount", "type=bind,source=*,target=/run.sh,ro",
 						"--mount", "type=volume,source="+volumeID+",target=/work",
-						dockerWorkspaceImage,
+						dockerVolumeWorkspaceImage,
 						"sh", "/run.sh",
 					),
 				)
@@ -334,7 +334,7 @@ index 06471f4..5f9d3fa 100644
 				"docker", "run", "--rm", "--init", "--workdir", "/work",
 				"--mount", "type=bind,source=*,target=/run.sh,ro",
 				"--mount", "type=volume,source="+volumeID+",target=/work",
-				dockerWorkspaceImage,
+				dockerVolumeWorkspaceImage,
 				"sh", "/run.sh",
 			),
 		)
@@ -362,7 +362,7 @@ func TestVolumeWorkspace_runScript(t *testing.T) {
 					"docker", "run", "--rm", "--init", "--workdir", "/work",
 					"--mount", "type=bind,source=*,target=/run.sh,ro",
 					"--mount", "type=volume,source="+volumeID+",target=/work",
-					dockerWorkspaceImage,
+					dockerVolumeWorkspaceImage,
 					"sh", "/run.sh",
 				)
 				if err := glob(name, arg...); err != nil {

--- a/internal/campaigns/workspace.go
+++ b/internal/campaigns/workspace.go
@@ -12,10 +12,6 @@ import (
 type WorkspaceCreator interface {
 	// Create creates a new workspace for the given repository and ZIP file.
 	Create(ctx context.Context, repo *graphql.Repository, zip string) (Workspace, error)
-
-	// DockerImages returns any Docker images required to use workspaces created
-	// by this creator.
-	DockerImages() []string
 }
 
 // Workspace implementations manage per-changeset storage when executing

--- a/internal/campaigns/workspace.go
+++ b/internal/campaigns/workspace.go
@@ -1,9 +1,14 @@
 package campaigns
 
 import (
+	"bytes"
 	"context"
+	"runtime"
+	"strconv"
+	"strings"
 
 	"github.com/sourcegraph/src-cli/internal/campaigns/graphql"
+	"github.com/sourcegraph/src-cli/internal/exec"
 )
 
 // WorkspaceCreator implementations are used to create workspaces, which manage
@@ -39,4 +44,94 @@ type Workspace interface {
 	// Diff should return the total diff for the workspace. This may be called
 	// multiple times in the life of a workspace.
 	Diff(ctx context.Context) ([]byte, error)
+}
+
+type workspaceCreatorType int
+
+const (
+	workspaceCreatorBind workspaceCreatorType = iota
+	workspaceCreatorVolume
+)
+
+// bestWorkspaceCreator determines the correct workspace creator to use based on
+// the environment and campaign to be executed.
+func bestWorkspaceCreator(ctx context.Context, steps []Step) workspaceCreatorType {
+	// The basic theory here is that we have two options: bind and volume. Bind
+	// is battle tested and always safe, but can be slow on non-Linux platforms
+	// because bind mounts are slow. Volume is faster on those platforms, but
+	// exposes users to UID mismatch issues they'd otherwise be insulated from
+	// by the semantics of bind mounting on non-Linux platforms: specifically,
+	// if you have a campaign with steps that run as UID 1000 and then UID 2000,
+	// you'll get errors when the second step tries to write.
+
+	// For the time being, we're only going to consider volume mode on Intel
+	// macOS.
+	if runtime.GOOS != "darwin" || runtime.GOARCH != "amd64" {
+		return workspaceCreatorBind
+	}
+
+	return detectBestWorkspaceCreator(ctx, steps)
+}
+
+func detectBestWorkspaceCreator(ctx context.Context, steps []Step) workspaceCreatorType {
+	// OK, so we're interested in volume mode, but we need to take its
+	// shortcomings around mixed user environments into account.
+	//
+	// To do that, let's iterate over the Docker images that are going to be
+	// used and get their default UID. This admittedly only gets us so far —
+	// there's nothing stopping an adventurous user from running su directly in
+	// their script, or running a setuid binary — but it should be a good enough
+	// heuristic. (And, if we get this wrong, there's nothing stopping a user
+	// from providing a workspace type explicitly with the -workspace flag.)
+	//
+	// Once we have the UIDs, it's pretty simple: the moment we see more than
+	// one UID, we should fall back to bind mode.
+	//
+	// In theory, we could make this more sensitive and complicated: a non-root
+	// container that's followed by only root containers would actually be OK,
+	// but let's keep it simple for now.
+	uids := make(map[int]struct{})
+
+	for _, step := range steps {
+		stdout := new(bytes.Buffer)
+
+		args := []string{
+			"run",
+			"--rm",
+			"--entrypoint", "/bin/sh",
+			step.image,
+			"-c", "id -u",
+		}
+		cmd := exec.CommandContext(ctx, "docker", args...)
+		cmd.Stdout = stdout
+
+		if err := cmd.Run(); err != nil {
+			// An error here likely indicates that `id` isn't available on the
+			// path. That's OK: let's not make any assumptions at this point
+			// about the image, and we'll default to the always safe option.
+			return workspaceCreatorBind
+		}
+
+		// POSIX specifies the output of `id -u` as the effective UID,
+		// terminated by a newline.
+		raw := strings.TrimSpace(stdout.String())
+		uid, err := strconv.Atoi(raw)
+		if err != nil {
+			// This is a bit worse than the previous error case: there's an `id`
+			// command on the path, but it's not returning POSIX compliant
+			// output. That's weird, but we really don't need it to be terminal;
+			// let's fall back to bind mode.
+			//
+			// TODO: when logging is available at this level, we should log an
+			// error at verbose level to make this easier to debug.
+			return workspaceCreatorBind
+		}
+
+		uids[uid] = struct{}{}
+		if len(uids) > 1 {
+			return workspaceCreatorBind
+		}
+	}
+
+	return workspaceCreatorVolume
 }

--- a/internal/campaigns/workspace_test.go
+++ b/internal/campaigns/workspace_test.go
@@ -1,0 +1,115 @@
+package campaigns
+
+import (
+	"context"
+	"runtime"
+	"testing"
+
+	"github.com/sourcegraph/src-cli/internal/exec/expect"
+)
+
+func TestBestWorkspaceCreator(t *testing.T) {
+	ctx := context.Background()
+	isOverridden := !(runtime.GOOS == "darwin" && runtime.GOARCH == "amd64")
+
+	for name, tc := range map[string]struct {
+		behaviours map[string]expect.Behaviour
+		want       workspaceCreatorType
+	}{
+		"nil steps": {
+			behaviours: nil,
+			want:       workspaceCreatorVolume,
+		},
+		"no steps": {
+			behaviours: map[string]expect.Behaviour{},
+			want:       workspaceCreatorVolume,
+		},
+		"root": {
+			behaviours: map[string]expect.Behaviour{
+				"foo": {Stdout: []byte("0\n")},
+				"bar": {Stdout: []byte("0\n")},
+			},
+			want: workspaceCreatorVolume,
+		},
+		"same user": {
+			behaviours: map[string]expect.Behaviour{
+				"foo": {Stdout: []byte("1000\n")},
+				"bar": {Stdout: []byte("1000\n")},
+			},
+			want: workspaceCreatorVolume,
+		},
+		"different user": {
+			behaviours: map[string]expect.Behaviour{
+				"foo": {Stdout: []byte("1000\n")},
+				"bar": {Stdout: []byte("0\n")},
+			},
+			want: workspaceCreatorBind,
+		},
+		"invalid id output: string": {
+			behaviours: map[string]expect.Behaviour{
+				"foo": {Stdout: []byte("xxx\n")},
+			},
+			want: workspaceCreatorBind,
+		},
+		"invalid id output: empty": {
+			behaviours: map[string]expect.Behaviour{
+				"foo": {Stdout: []byte("")},
+			},
+			want: workspaceCreatorBind,
+		},
+		"error invoking id": {
+			behaviours: map[string]expect.Behaviour{
+				"foo": {ExitCode: 1},
+			},
+			want: workspaceCreatorBind,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			var (
+				commands []*expect.Expectation = nil
+				steps    []Step                = nil
+			)
+			if tc.behaviours != nil {
+				commands = []*expect.Expectation{}
+				steps = []Step{}
+				for image, behaviour := range tc.behaviours {
+					commands = append(commands, expect.NewGlob(
+						behaviour,
+						"docker", "run", "--rm", "--entrypoint", "/bin/sh",
+						image, "-c", "id -u",
+					))
+					steps = append(steps, Step{image: image})
+				}
+			}
+
+			if !isOverridden {
+				// If bestWorkspaceCreator() won't short circuit on this
+				// platform, we're going to run the Docker commands twice by
+				// definition.
+				expect.Commands(t, append(commands, commands...)...)
+			} else {
+				expect.Commands(t, commands...)
+			}
+
+			if isOverridden {
+				// This is an overridden platform, so the workspace type will
+				// always be bind from bestWorkspaceCreator().
+				if have, want := bestWorkspaceCreator(ctx, steps), workspaceCreatorBind; have != want {
+					t.Errorf("unexpected creator type on overridden platform: have=%d want=%d", have, want)
+				}
+			} else {
+				if have := bestWorkspaceCreator(ctx, steps); have != tc.want {
+					t.Errorf("unexpected creator type on non-overridden platform: have=%d want=%d", have, tc.want)
+				}
+			}
+
+			// Regardless of what bestWorkspaceCreator() would have done, let's
+			// test that the right thing happens regardless if detection were to
+			// actually occur.
+			have := detectBestWorkspaceCreator(ctx, steps)
+			if have != tc.want {
+				t.Errorf("unexpected creator type: have=%d want=%d", have, tc.want)
+			}
+		})
+	}
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,10 @@
+package version
+
+// DefaultBuildTag is the value BuildTag will be set to if this is not a release
+// build.
+const DefaultBuildTag = "dev"
+
+// BuildTag is the git tag at the time of build and is used to
+// denote the binary's current version. This value is supplied
+// as an ldflag at compile time by the GoReleaser action.
+var BuildTag = DefaultBuildTag


### PR DESCRIPTION
This fixes sourcegraph/sourcegraph#17172. I'm inclined to get this in before I try releasing 3.23.2 again.

The only real drawback of this PR (besides the extra lines of code) is that `src` will now always ensure the `sourcegraph/src-campaign-volume-workspace` container is available, since we don't know at the point of downloading Docker images which workspace we'll use. (To figure that out, we'd need the images, and then the snake eats itself.) Since Docker is good at caching, I'm not too concerned: this is only one extra `docker image inspect` call in any case except for the very first cold run with a new version. (Also, we can _definitely_ optimise those more later.)

Speaking of versioning, there's one other change to make this work as well: when I implemented #412, I missed that newer versions of the workspace image wouldn't be pulled when new `src` versions were released. I've fixed this now (otherwise all my careful Docker image tagging would be for naught!), but note there's a touch of extra complexity in here around moving the `buildTag` to another package so we can access it. I think it's fine, but it's worth an extra set of eyes.