### PR TITLE
Correctly abort on interrupt instead of going into endless loop

### DIFF
--- a/internal/campaigns/executor.go
+++ b/internal/campaigns/executor.go
@@ -192,10 +192,12 @@ func (x *executor) LogFiles() []string {
 }
 
 func (x *executor) Start(ctx context.Context) {
+	defer func() { close(x.doneEnqueuing) }()
+
 	for _, task := range x.tasks {
 		select {
 		case <-ctx.Done():
-			break
+			return
 		default:
 		}
 
@@ -215,8 +217,6 @@ func (x *executor) Start(ctx context.Context) {
 			}
 		}(task)
 	}
-
-	close(x.doneEnqueuing)
 }
 
 func (x *executor) Wait() ([]*ChangesetSpec, error) {


### PR DESCRIPTION
Running `:GoMetaLinter` just pointed me to this "ineffective break
statement" that I introduced in #328 with the following comment:

> It also makes sure that we don't enqueue more tasks/steps after being
> canceled: that's the code in `(*executor).Start()` that aborts the
> `Range` call if the context has been cancelled/timed-out and aborts
> execution of a task if the goroutine already blocked on
> `x.par.Acquire()`.

Well... turns out that wasn't the case, was it?

Instead the code only broke out of the `select` and continued trying to
acquire a lock.

I also suspect that this bug might have something to do with a customer
reporting that long-running containers are not stopped when hitting
Ctrl-C (https://github.com/sourcegraph/sourcegraph/issues/16026) even
after we thought the issue was fixed with #328. I'm not 100% sure on
this one though.