### PR TITLE
Make 'reachedTimeout' check more resilient

### DIFF
--- a/internal/campaigns/executor.go
+++ b/internal/campaigns/executor.go
@@ -410,7 +410,7 @@ func reachedTimeout(cmdCtx context.Context, err error) bool {
 		}
 	}
 
-	return errors.Is(err, context.DeadlineExceeded)
+	return errors.Is(errors.Cause(err), context.DeadlineExceeded)
 }
 
 func createChangesetSpecs(task *Task, result ExecutionResult, features featureFlags) ([]*ChangesetSpec, error) {


### PR DESCRIPTION
This fixes https://github.com/sourcegraph/src-cli/issues/416 (hopefully)