### PR TITLE
campaigns: use the temp dir when mounting scripts in volume mode 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ All notable changes to `src-cli` are documented in this file.
 
 ### Fixed
 
+- Executing campaigns on macOS 11 with Docker 3.1 could fail when using a volume workspace. This has been fixed. [#436](https://github.com/sourcegraph/src-cli/pull/436)
+
 ### Removed
 
 ## 3.24.1

--- a/cmd/src/campaigns_common.go
+++ b/cmd/src/campaigns_common.go
@@ -224,7 +224,7 @@ func campaignsExecute(ctx context.Context, out *output.Output, svc *campaigns.Se
 	}
 
 	pending = campaignsCreatePending(out, "Preparing workspaces")
-	workspaceCreator := svc.NewWorkspaceCreator(ctx, flags.cacheDir, campaignSpec.Steps)
+	workspaceCreator := svc.NewWorkspaceCreator(ctx, flags.cacheDir, flags.tempDir, campaignSpec.Steps)
 	pending.VerboseLine(output.Linef("🚧", output.StyleSuccess, "Workspace creator: %T", workspaceCreator))
 	campaignsCompletePending(pending, "Prepared workspaces")
 

--- a/internal/campaigns/service.go
+++ b/internal/campaigns/service.go
@@ -222,7 +222,7 @@ func (svc *Service) NewWorkspaceCreator(ctx context.Context, dir string, steps [
 	}
 
 	if workspace == workspaceCreatorVolume {
-		return &dockerVolumeWorkspaceCreator{}
+		return &dockerVolumeWorkspaceCreator{tempDir: dir}
 	}
 	return &dockerBindWorkspaceCreator{dir: dir}
 }

--- a/internal/campaigns/service.go
+++ b/internal/campaigns/service.go
@@ -211,7 +211,7 @@ func (svc *Service) NewRepoFetcher(dir string, cleanArchives bool) RepoFetcher {
 	}
 }
 
-func (svc *Service) NewWorkspaceCreator(ctx context.Context, dir string, steps []Step) WorkspaceCreator {
+func (svc *Service) NewWorkspaceCreator(ctx context.Context, cacheDir, tempDir string, steps []Step) WorkspaceCreator {
 	var workspace workspaceCreatorType
 	if svc.workspace == "volume" {
 		workspace = workspaceCreatorVolume
@@ -222,9 +222,9 @@ func (svc *Service) NewWorkspaceCreator(ctx context.Context, dir string, steps [
 	}
 
 	if workspace == workspaceCreatorVolume {
-		return &dockerVolumeWorkspaceCreator{tempDir: dir}
+		return &dockerVolumeWorkspaceCreator{tempDir: tempDir}
 	}
-	return &dockerBindWorkspaceCreator{dir: dir}
+	return &dockerBindWorkspaceCreator{dir: cacheDir}
 }
 
 // dockerImageSet represents a set of Docker images that need to be pulled. The


### PR DESCRIPTION
@eseliger noticed this one: volume workspaces were mounting their run scripts from the OS temporary directory, which could cause problems on macOS 11 + Docker 3.1. (And probably other configurations, but it worked for me on macOS 10.15.)

It should be using the same temporary directory as everything else, so let's do that.