### PR TITLE
Enable dynamic changesetTemplates by adding templating & steps outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ All notable changes to `src-cli` are documented in this file.
 
 ### Added
 
+- `steps` in campaign specs can now have [`outputs`](https://docs.sourcegraph.com/campaigns/references/campaign_spec_yaml_reference#steps-outputs) that support [templating](https://docs.sourcegraph.com/campaigns/references/campaign_spec_templating). [#424](https://github.com/sourcegraph/src-cli/pull/424)
+- `changesetTemplate` fields in campaign specs now also support [templating](https://docs.sourcegraph.com/campaigns/references/campaign_spec_templating). [#424](https://github.com/sourcegraph/src-cli/pull/424)
+
 ### Changed
 
 ### Fixed

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
 	golang.org/x/sys v0.0.0-20200622214017-ed371f2e16b4
 	gopkg.in/yaml.v2 v2.3.0
+	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
 	jaytaylor.com/html2text v0.0.0-20200412013138-3577fbdbcff7
 )
 

--- a/internal/campaigns/campaign_spec.go
+++ b/internal/campaigns/campaign_spec.go
@@ -71,8 +71,16 @@ type Step struct {
 	Container string            `json:"container,omitempty" yaml:"container"`
 	Env       env.Environment   `json:"env,omitempty" yaml:"env"`
 	Files     map[string]string `json:"files,omitempty" yaml:"files,omitempty"`
+	Outputs   Outputs           `json:"output,omitempty" yaml:"output,omitempty"`
 
 	image string
+}
+
+type Outputs map[string]Output
+
+type Output struct {
+	Value  string `json:"value,omitempty" yaml:"value,omitempty"`
+	Format string `json:"format,omitempty" yaml:"format,omitempty"`
 }
 
 type TransformChanges struct {

--- a/internal/campaigns/campaign_spec.go
+++ b/internal/campaigns/campaign_spec.go
@@ -71,7 +71,7 @@ type Step struct {
 	Container string            `json:"container,omitempty" yaml:"container"`
 	Env       env.Environment   `json:"env,omitempty" yaml:"env"`
 	Files     map[string]string `json:"files,omitempty" yaml:"files,omitempty"`
-	Outputs   Outputs           `json:"output,omitempty" yaml:"output,omitempty"`
+	Outputs   Outputs           `json:"outputs,omitempty" yaml:"outputs,omitempty"`
 
 	image string
 }

--- a/internal/campaigns/execution_cache.go
+++ b/internal/campaigns/execution_cache.go
@@ -80,11 +80,6 @@ func (c ExecutionDiskCache) cacheFilePath(key ExecutionCacheKey) (string, error)
 	return filepath.Join(c.Dir, keyString+".v3.json"), nil
 }
 
-type ExecutionResult struct {
-	Diff    string                 `json:"diff"`
-	Outputs map[string]interface{} `json:"outputs"`
-}
-
 func (c ExecutionDiskCache) Get(ctx context.Context, key ExecutionCacheKey) (ExecutionResult, bool, error) {
 	var result ExecutionResult
 

--- a/internal/campaigns/execution_cache.go
+++ b/internal/campaigns/execution_cache.go
@@ -127,6 +127,7 @@ func (c ExecutionDiskCache) Get(ctx context.Context, key ExecutionCacheKey) (Exe
 		}
 
 		return result, true, err
+
 	default:
 		// More than one cache file found.
 		// Sort them so that we'll can possibly read from the one with the most
@@ -194,6 +195,8 @@ func (c ExecutionDiskCache) readCacheFile(path string, result *ExecutionResult) 
 		// only bit of data we were interested in.
 		result.Diff = string(data)
 		result.Outputs = map[string]interface{}{}
+		// Conversion is lossy, though: we don't populate result.StepChanges.
+		result.ChangedFiles = &StepChanges{}
 
 		return nil
 
@@ -213,6 +216,7 @@ func (c ExecutionDiskCache) readCacheFile(path string, result *ExecutionResult) 
 
 		result.Diff = spec.Commits[0].Diff
 		result.Outputs = map[string]interface{}{}
+		result.ChangedFiles = &StepChanges{}
 
 		return nil
 	}

--- a/internal/campaigns/execution_cache.go
+++ b/internal/campaigns/execution_cache.go
@@ -174,9 +174,6 @@ func isOldCacheFile(path string) bool { return !strings.HasSuffix(path, cacheFil
 func (c ExecutionDiskCache) readCacheFile(path string, result *ExecutionResult) error {
 	data, err := ioutil.ReadFile(path)
 	if err != nil {
-		if os.IsNotExist(err) {
-			err = nil // treat as not-found
-		}
 		return err
 	}
 

--- a/internal/campaigns/execution_cache.go
+++ b/internal/campaigns/execution_cache.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -71,13 +72,15 @@ type ExecutionDiskCache struct {
 	Dir string
 }
 
+const cacheFileExt = ".v3.json"
+
 func (c ExecutionDiskCache) cacheFilePath(key ExecutionCacheKey) (string, error) {
 	keyString, err := key.Key()
 	if err != nil {
 		return "", errors.Wrap(err, "calculating execution cache key")
 	}
 
-	return filepath.Join(c.Dir, keyString+".v3.json"), nil
+	return filepath.Join(c.Dir, keyString+cacheFileExt), nil
 }
 
 func (c ExecutionDiskCache) Get(ctx context.Context, key ExecutionCacheKey) (ExecutionResult, bool, error) {
@@ -88,32 +91,106 @@ func (c ExecutionDiskCache) Get(ctx context.Context, key ExecutionCacheKey) (Exe
 		return result, false, err
 	}
 
+	// We try to be backwards compatible and see if we also find older cache
+	// files.
+	//
+	// There are three different cache versions out in the wild and to be
+	// backwards compatible we read all of them.
+	//
+	// In Sourcegraph/src-cli 3.26 we can remove the code here and simply read
+	// the cache from `path`, since all the old cache files should be deleted
+	// until then.
+	globPattern := strings.TrimSuffix(path, cacheFileExt) + ".*"
+	matches, err := filepath.Glob(globPattern)
+	if err != nil {
+		return result, false, err
+	}
+
+	switch len(matches) {
+	case 0:
+		// Nothing found
+		return result, false, nil
+	case 1:
+		// One cache file found
+		if err := c.readCacheFile(matches[0], &result); err != nil {
+			return result, false, err
+		}
+
+		// If it's an old cache file, we rewrite the cache and delete the old file
+		if isOldCacheFile(matches[0]) {
+			if err := c.Set(ctx, key, result); err != nil {
+				return result, false, errors.Wrap(err, "failed to rewrite cache in new format")
+			}
+			if err := os.Remove(matches[0]); err != nil {
+				return result, false, errors.Wrap(err, "failed to remove old cache file")
+			}
+		}
+
+		return result, true, err
+	default:
+		// More than one cache file found.
+		// Sort them so that we'll can possibly read from the one with the most
+		// current version.
+		sortCacheFiles(matches)
+
+		newest := matches[0]
+		toDelete := matches[1:]
+
+		// Read from newest
+		if err := c.readCacheFile(newest, &result); err != nil {
+			return result, false, err
+		}
+
+		// If the newest was also an older version, we write a new version...
+		if isOldCacheFile(newest) {
+			if err := c.Set(ctx, key, result); err != nil {
+				return result, false, errors.Wrap(err, "failed to rewrite cache in new format")
+			}
+			// ... and mark the file also as to-be-deleted
+			toDelete = append(toDelete, newest)
+		}
+
+		// Now we clean up the old ones
+		for _, path := range toDelete {
+			if err := os.Remove(path); err != nil {
+				return result, false, errors.Wrap(err, "failed to remove old cache file")
+			}
+		}
+
+		return result, true, nil
+	}
+}
+
+// sortCacheFiles sorts cache file paths by their "version", so that files
+// ending in `cacheFileExt` are first.
+func sortCacheFiles(paths []string) {
+	sort.Slice(paths, func(i, j int) bool {
+		return !isOldCacheFile(paths[i]) && isOldCacheFile(paths[j])
+	})
+}
+
+func isOldCacheFile(path string) bool { return !strings.HasSuffix(path, cacheFileExt) }
+
+func (c ExecutionDiskCache) readCacheFile(path string, result *ExecutionResult) error {
 	data, err := ioutil.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
 			err = nil // treat as not-found
 		}
-		return result, false, err
+		return err
 	}
 
-	// There are now three different cache versions out in the wild and to be
-	// backwards compatible we read all of them.
-	// 2-step plan for taming this:
-	//  1) February 2021: deprecate old caches by deleting the files when
-	//                    detected and reporting as cache-miss.
-	//  2) May 2021 (two releases later): remove handling of these files from
-	//                                    this function
 	switch {
 	case strings.HasSuffix(path, ".v3.json"):
 		// v3 of the cache: we cache the diff and the outputs produced by the step.
-		if err := json.Unmarshal(data, &result); err != nil {
+		if err := json.Unmarshal(data, result); err != nil {
 			// Delete the invalid data to avoid causing an error for next time.
 			if err := os.Remove(path); err != nil {
-				return result, false, errors.Wrap(err, "while deleting cache file with invalid JSON")
+				return errors.Wrap(err, "while deleting cache file with invalid JSON")
 			}
-			return result, false, errors.Wrapf(err, "reading cache file %s", path)
+			return errors.Wrapf(err, "reading cache file %s", path)
 		}
-		return result, true, nil
+		return nil
 
 	case strings.HasSuffix(path, ".diff"):
 		// v2 of the cache: we only cached the diff, since that's the
@@ -121,7 +198,7 @@ func (c ExecutionDiskCache) Get(ctx context.Context, key ExecutionCacheKey) (Exe
 		result.Diff = string(data)
 		result.Outputs = map[string]interface{}{}
 
-		return result, true, nil
+		return nil
 
 	case strings.HasSuffix(path, ".json"):
 		// v1 of the cache: we cached the complete ChangesetSpec instead of just the diffs.
@@ -129,21 +206,21 @@ func (c ExecutionDiskCache) Get(ctx context.Context, key ExecutionCacheKey) (Exe
 		if err := json.Unmarshal(data, &spec); err != nil {
 			// Delete the invalid data to avoid causing an error for next time.
 			if err := os.Remove(path); err != nil {
-				return result, false, errors.Wrap(err, "while deleting cache file with invalid JSON")
+				return errors.Wrap(err, "while deleting cache file with invalid JSON")
 			}
-			return result, false, errors.Wrapf(err, "reading cache file %s", path)
+			return errors.Wrapf(err, "reading cache file %s", path)
 		}
 		if len(spec.Commits) != 1 {
-			return result, false, errors.New("cached result has no commits")
+			return errors.New("cached result has no commits")
 		}
 
 		result.Diff = spec.Commits[0].Diff
 		result.Outputs = map[string]interface{}{}
 
-		return result, true, nil
+		return nil
 	}
 
-	return result, false, fmt.Errorf("unknown file format for cache file %q", path)
+	return fmt.Errorf("unknown file format for cache file %q", path)
 }
 
 func (c ExecutionDiskCache) Set(ctx context.Context, key ExecutionCacheKey, result ExecutionResult) error {

--- a/internal/campaigns/execution_cache_test.go
+++ b/internal/campaigns/execution_cache_test.go
@@ -139,6 +139,12 @@ func TestExecutionDiskCache(t *testing.T) {
 		Outputs: map[string]interface{}{},
 	}
 
+	onlyDiff := ExecutionResult{
+		Diff:         testDiff,
+		ChangedFiles: &StepChanges{},
+		Outputs:      map[string]interface{}{},
+	}
+
 	t.Run("cache contains v3 cache file", func(t *testing.T) {
 		cache := ExecutionDiskCache{Dir: cacheTmpDir(t)}
 
@@ -174,7 +180,6 @@ func TestExecutionDiskCache(t *testing.T) {
 		oldFilePath := writeV1CacheFile(t, cache, cacheKey1, testDiff)
 
 		// Cache hit, but only for the diff
-		onlyDiff := ExecutionResult{Diff: testDiff, Outputs: map[string]interface{}{}}
 		assertCacheHit(t, cache, cacheKey1, onlyDiff)
 
 		// And the old file should be deleted
@@ -192,8 +197,7 @@ func TestExecutionDiskCache(t *testing.T) {
 		// Simulate old cache file lying around in cache
 		oldFilePath := writeV2CacheFile(t, cache, cacheKey1, testDiff)
 
-		// Now we get a cache hit, but only for the diff (
-		onlyDiff := ExecutionResult{Diff: testDiff, Outputs: map[string]interface{}{}}
+		// Now we get a cache hit, but only for the diff
 		assertCacheHit(t, cache, cacheKey1, onlyDiff)
 
 		// And the old file should be deleted
@@ -226,8 +230,7 @@ func TestExecutionDiskCache(t *testing.T) {
 		oldFilePath1 := writeV1CacheFile(t, cache, cacheKey1, testDiff)
 		oldFilePath2 := writeV1CacheFile(t, cache, cacheKey1, testDiff)
 
-		// Now we get a cache hit, but only for the diff (
-		onlyDiff := ExecutionResult{Diff: testDiff, Outputs: map[string]interface{}{}}
+		// Now we get a cache hit, but only for the diff
 		assertCacheHit(t, cache, cacheKey1, onlyDiff)
 
 		// And the old files should be deleted

--- a/internal/campaigns/execution_cache_test.go
+++ b/internal/campaigns/execution_cache_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 const testExecutionCacheKeyEnv = "TEST_EXECUTION_CACHE_KEY_ENV"

--- a/internal/campaigns/executor.go
+++ b/internal/campaigns/executor.go
@@ -183,6 +183,7 @@ func (x *executor) AddTask(repo *graphql.Repository, steps []Step, transform *Tr
 		Template:         template,
 		TransformChanges: transform,
 	}
+
 	x.tasks = append(x.tasks, task)
 
 	x.statusesMu.Lock()
@@ -277,10 +278,10 @@ func (x *executor) do(ctx context.Context, task *Task) (err error) {
 				return
 			}
 
-			// TODO: We need to cache the vars here too if we want use to render changesetTemplate
-			vars := map[string]interface{}{}
+			// TODO: We need to cache the outputs here too if we want use to render changesetTemplate
+			outputs := map[string]interface{}{}
 			var specs []*ChangesetSpec
-			specs, err = createChangesetSpecs(task, diff, vars, x.features)
+			specs, err = createChangesetSpecs(task, diff, outputs, x.features)
 			if err != nil {
 				return err
 			}

--- a/internal/campaigns/executor_test.go
+++ b/internal/campaigns/executor_test.go
@@ -320,9 +320,6 @@ func TestExecutor_Integration(t *testing.T) {
 					t.Fatalf("wrong number of changeset specs. want=%d, have=%d", want, have)
 				}
 
-				for i, spec := range specs {
-					t.Logf("specs[%d]=%+v\n", i, spec.CreatedChangeset)
-				}
 				for _, spec := range specs {
 					if tc.wantTitle != "" && spec.Title != tc.wantTitle {
 						t.Errorf("wrong title. want=%q, have=%q", tc.wantTitle, spec.Title)

--- a/internal/campaigns/executor_test.go
+++ b/internal/campaigns/executor_test.go
@@ -618,13 +618,13 @@ func newZipArchivesMux(t *testing.T, callback http.HandlerFunc, archives ...mock
 
 // inMemoryExecutionCache provides an in-memory cache for testing purposes.
 type inMemoryExecutionCache struct {
-	cache map[string]executionResult
+	cache map[string]ExecutionResult
 	mu    sync.RWMutex
 }
 
 func newInMemoryExecutionCache() *inMemoryExecutionCache {
 	return &inMemoryExecutionCache{
-		cache: make(map[string]executionResult),
+		cache: make(map[string]ExecutionResult),
 	}
 }
 
@@ -635,22 +635,22 @@ func (c *inMemoryExecutionCache) size() int {
 	return len(c.cache)
 }
 
-func (c *inMemoryExecutionCache) Get(ctx context.Context, key ExecutionCacheKey) (string, map[string]interface{}, bool, error) {
+func (c *inMemoryExecutionCache) Get(ctx context.Context, key ExecutionCacheKey) (ExecutionResult, bool, error) {
 	k, err := key.Key()
 	if err != nil {
-		return "", nil, false, err
+		return ExecutionResult{}, false, err
 	}
 
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
 	if res, ok := c.cache[k]; ok {
-		return res.Diff, res.Outputs, true, nil
+		return res, true, nil
 	}
-	return "", nil, false, nil
+	return ExecutionResult{}, false, nil
 }
 
-func (c *inMemoryExecutionCache) Set(ctx context.Context, key ExecutionCacheKey, diff string, outputs map[string]interface{}) error {
+func (c *inMemoryExecutionCache) Set(ctx context.Context, key ExecutionCacheKey, result ExecutionResult) error {
 	k, err := key.Key()
 	if err != nil {
 		return err
@@ -659,7 +659,7 @@ func (c *inMemoryExecutionCache) Set(ctx context.Context, key ExecutionCacheKey,
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	c.cache[k] = executionResult{Diff: diff, Outputs: outputs}
+	c.cache[k] = result
 	return nil
 }
 

--- a/internal/campaigns/executor_test.go
+++ b/internal/campaigns/executor_test.go
@@ -235,8 +235,13 @@ func TestExecutor_Integration(t *testing.T) {
 				},
 			},
 			template: &ChangesetTemplate{
-				Title:  "myOutputName1=${{ outputs.myOutputName1}}",
-				Body:   "myOutputName1=${{ outputs.myOutputName1}},myOutputName2=${{ outputs.myOutputName2.thisStepStdout }}",
+				Title: "myOutputName1=${{ outputs.myOutputName1}}",
+				Body: `myOutputName1=${{ outputs.myOutputName1}},myOutputName2=${{ outputs.myOutputName2.thisStepStdout }}
+modified_files=${{ steps.modified_files }}
+added_files=${{ steps.added_files }}
+deleted_files=${{ steps.deleted_files }}
+renamed_files=${{ steps.renamed_files }}
+repository_name=${{ repository.name }}`,
 				Branch: "templated-branch-${{ outputs.myOutputName3 }}",
 				Commit: ExpandedGitCommitDescription{
 					Message: "myOutputName1=${{ outputs.myOutputName1}},myOutputName2=${{ outputs.myOutputName2.thisStepStdout }}",
@@ -248,8 +253,13 @@ func TestExecutor_Integration(t *testing.T) {
 					"templated-branch-cool-suffix": []string{"main.go"},
 				},
 			},
-			wantTitle:         "myOutputName1=main.go",
-			wantBody:          "myOutputName1=main.go,myOutputName2=Hello World!",
+			wantTitle: "myOutputName1=main.go",
+			wantBody: `myOutputName1=main.go,myOutputName2=Hello World!
+modified_files=[main.go]
+added_files=[]
+deleted_files=[]
+renamed_files=[]
+repository_name=github.com/sourcegraph/src-cli`,
 			wantCommitMessage: "myOutputName1=main.go,myOutputName2=Hello World!",
 		},
 	}
@@ -325,7 +335,7 @@ func TestExecutor_Integration(t *testing.T) {
 						t.Errorf("wrong title. want=%q, have=%q", tc.wantTitle, spec.Title)
 					}
 					if tc.wantBody != "" && spec.Body != tc.wantBody {
-						t.Errorf("wrong body. want=%q, have=%q", tc.wantBody, spec.Body)
+						t.Errorf("wrong body.\nwant=%q\nhave=%q\n", tc.wantBody, spec.Body)
 					}
 
 					if have, want := len(spec.Commits), 1; have != want {

--- a/internal/campaigns/run_steps.go
+++ b/internal/campaigns/run_steps.go
@@ -20,7 +20,13 @@ import (
 )
 
 type ExecutionResult struct {
-	Diff    string                 `json:"diff"`
+	// Diff is the produced by executing all steps.
+	Diff string `json:"diff"`
+
+	// ChangedFiles are files that have been changed by all steps.
+	ChangedFiles *StepChanges `json:"changedFiles"`
+
+	// Outputs are the outputs produced by all steps.
 	Outputs map[string]interface{} `json:"outputs"`
 }
 
@@ -231,7 +237,12 @@ func runSteps(ctx context.Context, rf RepoFetcher, wc WorkspaceCreator, repo *gr
 	if err != nil {
 		return execResult, errors.Wrap(err, "git diff failed")
 	}
+
 	execResult.Diff = string(diffOut)
+	if len(results) > 0 && results[len(results)-1].files != nil {
+		execResult.ChangedFiles = results[len(results)-1].files
+	}
+
 	return execResult, err
 }
 

--- a/internal/campaigns/templating.go
+++ b/internal/campaigns/templating.go
@@ -11,7 +11,48 @@ import (
 	"github.com/sourcegraph/src-cli/internal/campaigns/graphql"
 )
 
-func renderTemplate(name, tmpl string, out io.Writer, stepCtx *StepContext) error {
+// ChangesetTemplateContext represents the contextual information available
+// when rendering a field of the ChangesetTemplate as a template.
+type ChangesetTemplateContext struct {
+	// TODO: This should also have `Steps`
+	Outputs    map[string]interface{}
+	Repository graphql.Repository
+}
+
+// ToFuncMap returns a template.FuncMap to access fields on the StepContext in a
+// text/template.
+func (tmplCtx *ChangesetTemplateContext) ToFuncMap() template.FuncMap {
+	return template.FuncMap{
+		"join":  strings.Join,
+		"split": strings.Split,
+		"repository": func() map[string]interface{} {
+			return map[string]interface{}{
+				"search_result_paths": tmplCtx.Repository.SearchResultPaths(),
+				"name":                tmplCtx.Repository.Name,
+			}
+		},
+		"outputs": func() map[string]interface{} {
+			return tmplCtx.Outputs
+		},
+	}
+}
+
+func renderChangesetTemplateField(name, tmpl string, tmplCtx *ChangesetTemplateContext) (string, error) {
+	var out bytes.Buffer
+
+	t, err := template.New(name).Delims("${{", "}}").Funcs(tmplCtx.ToFuncMap()).Parse(tmpl)
+	if err != nil {
+		return "", err
+	}
+
+	if err := t.Execute(&out, tmplCtx); err != nil {
+		return "", err
+	}
+
+	return out.String(), nil
+}
+
+func renderStepTemplate(name, tmpl string, out io.Writer, stepCtx *StepContext) error {
 	t, err := parseAsTemplate(name, tmpl, stepCtx)
 	if err != nil {
 		return errors.Wrap(err, "parsing step run")
@@ -24,13 +65,13 @@ func parseAsTemplate(name, input string, stepCtx *StepContext) (*template.Templa
 	return template.New(name).Delims("${{", "}}").Funcs(stepCtx.ToFuncMap()).Parse(input)
 }
 
-func renderMap(m map[string]string, stepCtx *StepContext) (map[string]string, error) {
+func renderStepMap(m map[string]string, stepCtx *StepContext) (map[string]string, error) {
 	rendered := make(map[string]string, len(m))
 
 	for k, v := range rendered {
 		var out bytes.Buffer
 
-		if err := renderTemplate(k, v, &out, stepCtx); err != nil {
+		if err := renderStepTemplate(k, v, &out, stepCtx); err != nil {
 			return rendered, err
 		}
 
@@ -40,44 +81,61 @@ func renderMap(m map[string]string, stepCtx *StepContext) (map[string]string, er
 	return rendered, nil
 }
 
-// StepContext represents the contextual information available when executing a
-// step that's defined in a campaign spec.
+// StepContext represents the contextual information available when render a
+// step's fields, such as "run" or "outputs", as templates.
 type StepContext struct {
+	// Outputs are the outputs set by the current and all previous steps.
+	Outputs map[string]interface{}
+	// Step is the result of the current step. Empty when evaluating the "run" field
+	// but filled when evaluating the "outputs" field.
+	Step StepResult
+	// PreviousStep is the result of the previous step. Empty when there is no
+	// previous step.
 	PreviousStep StepResult
-	Repository   graphql.Repository
+	// Repository is the Sourcegraph repository in which the steps are executed.
+	Repository graphql.Repository
 }
 
 // ToFuncMap returns a template.FuncMap to access fields on the StepContext in a
 // text/template.
 func (stepCtx *StepContext) ToFuncMap() template.FuncMap {
+	newStepResult := func(res *StepResult) map[string]interface{} {
+		m := map[string]interface{}{
+			"modified_files": "",
+			"added_files":    "",
+			"deleted_files":  "",
+			"renamed_files":  "",
+			"stdout":         "",
+			"stderr":         "",
+		}
+
+		m["modified_files"] = res.ModifiedFiles()
+		m["added_files"] = res.AddedFiles()
+		m["deleted_files"] = res.DeletedFiles()
+		m["renamed_files"] = res.RenamedFiles()
+
+		if res.Stdout != nil {
+			m["stdout"] = res.Stdout.String()
+		}
+
+		if res.Stderr != nil {
+			m["stderr"] = res.Stderr.String()
+		}
+
+		return m
+	}
+
 	return template.FuncMap{
-		"join": func(list []string, sep string) string {
-			return strings.Join(list, sep)
-		},
-		"split": func(s string, sep string) []string {
-			return strings.Split(s, sep)
-		},
+		"join":  strings.Join,
+		"split": strings.Split,
 		"previous_step": func() map[string]interface{} {
-			result := map[string]interface{}{
-				"modified_files": stepCtx.PreviousStep.ModifiedFiles(),
-				"added_files":    stepCtx.PreviousStep.AddedFiles(),
-				"deleted_files":  stepCtx.PreviousStep.DeletedFiles(),
-				"renamed_files":  stepCtx.PreviousStep.RenamedFiles(),
-			}
-
-			if stepCtx.PreviousStep.Stdout != nil {
-				result["stdout"] = stepCtx.PreviousStep.Stdout.String()
-			} else {
-				result["stdout"] = ""
-			}
-
-			if stepCtx.PreviousStep.Stderr != nil {
-				result["stderr"] = stepCtx.PreviousStep.Stderr.String()
-			} else {
-				result["stderr"] = ""
-			}
-
-			return result
+			return newStepResult(&stepCtx.PreviousStep)
+		},
+		"step": func() map[string]interface{} {
+			return newStepResult(&stepCtx.Step)
+		},
+		"outputs": func() map[string]interface{} {
+			return stepCtx.Outputs
 		},
 		"repository": func() map[string]interface{} {
 			return map[string]interface{}{

--- a/internal/campaigns/templating.go
+++ b/internal/campaigns/templating.go
@@ -40,7 +40,7 @@ func renderStepMap(m map[string]string, stepCtx *StepContext) (map[string]string
 	return rendered, nil
 }
 
-// StepContext represents the contextual information available when render a
+// StepContext represents the contextual information available when rendering a
 // step's fields, such as "run" or "outputs", as templates.
 type StepContext struct {
 	// Outputs are the outputs set by the current and all previous steps.

--- a/internal/campaigns/templating_test.go
+++ b/internal/campaigns/templating_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/sourcegraph/src-cli/internal/campaigns/graphql"
+	"gopkg.in/yaml.v2"
 )
 
 func TestParseGitStatus(t *testing.T) {
@@ -33,7 +34,26 @@ R  README.md -> README.markdown
 	}
 }
 
+const rawYaml = `dist: release
+env:
+  - GO111MODULE=on
+  - CGO_ENABLED=0
+before:
+  hooks:
+    - go mod download
+    - go mod tidy
+    - go generate ./schema
+`
+
 func TestParsingAndRenderingTemplates(t *testing.T) {
+	// To avoid bugs due to differences between test setup and actual code, we
+	// do the actual parsing of YAML here to get an interface{} which we'll put
+	// in the StepContext.
+	var parsedYaml interface{}
+	if err := yaml.Unmarshal([]byte(rawYaml), &parsedYaml); err != nil {
+		t.Fatalf("failed to parse YAML: %s", err)
+	}
+
 	stepCtx := &StepContext{
 		PreviousStep: StepResult{
 			files: &StepChanges{
@@ -42,8 +62,22 @@ func TestParsingAndRenderingTemplates(t *testing.T) {
 				Deleted:  []string{".DS_Store"},
 				Renamed:  []string{"new-filename.txt"},
 			},
-			Stdout: bytes.NewBufferString("this is stdout"),
-			Stderr: bytes.NewBufferString("this is stderr"),
+			Stdout: bytes.NewBufferString("this is previous step's stdout"),
+			Stderr: bytes.NewBufferString("this is previous step's stderr"),
+		},
+		Outputs: map[string]interface{}{
+			"lastLine": "lastLine is this",
+			"project":  parsedYaml,
+		},
+		Step: StepResult{
+			files: &StepChanges{
+				Modified: []string{"step-go.mod"},
+				Added:    []string{"step-main.go.swp"},
+				Deleted:  []string{"step-.DS_Store"},
+				Renamed:  []string{"step-new-filename.txt"},
+			},
+			Stdout: bytes.NewBufferString("this is current step's stdout"),
+			Stderr: bytes.NewBufferString("this is current step's stderr"),
 		},
 		Repository: graphql.Repository{
 			Name: "github.com/sourcegraph/src-cli",
@@ -61,83 +95,45 @@ func TestParsingAndRenderingTemplates(t *testing.T) {
 		want    string
 	}{
 		{
-			name:    "previous step file changes",
-			stepCtx: stepCtx,
-			run: `${{ .PreviousStep.ModifiedFiles }}
-${{ .PreviousStep.AddedFiles }}
-${{ .PreviousStep.DeletedFiles }}
-${{ .PreviousStep.RenamedFiles }}
-`,
-			want: `[go.mod]
-[main.go.swp]
-[.DS_Store]
-[new-filename.txt]
-`,
-		},
-		{
-			name:    "previous step output",
-			stepCtx: stepCtx,
-			run:     `${{ .PreviousStep.Stdout }} ${{ .PreviousStep.Stderr }}`,
-			want:    `this is stdout this is stderr`,
-		},
-		{
-			name:    "repository name",
-			stepCtx: stepCtx,
-			run:     `${{ .Repository.Name }}`,
-			want:    `github.com/sourcegraph/src-cli`,
-		},
-		{
-			name:    "search result paths",
-			stepCtx: stepCtx,
-			run:     `${{ .Repository.SearchResultPaths }}`,
-			want:    `README.md main.go`,
-		},
-		{
 			name:    "lower-case aliases",
 			stepCtx: stepCtx,
 			run: `${{ repository.search_result_paths }}
-		${{ repository.name }}
-		${{ previous_step.modified_files }}
-		${{ previous_step.added_files }}
-		${{ previous_step.deleted_files }}
-		${{ previous_step.renamed_files }}
-		${{ previous_step.stdout }}
-		${{ previous_step.stderr}}
-		`,
-			want: `README.md main.go
-		github.com/sourcegraph/src-cli
-		[go.mod]
-		[main.go.swp]
-		[.DS_Store]
-		[new-filename.txt]
-		this is stdout
-		this is stderr
-		`,
-		},
-		{
-			name:    "empty context",
-			stepCtx: &StepContext{},
-			run: `${{ .Repository.SearchResultPaths }}
-${{ .Repository.Name }}
+${{ repository.name }}
 ${{ previous_step.modified_files }}
 ${{ previous_step.added_files }}
 ${{ previous_step.deleted_files }}
 ${{ previous_step.renamed_files }}
 ${{ previous_step.stdout }}
 ${{ previous_step.stderr}}
+${{ outputs.lastLine }}
+${{ index outputs.project.env 1 }}
+${{ step.modified_files }}
+${{ step.added_files }}
+${{ step.deleted_files }}
+${{ step.renamed_files }}
+${{ step.stdout}}
+${{ step.stderr}}
 `,
-			want: `
-
-[]
-[]
-[]
-[]
-
-
+			want: `README.md main.go
+github.com/sourcegraph/src-cli
+[go.mod]
+[main.go.swp]
+[.DS_Store]
+[new-filename.txt]
+this is previous step's stdout
+this is previous step's stderr
+lastLine is this
+CGO_ENABLED=0
+[step-go.mod]
+[step-main.go.swp]
+[step-.DS_Store]
+[step-new-filename.txt]
+this is current step's stdout
+this is current step's stderr
 `,
 		},
 		{
-			name:    "empty context and aliases",
+			name:    "empty context",
 			stepCtx: &StepContext{},
 			run: `${{ repository.search_result_paths }}
 ${{ repository.name }}
@@ -147,9 +143,25 @@ ${{ previous_step.deleted_files }}
 ${{ previous_step.renamed_files }}
 ${{ previous_step.stdout }}
 ${{ previous_step.stderr}}
+${{ outputs.lastLine }}
+${{ outputs.project }}
+${{ step.modified_files }}
+${{ step.added_files }}
+${{ step.deleted_files }}
+${{ step.renamed_files }}
+${{ step.stdout}}
+${{ step.stderr}}
 `,
 			want: `
 
+[]
+[]
+[]
+[]
+
+
+<no value>
+<no value>
 []
 []
 []
@@ -162,14 +174,11 @@ ${{ previous_step.stderr}}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			parsed, err := parseAsTemplate("testing", tc.run, tc.stepCtx)
+			var out bytes.Buffer
+
+			err := renderStepTemplate("testing", tc.run, &out, tc.stepCtx)
 			if err != nil {
 				t.Fatal(err)
-			}
-
-			var out bytes.Buffer
-			if err := parsed.Execute(&out, tc.stepCtx); err != nil {
-				t.Fatalf("executing template failed: %s", err)
 			}
 
 			if out.String() != tc.want {

--- a/internal/campaigns/templating_test.go
+++ b/internal/campaigns/templating_test.go
@@ -209,6 +209,12 @@ func TestRenderChangesetTemplateField(t *testing.T) {
 				"main.go":   true,
 			},
 		},
+		Steps: &StepChanges{
+			Modified: []string{"modified-file.txt"},
+			Added:    []string{"added-file.txt"},
+			Deleted:  []string{"deleted-file.txt"},
+			Renamed:  []string{"renamed-file.txt"},
+		},
 	}
 
 	tests := []struct {
@@ -224,11 +230,19 @@ func TestRenderChangesetTemplateField(t *testing.T) {
 ${{ repository.name }}
 ${{ outputs.lastLine }}
 ${{ index outputs.project.env 1 }}
+${{ steps.modified_files }}
+${{ steps.added_files }}
+${{ steps.deleted_files }}
+${{ steps.renamed_files }}
 `,
 			want: `README.md main.go
 github.com/sourcegraph/src-cli
 lastLine is this
 CGO_ENABLED=0
+[modified-file.txt]
+[added-file.txt]
+[deleted-file.txt]
+[renamed-file.txt]
 `,
 		},
 		{
@@ -238,11 +252,19 @@ CGO_ENABLED=0
 ${{ repository.name }}
 ${{ outputs.lastLine }}
 ${{ outputs.project }}
+${{ steps.modified_files }}
+${{ steps.added_files }}
+${{ steps.deleted_files }}
+${{ steps.renamed_files }}
 `,
 			want: `
 
 <no value>
 <no value>
+[]
+[]
+[]
+[]
 `,
 		},
 	}

--- a/internal/campaigns/templating_test.go
+++ b/internal/campaigns/templating_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/sourcegraph/src-cli/internal/campaigns/graphql"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 func TestParseGitStatus(t *testing.T) {

--- a/internal/campaigns/templating_test.go
+++ b/internal/campaigns/templating_test.go
@@ -45,7 +45,7 @@ before:
     - go generate ./schema
 `
 
-func TestParsingAndRenderingTemplates(t *testing.T) {
+func TestRenderStepTemplate(t *testing.T) {
 	// To avoid bugs due to differences between test setup and actual code, we
 	// do the actual parsing of YAML here to get an interface{} which we'll put
 	// in the StepContext.

--- a/schema/campaign_spec.schema.json
+++ b/schema/campaign_spec.schema.json
@@ -75,6 +75,26 @@
             "description": "The Docker image used to launch the Docker container in which the shell command is run.",
             "examples": ["alpine:3"]
           },
+          "outputs": {
+            "type": "object",
+            "description": "Output variables of this step that can be referenced in the changesetTemplate or other steps via outputs.<name-of-output>",
+            "additionalProperties": {
+              "type": "object",
+              "required": ["value"],
+              "properties": {
+                "value": {
+                  "type": "string",
+                  "description": "The value of the output, which can be a template string.",
+                  "examples": ["${{ step.stdout }}", "${{ repository.name }}" ]
+                },
+                "format": {
+                  "type": "string",
+                  "description": "The expected format of the output. If set, the output is being parsed in that format before being stored in the var.",
+                  "enum": ["json", "yaml", "text"]
+                }
+              }
+            }
+          },
           "env": {
             "description": "Environment variables to set in the step environment.",
             "oneOf": [
@@ -109,6 +129,10 @@
             "type": "object",
             "description": "Files that should be mounted into or be created inside the Docker container.",
             "additionalProperties": {"type": "string"}
+          },
+          "outputVariable": {
+            "type": "string",
+            "description": "The name of the variable in which to save the output of the step. The variable has to have been declared in `vars`."
           }
         }
       }

--- a/schema/campaign_spec.schema.json
+++ b/schema/campaign_spec.schema.json
@@ -85,11 +85,11 @@
                 "value": {
                   "type": "string",
                   "description": "The value of the output, which can be a template string.",
-                  "examples": ["${{ step.stdout }}", "${{ repository.name }}" ]
+                  "examples": ["hello world", "${{ step.stdout }}", "${{ repository.name }}" ]
                 },
                 "format": {
                   "type": "string",
-                  "description": "The expected format of the output. If set, the output is being parsed in that format before being stored in the var.",
+                  "description": "The expected format of the output. If set, the output is being parsed in that format before being stored in the var. If not set, 'text' is assumed to the format.",
                   "enum": ["json", "yaml", "text"]
                 }
               }

--- a/schema/campaign_spec.schema.json
+++ b/schema/campaign_spec.schema.json
@@ -129,10 +129,6 @@
             "type": "object",
             "description": "Files that should be mounted into or be created inside the Docker container.",
             "additionalProperties": {"type": "string"}
-          },
-          "outputVariable": {
-            "type": "string",
-            "description": "The name of the variable in which to save the output of the step. The variable has to have been declared in `vars`."
           }
         }
       }

--- a/schema/campaign_spec_stringdata.go
+++ b/schema/campaign_spec_stringdata.go
@@ -61,29 +61,6 @@ const CampaignSpecJSON = `{
         ]
       }
     },
-    "vars": {
-      "type": "array",
-      "description": "Optional list of variables that can be used with templating-syntax to interpolate values into ` + "`" + `steps` + "`" + ` and ` + "`" + `changesetTemplate` + "`" + `",
-      "items": {
-        "title": "Var",
-        "type": "object",
-        "description": "A variable that is available in the ` + "`" + `steps` + "`" + ` or ` + "`" + `changesetTemplate` + "`" + ` as a template variable.",
-        "additionalProperties": false,
-        "required": ["name", "default"],
-        "properties": {
-          "name": {
-            "type": "string",
-            "description": "The name of the variable.",
-            "pattern": "^[\\w.-_]+$"
-          },
-          "default": {
-            "type": "string",
-            "description": "The default value of the variable.",
-            "examples": ["alpine:3"]
-          }
-        }
-      }
-    },
     "steps": {
       "type": "array",
       "description": "The sequence of commands to run (for each repository branch matched in the ` + "`" + `on` + "`" + ` property) to produce the campaign's changes.",
@@ -102,22 +79,6 @@ const CampaignSpecJSON = `{
             "type": "string",
             "description": "The Docker image used to launch the Docker container in which the shell command is run.",
             "examples": ["alpine:3"]
-          },
-          "output": {
-            "type": "object",
-            "description": "Specification of whether and how to capture the output produced by the command",
-            "required": ["var"],
-            "properties": {
-              "var": {
-                "type": "string",
-                "description": "The name of the variable in which to store the output, after optionally converting it if 'format' is given."
-              },
-              "format": {
-                "type": "string",
-                "description": "The expected format of the output. If given the output is being parsed in that format before being stored in the var.",
-                "enum": ["json", "yaml", "text"]
-              }
-            }
           },
           "outputs": {
             "type": "object",
@@ -173,10 +134,6 @@ const CampaignSpecJSON = `{
             "type": "object",
             "description": "Files that should be mounted into or be created inside the Docker container.",
             "additionalProperties": {"type": "string"}
-          },
-          "outputVariable": {
-            "type": "string",
-            "description": "The name of the variable in which to save the output of the step. The variable has to have been declared in ` + "`" + `vars` + "`" + `."
           }
         }
       }

--- a/schema/campaign_spec_stringdata.go
+++ b/schema/campaign_spec_stringdata.go
@@ -61,6 +61,29 @@ const CampaignSpecJSON = `{
         ]
       }
     },
+    "vars": {
+      "type": "array",
+      "description": "Optional list of variables that can be used with templating-syntax to interpolate values into ` + "`" + `steps` + "`" + ` and ` + "`" + `changesetTemplate` + "`" + `",
+      "items": {
+        "title": "Var",
+        "type": "object",
+        "description": "A variable that is available in the ` + "`" + `steps` + "`" + ` or ` + "`" + `changesetTemplate` + "`" + ` as a template variable.",
+        "additionalProperties": false,
+        "required": ["name", "default"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The name of the variable.",
+            "pattern": "^[\\w.-_]+$"
+          },
+          "default": {
+            "type": "string",
+            "description": "The default value of the variable.",
+            "examples": ["alpine:3"]
+          }
+        }
+      }
+    },
     "steps": {
       "type": "array",
       "description": "The sequence of commands to run (for each repository branch matched in the ` + "`" + `on` + "`" + ` property) to produce the campaign's changes.",
@@ -79,6 +102,42 @@ const CampaignSpecJSON = `{
             "type": "string",
             "description": "The Docker image used to launch the Docker container in which the shell command is run.",
             "examples": ["alpine:3"]
+          },
+          "output": {
+            "type": "object",
+            "description": "Specification of whether and how to capture the output produced by the command",
+            "required": ["var"],
+            "properties": {
+              "var": {
+                "type": "string",
+                "description": "The name of the variable in which to store the output, after optionally converting it if 'format' is given."
+              },
+              "format": {
+                "type": "string",
+                "description": "The expected format of the output. If given the output is being parsed in that format before being stored in the var.",
+                "enum": ["json", "yaml", "text"]
+              }
+            }
+          },
+          "outputs": {
+            "type": "object",
+            "description": "Output variables of this step that can be referenced in the changesetTemplate or other steps via outputs.<name-of-output>",
+            "additionalProperties": {
+              "type": "object",
+              "required": ["value"],
+              "properties": {
+                "value": {
+                  "type": "string",
+                  "description": "The value of the output, which can be a template string.",
+                  "examples": ["${{ step.stdout }}", "${{ repository.name }}" ]
+                },
+                "format": {
+                  "type": "string",
+                  "description": "The expected format of the output. If set, the output is being parsed in that format before being stored in the var.",
+                  "enum": ["json", "yaml", "text"]
+                }
+              }
+            }
           },
           "env": {
             "description": "Environment variables to set in the step environment.",
@@ -114,6 +173,10 @@ const CampaignSpecJSON = `{
             "type": "object",
             "description": "Files that should be mounted into or be created inside the Docker container.",
             "additionalProperties": {"type": "string"}
+          },
+          "outputVariable": {
+            "type": "string",
+            "description": "The name of the variable in which to save the output of the step. The variable has to have been declared in ` + "`" + `vars` + "`" + `."
           }
         }
       }

--- a/schema/campaign_spec_stringdata.go
+++ b/schema/campaign_spec_stringdata.go
@@ -90,11 +90,11 @@ const CampaignSpecJSON = `{
                 "value": {
                   "type": "string",
                   "description": "The value of the output, which can be a template string.",
-                  "examples": ["${{ step.stdout }}", "${{ repository.name }}" ]
+                  "examples": ["hello world", "${{ step.stdout }}", "${{ repository.name }}" ]
                 },
                 "format": {
                   "type": "string",
-                  "description": "The expected format of the output. If set, the output is being parsed in that format before being stored in the var.",
+                  "description": "The expected format of the output. If set, the output is being parsed in that format before being stored in the var. If not set, 'text' is assumed to the format.",
                   "enum": ["json", "yaml", "text"]
                 }
               }


### PR DESCRIPTION
### What?

This PR enables **dynamic `changesetTemplates`** in campaign specs by doing two things:

1. it adds templating support to the `title`, `body`, `branch` and `commit.message` fields in `changesetTemplate`.
2. it adds `outputs` to `steps`, which are values that are set after the step has been executed and that have _access to template variables, including the current step's output_.

This solves the problem of not being able to customize the `changesetTemplate` per repository (only `published` could be configured per repository).

### Show me

With this PR, the following campaign spec works:

```yaml
name: dynamic-changeset-template
description: Hello Outputs

on:
  - repository: github.com/sourcegraph/src-cli

steps:
  - run: echo "Hello there!" >> message.txt && cat message.txt
    container: alpine:3
    # NEW:
    outputs:
      friendlyMessage:
        value: "${{ step.stdout }}"
        # format: text is implicit
  - run: cat .goreleaser.yml >&2
    container: alpine:3
    # NEW:
    outputs:
      goreleaserConfig:
        value: "${{ step.stderr }}"
        # we will parse the value here as YAML, meaning that we can access it as an object
        format: yaml
      goreleaserConfigExists:
        # we can use the power of Go's text/template engine to dynamically produce complex values
        value: "exists: ${{ gt (len step.stderr) 0 }}"
        format: yaml

changesetTemplate:
  # title allows templating
  title: "The friendly message is: `${{ outputs.friendlyMessage }}`"
  # body allows templating
  body: |
    This repository has a `gorelaserConfig`: ${{ outputs.goreleaserConfigExists.exists }}.

    (Since these are just Go `text/templates` and `goreleaserConfig` was parsed as YAML we can access every field)

    The `goreleaser.yml` defines the following `before.hooks`:

    ${{ range $index, $hook := outputs.goreleaserConfig.before.hooks }}
    - `${{ $hook }}`
    ${{ end }}

    These files were added by the steps:

    ```
    ${{ join steps.added_files " " }}
    ```

  # branch allows templating
  branch: thorsten/variables-${{ outputs.goreleaserConfig.dist }}
  published: draft
  commit:
    # commit message allows templating
    message: "The friendly message is: `${{ outputs.friendlyMessage }}`"
```

It created [this pull request](https://github.com/sourcegraph/src-cli/pull/428):

![screenshot_2021-01-14_15 38 19@2x](https://user-images.githubusercontent.com/1185253/104605299-9aeca480-567e-11eb-8d06-4209e4fe3f78.png)


### Meta

PR in `sourcegraph/sourcegraph` that adds the schema: https://github.com/sourcegraph/sourcegraph/pull/17243

### What's missing?

- [x] BIG FAT **TODO**: caching! we need to cache the outputs too now, not just the diff.
- [x] ~Documentation. I want to add docs for this in https://github.com/sourcegraph/sourcegraph/pull/17243 and also better document templating support, since we now lean on it more heavily.~ PR is here: https://github.com/sourcegraph/sourcegraph/pull/17286

### Possible follow-ups

- [ ] Can be a follow-up PR: making `transformChanges.group.branch` optional by making `transform_changes.group` available as a template variable in `changesetTemplate.branch`. 