### PR TITLE
Fix possible closed-channel-send panic

### DIFF
--- a/internal/campaigns/executor.go
+++ b/internal/campaigns/executor.go
@@ -222,7 +222,7 @@ func (x *executor) Start(ctx context.Context) {
 func (x *executor) Wait(ctx context.Context) ([]*ChangesetSpec, error) {
 	<-x.doneEnqueuing
 
-	result := make(chan error)
+	result := make(chan error, 1)
 
 	go func(ch chan error) {
 		ch <- x.par.Wait()

--- a/internal/campaigns/executor.go
+++ b/internal/campaigns/executor.go
@@ -223,14 +223,16 @@ func (x *executor) Wait(ctx context.Context) ([]*ChangesetSpec, error) {
 	<-x.doneEnqueuing
 
 	result := make(chan error)
-	defer func() { close(result) }()
 
-	go func(ch chan error) { ch <- x.par.Wait() }(result)
+	go func(ch chan error) {
+		ch <- x.par.Wait()
+	}(result)
 
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()
 	case err := <-result:
+		close(result)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
The previous code could cause a panic when `ctx.Done()` returns something, the outer function returns, the `defer` is triggered and the channel closed and _only then_ the `x.pair.Wait()` returns in the goroutine.