### PR TITLE
Switch 'src validate' to use yaml.v3

### DIFF
--- a/cmd/src/validate.go
+++ b/cmd/src/validate.go
@@ -17,28 +17,28 @@ import (
 	jsoniter "github.com/json-iterator/go"
 	"github.com/mattn/go-isatty"
 	"github.com/sourcegraph/src-cli/internal/api"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 type validationSpec struct {
 	FirstAdmin struct {
-		Email             string
-		Username          string
-		Password          string
-		CreateAccessToken bool
-	}
+		Email             string `yaml:"email"`
+		Username          string `yaml:"username"`
+		Password          string `yaml:"password"`
+		CreateAccessToken bool   `yaml:"createAccessToken"`
+	} `yaml:"firstAdmin"`
 	WaitRepoCloned struct {
-		Repo                     string
-		MaxTries                 int
-		SleepBetweenTriesSeconds int
-	}
-	SearchQuery     string
+		Repo                     string `yaml:"repo"`
+		MaxTries                 int    `yaml:"maxTries"`
+		SleepBetweenTriesSeconds int    `yaml:"sleepBetweenTriesSecond"`
+	} `yaml:"waitRepoCloned"`
+	SearchQuery     string `yaml:"searchQuery"`
 	ExternalService struct {
-		Kind           string
-		DisplayName    string
-		Config         *json.RawMessage
-		DeleteWhenDone bool
-	}
+		Kind           string                 `yaml:"kind"`
+		DisplayName    string                 `yaml:"displayName"`
+		Config         map[string]interface{} `yaml:"config"`
+		DeleteWhenDone bool                   `yaml:"deleteWhenDone"`
+	} `yaml:"externalService"`
 }
 
 type validator struct {
@@ -235,7 +235,7 @@ mutation AddExternalService($kind: ExternalServiceKind!, $displayName: String!, 
 }`
 
 func (vd *validator) addExternalService(vspec *validationSpec) (string, error) {
-	configJson, err := vspec.ExternalService.Config.MarshalJSON()
+	configJson, err := json.Marshal(vspec.ExternalService.Config)
 	if err != nil {
 		return "", err
 	}

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,6 @@ require (
 	golang.org/x/net v0.0.0-20200625001655-4c5254603344
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
 	golang.org/x/sys v0.0.0-20200622214017-ed371f2e16b4
-	gopkg.in/yaml.v2 v2.3.0
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
 	jaytaylor.com/html2text v0.0.0-20200412013138-3577fbdbcff7
 )

--- a/go.sum
+++ b/go.sum
@@ -52,10 +52,6 @@ github.com/shurcooL/go v0.0.0-20180423040247-9e1955d9fb6e/go.mod h1:TDJrrUr11Vxr
 github.com/shurcooL/go-goon v0.0.0-20170922171312-37c2f522c041/go.mod h1:N5mDOmsrJOB+vfqUK+7DmDyjhSLIIBnXo9lvZJj3MWQ=
 github.com/sourcegraph/campaignutils v0.0.0-20201124055807-2f9cfa9317e2 h1:MJu/6WzWdPegzYnZLb04IS0u4VyUpPIAHQyWT5i2vR8=
 github.com/sourcegraph/campaignutils v0.0.0-20201124055807-2f9cfa9317e2/go.mod h1:xm6i78Mk2t4DBLQDqEFc/3x6IPf7yYZCgbNaTQGhJHA=
-github.com/sourcegraph/codeintelutils v0.0.0-20210113171425-9ec641b48a8e h1:PdNc6fH0HHQ5xbnCwPkHuFdVCofQilFm9gG40fEQKms=
-github.com/sourcegraph/codeintelutils v0.0.0-20210113171425-9ec641b48a8e/go.mod h1:HplI8gRslTrTUUsSYwu28hSOderix7m5dHNca7xBzeo=
-github.com/sourcegraph/codeintelutils v0.0.0-20210118225004-6e6891d301ca h1:YotYereMYoAX/Q/2OS3zn2MJKgVbVdzQU65PRiaGHYE=
-github.com/sourcegraph/codeintelutils v0.0.0-20210118225004-6e6891d301ca/go.mod h1:HplI8gRslTrTUUsSYwu28hSOderix7m5dHNca7xBzeo=
 github.com/sourcegraph/codeintelutils v0.0.0-20210118231003-6698e102a8a1 h1:IPWruUo+BwPJqCHBVgjKxK6zTxMkOhwCSYpQ/jZHG/w=
 github.com/sourcegraph/codeintelutils v0.0.0-20210118231003-6698e102a8a1/go.mod h1:HplI8gRslTrTUUsSYwu28hSOderix7m5dHNca7xBzeo=
 github.com/sourcegraph/go-diff v0.6.1 h1:hmA1LzxW0n1c3Q4YbrFgg4P99GSnebYa3x8gr0HZqLQ=


### PR DESCRIPTION
This fixes #429 by switching `src validate` to use `yaml.v3`.

When trying to confirm that it still works, I found out that parsing the validate input as YAML didn't work for me, even without the change.

Both `yaml.v3` and `yaml.v2` assume that the fields in the YAML are in `snake_case` and need tags added to the struct fields to make it work with `camelCase`.

The `github.com/ghodss/yaml` works with `snake_case` and also supports the unmarshalling into a `*json.RawMessage`, which `yaml.v2` and `yaml.v3` don't support.

But since the goal was to only use a single YAML library I switched to `yaml.v3` and changed the code to work with it. I tested this locally and checked that everything's unmarshalled correctly.'


See the script here for how I explored this (and learned to curse YAML yet again).

<details>

```go
package main

import (
	"encoding/json"
	"fmt"

	ghodssyaml "github.com/ghodss/yaml"
	yamlv2 "gopkg.in/yaml.v2"
	yamlv3 "gopkg.in/yaml.v3"
)

type unmarshalFunc func([]byte, interface{}) error

func main() {
	funcs := []struct {
		name string
		fn   unmarshalFunc
	}{
		{name: "yaml.v2", fn: yamlv2.Unmarshal},
		{name: "yaml.v3", fn: yamlv3.Unmarshal},
		{name: "ghodss/yaml", fn: ghodssyaml.Unmarshal},
	}

	fmt.Printf("validationSpec:\n")
	for _, tt := range funcs {
		fmt.Printf("--- %s ---\n", tt.name)
		var vspec validationSpec
		if err := tt.fn([]byte(input), &vspec); err != nil {
			fmt.Printf("%s error: %s\n", tt.name, err)
		}
		if have, want := vspec.FirstAdmin.Email, "foo@example.com"; have != want {
			fmt.Printf("%s vspec.FirstAdmin.Email wrong. want=%q, have=%q\n", tt.name, want, have)
		}
		fmt.Printf("done.\n")
	}

	fmt.Printf("\n\nvalidationSpecWithCamelCaseTags:\n")
	for _, tt := range funcs {
		fmt.Printf("--- %s ---\n", tt.name)
		var vspec validationSpecWithCamelCaseTags
		if err := tt.fn([]byte(input), &vspec); err != nil {
			fmt.Printf("%s error: %s\n", tt.name, err)
		}
		if have, want := vspec.FirstAdmin.Email, "foo@example.com"; have != want {
			fmt.Printf("%s vspec.FirstAdmin.Email wrong. want=%q, have=%q\n", tt.name, want, have)
		}
		fmt.Printf("done.\n")
	}
}

type validationSpec struct {
	FirstAdmin struct {
		Email             string
		Username          string
		Password          string
		CreateAccessToken bool
	}
	WaitRepoCloned struct {
		Repo                     string
		MaxTries                 int
		SleepBetweenTriesSeconds int
	}
	SearchQuery     string
	ExternalService struct {
		Kind           string
		DisplayName    string
		Config         *json.RawMessage
		DeleteWhenDone bool
	}
}

type validationSpecWithCamelCaseTags struct {
	FirstAdmin struct {
		Email             string `yaml:"email"`
		Username          string `yaml:"username"`
		Password          string `yaml:"password"`
		CreateAccessToken bool   `yaml:"createAccessToken"`
	} `yaml:"firstAdmin"`
	WaitRepoCloned struct {
		Repo                     string `yaml:"repo"`
		MaxTries                 int    `yaml:"maxTries"`
		SleepBetweenTriesSeconds int    `yaml:"sleepBetweenTriesSecond"`
	} `yaml:"waitRepoCloned"`
	SearchQuery     string `yaml:"searchQuery"`
	ExternalService struct {
		Kind           string                 `yaml:"kind"`
		DisplayName    string                 `yaml:"displayName"`
		Config         map[string]interface{} `yaml:"config"`
		DeleteWhenDone bool                   `yaml:"deleteWhenDone"`
	} `yaml:"externalService"`
}

const input = `# creates the first admin user on a fresh install (skips creation if user exists)
firstAdmin:
    email: foo@example.com
    username: foo
    password: "{{ .admin_password }}"

# adds the specified code host
externalService:
  config:
    url: https://github.com
    token: "{{ .github_token }}"
    orgs: []
    repos:
      - sourcegraph-testing/zap
  kind: GITHUB
  displayName: footest
  # set to true if this code host config should be deleted at the end of validation
  deleteWhenDone: true

# checks maxTries if specified repo is cloned and waits sleepBetweenTriesSeconds between checks 
waitRepoCloned:
  repo: github.com/footest/foo
  maxTries: 5
  sleepBetweenTriesSeconds: 2

# performs the specified search and checks that at least one result is returned
searchQuery: repo:^github.com/footest/foo$ uniquelyFoo`
```
</details>

That prints:

```
validationSpec:
--- yaml.v2 ---
yaml.v2 vspec.FirstAdmin.Email wrong. want="foo@example.com", have=""
done.
--- yaml.v3 ---
yaml.v3 vspec.FirstAdmin.Email wrong. want="foo@example.com", have=""
done.
--- ghodss/yaml ---
done.


validationSpecWithCamelCaseTags:
--- yaml.v2 ---
done.
--- yaml.v3 ---
done.
--- ghodss/yaml ---
done.
```