### PR TITLE
campaigns: temporary switch back to bind for non-root

### DIFF
--- a/internal/campaigns/workspace.go
+++ b/internal/campaigns/workspace.go
@@ -128,7 +128,7 @@ func detectBestWorkspaceCreator(ctx context.Context, steps []Step) workspaceCrea
 		}
 
 		uids[uid] = struct{}{}
-		if len(uids) > 1 {
+		if len(uids) > 1 || uid != 0 {
 			return workspaceCreatorBind
 		}
 	}

--- a/internal/campaigns/workspace_test.go
+++ b/internal/campaigns/workspace_test.go
@@ -34,14 +34,13 @@ func TestBestWorkspaceCreator(t *testing.T) {
 		"same user": {
 			behaviours: map[string]expect.Behaviour{
 				"foo": {Stdout: []byte("1000\n")},
-				"bar": {Stdout: []byte("1000\n")},
 			},
-			want: workspaceCreatorVolume,
+			want: workspaceCreatorBind,
 		},
 		"different user": {
 			behaviours: map[string]expect.Behaviour{
-				"foo": {Stdout: []byte("1000\n")},
-				"bar": {Stdout: []byte("0\n")},
+				"foo": {Stdout: []byte("0\n")},
+				"bar": {Stdout: []byte("1000\n")},
 			},
 			want: workspaceCreatorBind,
 		},


### PR DESCRIPTION
This can be reverted once we land #434.