### PR TITLE
Keep repo archives cached for later executed tasks

### DIFF
--- a/cmd/src/campaigns_common.go
+++ b/cmd/src/campaigns_common.go
@@ -235,10 +235,15 @@ func campaignsExecute(ctx context.Context, out *output.Output, svc *campaigns.Se
 	pending.VerboseLine(output.Linef("🚧", output.StyleSuccess, "Workspace creator: %T", workspaceCreator))
 	campaignsCompletePending(pending, "Prepared workspaces")
 
+	fetcher := svc.NewRepoFetcher(flags.cacheDir, flags.cleanArchives)
+	for _, task := range tasks {
+		fetcher.MarkForLaterUse(task.Repository)
+	}
+
 	opts := campaigns.ExecutorOpts{
 		Cache:       svc.NewExecutionCache(flags.cacheDir),
 		Creator:     workspaceCreator,
-		RepoFetcher: svc.NewRepoFetcher(flags.cacheDir, flags.cleanArchives),
+		RepoFetcher: fetcher,
 		ClearCache:  flags.clearCache,
 		KeepLogs:    flags.keepLogs,
 		Timeout:     flags.timeout,

--- a/internal/campaigns/repo_fetcher_test.go
+++ b/internal/campaigns/repo_fetcher_test.go
@@ -58,6 +58,11 @@ func TestRepoFetcher_Fetch(t *testing.T) {
 			deleteZips: false,
 		}
 
+		// We're going to call Fetch three times
+		for i := 0; i < 3; i++ {
+			rf.MarkForLaterUse(repo)
+		}
+
 		rz, err := rf.Fetch(context.Background(), repo)
 		if err != nil {
 			t.Errorf("unexpected error: %s", err)


### PR DESCRIPTION
This is a follow-up to fix the issue discovered by @eseliger here: https://github.com/sourcegraph/src-cli/pull/442#discussion_r566840914

Short version: the previous implementation would only avoid deleting an
archive if there were *currently active tasks* holding references to it.
If tasks that need the same archive would execute sequentially, though,
the archive would be downloaded, deleted, downloaded again.

This here is a fix for the issue by first marking all repository
archives for later use and only once all marks have been turned into
references and those references have been closed is the archive deleted.