### PR TITLE
campaigns: wrap the troubleshooting suggestion

### DIFF
--- a/cmd/src/campaigns_common.go
+++ b/cmd/src/campaigns_common.go
@@ -385,7 +385,10 @@ func printExecutionError(out *output.Output, err error) {
 	}
 
 	out.Write("")
-	out.WriteLine(output.Line(output.EmojiLightbulb, output.StyleSuggestion, "The troubleshooting documentation can help to narrow down the cause of the errors: https://docs.sourcegraph.com/campaigns/references/troubleshooting"))
+
+	block := out.Block(output.Line(output.EmojiLightbulb, output.StyleSuggestion, "The troubleshooting documentation can help to narrow down the cause of the errors:"))
+	block.WriteLine(output.Line("", output.StyleSuggestion, "https://docs.sourcegraph.com/campaigns/references/troubleshooting"))
+	block.Close()
 }
 
 func flattenErrs(err error) (result []error) {


### PR DESCRIPTION
I like the troubleshooting suggestion added in #451, but I'd prefer to wrap the output, since it's quite wide right now:

![image](https://user-images.githubusercontent.com/229984/106540680-4a19e000-64b5-11eb-8574-3ac0fda6ddc8.png)
