### PR TITLE
Link to troubleshooting docs when src campaign apply|preview fails

### DIFF
--- a/cmd/src/campaigns_common.go
+++ b/cmd/src/campaigns_common.go
@@ -380,6 +380,8 @@ func printExecutionError(out *output.Output, err error) {
 		writeErrs([]error{err})
 	}
 
+	out.Write("")
+	out.WriteLine(output.Line(output.EmojiLightbulb, output.StyleSuggestion, "The troubleshooting documentation can help to narrow down the cause of the errors: https://docs.sourcegraph.com/campaigns/references/troubleshooting"))
 }
 
 func flattenErrs(err error) (result []error) {

--- a/internal/output/emoji.go
+++ b/internal/output/emoji.go
@@ -2,7 +2,8 @@ package output
 
 // Standard emoji for use in output.
 const (
-	EmojiFailure = "❌"
-	EmojiWarning = "❗️"
-	EmojiSuccess = "✅"
+	EmojiFailure   = "❌"
+	EmojiWarning   = "❗️"
+	EmojiSuccess   = "✅"
+	EmojiLightbulb = "💡"
 )

--- a/internal/output/style.go
+++ b/internal/output/style.go
@@ -25,11 +25,12 @@ type style struct{ code string }
 func (s *style) String() string { return s.code }
 
 var (
-	StyleReset   = &style{"\033[0m"}
-	StyleLogo    = Fg256Color(57)
-	StylePending = Fg256Color(4)
-	StyleWarning = Fg256Color(124)
-	StyleSuccess = Fg256Color(2)
+	StyleReset      = &style{"\033[0m"}
+	StyleLogo       = Fg256Color(57)
+	StylePending    = Fg256Color(4)
+	StyleWarning    = Fg256Color(124)
+	StyleSuccess    = Fg256Color(2)
+	StyleSuggestion = Fg256Color(244)
 
 	StyleBold      = &style{"\033[1m"}
 	StyleItalic    = &style{"\033[3m"}


### PR DESCRIPTION
This fixes https://github.com/sourcegraph/sourcegraph/issues/17259, but
contrary to what I stated in the original ticket, I think it makes more
sense to always link to these docs.

Why?

1. It's two lines. It doesn't hurt.
2. It's really tricky to find out exactly when to link to the docs and
   when not. Especially since running the steps could result in an error
   that could be fixed through the troubleshooting guide (example:
   broken docker setup).


---

### Screenshots

<img width="892" alt="screenshot_2021-02-01_16 24 59@2x" src="https://user-images.githubusercontent.com/1185253/106479557-be02bb00-64aa-11eb-9837-97e585e1fbdf.png">
<img width="892" alt="screenshot_2021-02-01_16 25 28@2x" src="https://user-images.githubusercontent.com/1185253/106479566-c1964200-64aa-11eb-8bb6-feb5ba49f112.png">
