### PR TITLE
Alternative approach to keeping archives cached

### DIFF
--- a/cmd/src/campaigns_common.go
+++ b/cmd/src/campaigns_common.go
@@ -235,10 +235,14 @@ func campaignsExecute(ctx context.Context, out *output.Output, svc *campaigns.Se
 	pending.VerboseLine(output.Linef("🚧", output.StyleSuccess, "Workspace creator: %T", workspaceCreator))
 	campaignsCompletePending(pending, "Prepared workspaces")
 
+	fetcher := svc.NewRepoFetcher(flags.cacheDir, flags.cleanArchives)
+	for _, task := range tasks {
+		task.Archive = fetcher.Checkout(task.Repository)
+	}
+
 	opts := campaigns.ExecutorOpts{
 		Cache:       svc.NewExecutionCache(flags.cacheDir),
 		Creator:     workspaceCreator,
-		RepoFetcher: svc.NewRepoFetcher(flags.cacheDir, flags.cleanArchives),
 		ClearCache:  flags.clearCache,
 		KeepLogs:    flags.keepLogs,
 		Timeout:     flags.timeout,

--- a/internal/campaigns/executor_test.go
+++ b/internal/campaigns/executor_test.go
@@ -361,12 +361,8 @@ repository_name=github.com/sourcegraph/src-cli`,
 			cache := newInMemoryExecutionCache()
 			creator := &dockerBindWorkspaceCreator{dir: testTempDir}
 			opts := ExecutorOpts{
-				Cache:   cache,
-				Creator: creator,
-				RepoFetcher: &repoFetcher{
-					client: client,
-					dir:    testTempDir,
-				},
+				Cache:       cache,
+				Creator:     creator,
 				TempDir:     testTempDir,
 				Parallelism: runtime.GOMAXPROCS(0),
 				Timeout:     tc.executorTimeout,
@@ -375,6 +371,10 @@ repository_name=github.com/sourcegraph/src-cli`,
 				opts.Timeout = 30 * time.Second
 			}
 
+			repoFetcher := &repoFetcher{
+				client: client,
+				dir:    testTempDir,
+			}
 			// execute contains the actual logic running the tasks on an
 			// executor. We'll run this multiple times to cover both the cache
 			// and non-cache code paths.
@@ -395,6 +395,7 @@ repository_name=github.com/sourcegraph/src-cli`,
 					}
 
 					task.Steps = tc.steps
+					task.Archive = repoFetcher.Checkout(task.Repository)
 					executor.AddTask(task)
 				}
 

--- a/internal/campaigns/repo_fetcher.go
+++ b/internal/campaigns/repo_fetcher.go
@@ -18,10 +18,10 @@ import (
 // RepoFetcher abstracts the process of retrieving an archive for the given
 // repository.
 type RepoFetcher interface {
-	// Fetch must retrieve the given repository and return it as a RepoZip.
-	// This will generally imply that the file should be written to a temporary
-	// location on the filesystem.
-	Fetch(context.Context, *graphql.Repository) (RepoZip, error)
+	// Checkout returns a RepoZip for the given repository that's possibly
+	// unfetched. Users need to call `Fetch()` on the RepoZip before using it
+	// and `Close()` once they're done using it.
+	Checkout(*graphql.Repository) RepoZip
 }
 
 // repoFetcher is the concrete implementation of the RepoFetcher interface used
@@ -37,8 +37,37 @@ type repoFetcher struct {
 
 var _ RepoFetcher = &repoFetcher{}
 
+func (rf *repoFetcher) zipFor(repo *graphql.Repository) *repoZip {
+	rf.zipsMu.Lock()
+	defer rf.zipsMu.Unlock()
+
+	if rf.zips == nil {
+		rf.zips = make(map[string]*repoZip)
+	}
+
+	path := filepath.Join(rf.dir, repo.Slug()+".zip")
+	zip, ok := rf.zips[path]
+	if !ok {
+		zip = &repoZip{path: path, repo: repo, client: rf.client, deleteOnClose: rf.deleteZips}
+		rf.zips[path] = zip
+	}
+	return zip
+}
+
+func (rf *repoFetcher) Checkout(repo *graphql.Repository) RepoZip {
+	zip := rf.zipFor(repo)
+	zip.mu.Lock()
+	defer zip.mu.Unlock()
+
+	zip.marks += 1
+	return zip
+}
+
 // RepoZip implementations represent a downloaded repository archive.
 type RepoZip interface {
+	// Fetch downloads the archive if it's not on disk yet.
+	Fetch(context.Context) error
+
 	// Close must finalise the downloaded archive. If one or more temporary
 	// files were created, they should be deleted here.
 	Close() error
@@ -47,74 +76,23 @@ type RepoZip interface {
 	Path() string
 }
 
+var _ RepoZip = &repoZip{}
+
 // repoZip is the concrete implementation of the RepoZip interface used outside
 // of tests.
 type repoZip struct {
-	path    string
-	fetcher *repoFetcher
+	mu sync.Mutex
 
-	mu         sync.Mutex
+	deleteOnClose bool
+	path          string
+	repo          *graphql.Repository
+
+	client api.Client
+
+	// references is the number of *active* tasks that currently use the archive.
 	references int
-}
-
-var _ RepoZip = &repoZip{}
-
-func (rf *repoFetcher) zipFor(path string) *repoZip {
-	rf.zipsMu.Lock()
-	defer rf.zipsMu.Unlock()
-
-	if rf.zips == nil {
-		rf.zips = make(map[string]*repoZip)
-	}
-
-	zip, ok := rf.zips[path]
-	if !ok {
-		zip = &repoZip{path: path, fetcher: rf}
-		rf.zips[path] = zip
-	}
-	return zip
-}
-
-func (rf *repoFetcher) Fetch(ctx context.Context, repo *graphql.Repository) (RepoZip, error) {
-	path := filepath.Join(rf.dir, repo.Slug()+".zip")
-
-	zip := rf.zipFor(path)
-	zip.mu.Lock()
-	defer zip.mu.Unlock()
-
-	// Someone already fetched it
-	if zip.references > 0 {
-		zip.references += 1
-		return zip, nil
-	}
-
-	exists, err := fileExists(zip.path)
-	if err != nil {
-		return nil, err
-	}
-
-	if !exists {
-		// Unlike the mkdirAll() calls elsewhere in this file, this is only
-		// giving us a temporary place on the filesystem to keep the archive.
-		// Since it's never mounted into the containers being run, we can keep
-		// these directories 0700 without issue.
-		if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
-			return nil, err
-		}
-
-		err = fetchRepositoryArchive(ctx, rf.client, repo, path)
-		if err != nil {
-			// If the context got cancelled, or we ran out of disk space, or ...
-			// while we were downloading the file, we remove the partially
-			// downloaded file.
-			os.Remove(path)
-
-			return nil, errors.Wrap(err, "fetching ZIP archive")
-		}
-	}
-
-	zip.references += 1
-	return zip, nil
+	// marks is the number of tasks that *will* make use of the archive.
+	marks int
 }
 
 func (rz *repoZip) Close() error {
@@ -122,7 +100,7 @@ func (rz *repoZip) Close() error {
 	defer rz.mu.Unlock()
 
 	rz.references -= 1
-	if rz.references == 0 && rz.fetcher.deleteZips {
+	if rz.references == 0 && rz.marks == 0 && rz.deleteOnClose {
 		return os.Remove(rz.path)
 	}
 
@@ -131,6 +109,47 @@ func (rz *repoZip) Close() error {
 
 func (rz *repoZip) Path() string {
 	return rz.path
+}
+
+func (rz *repoZip) Fetch(ctx context.Context) error {
+	rz.mu.Lock()
+	defer rz.mu.Unlock()
+
+	// Someone already fetched it
+	if rz.references > 0 {
+		rz.references += 1
+		rz.marks -= 1
+		return nil
+	}
+
+	exists, err := fileExists(rz.path)
+	if err != nil {
+		return err
+	}
+
+	if !exists {
+		// Unlike the mkdirAll() calls elsewhere in this file, this is only
+		// giving us a temporary place on the filesystem to keep the archive.
+		// Since it's never mounted into the containers being run, we can keep
+		// these directories 0700 without issue.
+		if err := os.MkdirAll(filepath.Dir(rz.path), 0700); err != nil {
+			return err
+		}
+
+		err = fetchRepositoryArchive(ctx, rz.client, rz.repo, rz.path)
+		if err != nil {
+			// If the context got cancelled, or we ran out of disk space, or ...
+			// while we were downloading the file, we remove the partially
+			// downloaded file.
+			os.Remove(rz.path)
+
+			return errors.Wrap(err, "fetching ZIP archive")
+		}
+	}
+
+	rz.references += 1
+	rz.marks -= 1
+	return nil
 }
 
 func fetchRepositoryArchive(ctx context.Context, client api.Client, repo *graphql.Repository, dest string) error {

--- a/internal/campaigns/run_steps.go
+++ b/internal/campaigns/run_steps.go
@@ -36,7 +36,7 @@ type executionResult struct {
 }
 
 type executionOpts struct {
-	fetcher RepoFetcher
+	archive RepoZip
 
 	wc   WorkspaceCreator
 	path string
@@ -52,14 +52,14 @@ type executionOpts struct {
 
 func runSteps(ctx context.Context, opts *executionOpts) (result executionResult, err error) {
 	opts.reportProgress("Downloading archive")
-	zip, err := opts.fetcher.Fetch(ctx, opts.repo)
+	err = opts.archive.Fetch(ctx)
 	if err != nil {
 		return executionResult{}, errors.Wrap(err, "fetching repo")
 	}
-	defer zip.Close()
+	defer opts.archive.Close()
 
 	opts.reportProgress("Initializing workspace")
-	workspace, err := opts.wc.Create(ctx, opts.repo, opts.steps, zip.Path())
+	workspace, err := opts.wc.Create(ctx, opts.repo, opts.steps, opts.archive.Path())
 	if err != nil {
 		return executionResult{}, errors.Wrap(err, "creating workspace")
 	}


### PR DESCRIPTION
This is a second, alterantive approach to https://github.com/sourcegraph/src-cli/pull/449 for keeping archives cached across different executions.

It models `RepoZip` as a [thunk](https://en.wikipedia.org/wiki/Thunk) in a way: `RepoFetcher.Checkout()` returns a `RepoZip` that's passed around with the `Task`. Once all `Tasks` have called `Fetch()` and `Close()` only then the archive is cleaned up.