### PR TITLE
Check for branch duplicates after creating changeset specs

### DIFF
--- a/cmd/src/campaigns_common.go
+++ b/cmd/src/campaigns_common.go
@@ -268,6 +268,11 @@ func campaignsExecute(ctx context.Context, out *output.Output, svc *campaigns.Se
 		}()
 	}
 
+	err = svc.ValidateChangesetSpecs(repos, specs)
+	if err != nil {
+		return "", "", err
+	}
+
 	ids := make([]campaigns.ChangesetSpecID, len(specs))
 
 	if len(specs) > 0 {
@@ -362,7 +367,7 @@ func printExecutionError(out *output.Output, err error) {
 				if err == context.Canceled {
 					block.Writef("%sAborting", output.StyleBold)
 				} else {
-					block.Writef("%s%s=%+v)", output.StyleBold, e.Error())
+					block.Writef("%s%s", output.StyleBold, e.Error())
 				}
 			}
 		}

--- a/internal/campaigns/executor_test.go
+++ b/internal/campaigns/executor_test.go
@@ -400,13 +400,18 @@ repository_name=github.com/sourcegraph/src-cli`,
 
 				executor.Start(context.Background())
 				specs, err := executor.Wait(context.Background())
-				if tc.wantErrInclude == "" && err != nil {
-					t.Fatalf("execution failed: %s", err)
-				}
-				if err != nil && !strings.Contains(err.Error(), tc.wantErrInclude) {
-					t.Errorf("wrong error. have=%q want included=%q", err, tc.wantErrInclude)
-				}
-				if tc.wantErrInclude != "" {
+				if tc.wantErrInclude == "" {
+					if err != nil {
+						t.Fatalf("execution failed: %s", err)
+					}
+				} else {
+					if err == nil {
+						t.Fatalf("expected error to include %q, but got no error", tc.wantErrInclude)
+					} else {
+						if !strings.Contains(err.Error(), tc.wantErrInclude) {
+							t.Errorf("wrong error. have=%q want included=%q", err, tc.wantErrInclude)
+						}
+					}
 					return
 				}
 

--- a/internal/campaigns/service.go
+++ b/internal/campaigns/service.go
@@ -448,26 +448,22 @@ func (svc *Service) ValidateChangesetSpecs(repos []*graphql.Repository, specs []
 	}
 
 	if len(duplicates) > 0 {
-		return &duplicateBranchErr{fooduplicates: duplicates}
+		return &duplicateBranchesErr{duplicates: duplicates}
 	}
 
 	return nil
 }
 
-type duplicateBranchErr struct {
-	repository *graphql.Repository
-	headRef    string
-	duplicates int
-
-	fooduplicates map[*graphql.Repository]map[string]int
+type duplicateBranchesErr struct {
+	duplicates map[*graphql.Repository]map[string]int
 }
 
-func (e *duplicateBranchErr) Error() string {
+func (e *duplicateBranchesErr) Error() string {
 	var out strings.Builder
 
 	fmt.Fprintf(&out, "Multiple changeset specs have the same branch:\n\n")
 
-	for repo, branches := range e.fooduplicates {
+	for repo, branches := range e.duplicates {
 		for branch, duplicates := range branches {
 			branch = strings.TrimPrefix(branch, "refs/heads/")
 			fmt.Fprintf(&out, "\t* %s: %d changeset specs have the branch %q\n", repo.Name, duplicates, branch)

--- a/internal/campaigns/service.go
+++ b/internal/campaigns/service.go
@@ -415,6 +415,70 @@ func (svc *Service) ExecuteCampaignSpec(ctx context.Context, opts ExecutorOpts, 
 	return specs, x.LogFiles(), errs.ErrorOrNil()
 }
 
+func (svc *Service) ValidateChangesetSpecs(repos []*graphql.Repository, specs []*ChangesetSpec) error {
+	repoByID := make(map[string]*graphql.Repository, len(repos))
+	for _, repo := range repos {
+		repoByID[repo.ID] = repo
+	}
+
+	byRepoAndBranch := make(map[string]map[string][]*ChangesetSpec)
+	for _, spec := range specs {
+		_, ok := byRepoAndBranch[spec.HeadRepository]
+		if !ok {
+			byRepoAndBranch[spec.HeadRepository] = make(map[string][]*ChangesetSpec)
+		}
+
+		byRepoAndBranch[spec.HeadRepository][spec.HeadRef] = append(byRepoAndBranch[spec.HeadRepository][spec.HeadRef], spec)
+	}
+
+	duplicates := make(map[*graphql.Repository]map[string]int)
+	for repoID, specsByBranch := range byRepoAndBranch {
+		for branch, specs := range specsByBranch {
+			if len(specs) < 2 {
+				continue
+			}
+
+			r := repoByID[repoID]
+			if _, ok := duplicates[r]; !ok {
+				duplicates[r] = make(map[string]int)
+			}
+
+			duplicates[r][branch] = len(specs)
+		}
+	}
+
+	if len(duplicates) > 0 {
+		return &duplicateBranchErr{fooduplicates: duplicates}
+	}
+
+	return nil
+}
+
+type duplicateBranchErr struct {
+	repository *graphql.Repository
+	headRef    string
+	duplicates int
+
+	fooduplicates map[*graphql.Repository]map[string]int
+}
+
+func (e *duplicateBranchErr) Error() string {
+	var out strings.Builder
+
+	fmt.Fprintf(&out, "Multiple changeset specs have the same branch:\n\n")
+
+	for repo, branches := range e.fooduplicates {
+		for branch, duplicates := range branches {
+			branch = strings.TrimPrefix(branch, "refs/heads/")
+			fmt.Fprintf(&out, "\t* %s: %d changeset specs have the branch %q\n", repo.Name, duplicates, branch)
+		}
+	}
+
+	fmt.Fprint(&out, "\nMake sure that the changesetTemplate.branch field in the campaign spec produces unique values for each changeset in a single repository and rerun this command.")
+
+	return out.String()
+}
+
 func (svc *Service) ParseCampaignSpec(in io.Reader) (*CampaignSpec, string, error) {
 	data, err := ioutil.ReadAll(in)
 	if err != nil {


### PR DESCRIPTION
This is a follow-up to #442 and ensures that changeset specs are not
getting silently lost by validating that multiple changeset specs in the
same repository have different branches.

I decided to make this a separate step _after_ the execution of the
steps so that users can leverage the cache. That allows them to change
the campaign spec and then rerun the command after they get this error,
vs. the execution being aborted after running into this error (if we'd
do the check inside executor).

Screenshot:

![image](https://user-images.githubusercontent.com/1185253/106462154-ff3ca000-6495-11eb-9157-fd96ded9b866.png)
