### PR TITLE
Handle ctx.Done() when waiting for steps to finish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ All notable changes to `src-cli` are documented in this file.
 
 ### Fixed
 
+- When `docker` becomes unresponsive `src campaign [apply|preview]` would get stuck and ignore Ctrl-C signals. That is now fixed.
+
 ### Removed
 
 ## 3.24.3

--- a/cmd/src/campaigns_common.go
+++ b/cmd/src/campaigns_common.go
@@ -357,7 +357,11 @@ func printExecutionError(out *output.Output, err error) {
 			if taskErr, ok := e.(campaigns.TaskExecutionErr); ok {
 				block.Write(formatTaskExecutionErr(taskErr))
 			} else {
-				block.Writef("%s%s", output.StyleBold, e.Error())
+				if err == context.Canceled {
+					block.Writef("%sAborting", output.StyleBold)
+				} else {
+					block.Writef("%s%s=%+v)", output.StyleBold, e.Error())
+				}
 			}
 		}
 

--- a/internal/campaigns/executor_test.go
+++ b/internal/campaigns/executor_test.go
@@ -325,7 +325,7 @@ repository_name=github.com/sourcegraph/src-cli`,
 				}
 
 				executor.Start(context.Background())
-				specs, err := executor.Wait()
+				specs, err := executor.Wait(context.Background())
 				if tc.wantErrInclude == "" && err != nil {
 					t.Fatalf("execution failed: %s", err)
 				}

--- a/internal/campaigns/service.go
+++ b/internal/campaigns/service.go
@@ -288,7 +288,7 @@ func (svc *Service) ExecuteCampaignSpec(ctx context.Context, repos []*graphql.Re
 	var errs *multierror.Error
 
 	x.Start(ctx)
-	specs, err := x.Wait()
+	specs, err := x.Wait(ctx)
 	if progress != nil {
 		x.LockedTaskStatuses(progress)
 		done <- struct{}{}


### PR DESCRIPTION
The `.Wait()` method didn't check `ctx.Done()` before and could instead
block on `x.par.Wait()`, waiting for a mutex.

I ran into this just now when my Docker became unresponsive and the
`docker run` in `(*dockerVolumeWorkspace).runScript` would block.

Ctrl-C didn't help and did *not* kill the docker process (why that
didn't happen is a separate question). But src-cli
also didn't exit because it was blocked waiting for that mutex.

So, this solves *another* case of src-cli becoming unresponsive.