### PR TITLE
output: hide the cursor when updating

### DIFF
--- a/internal/output/block.go
+++ b/internal/output/block.go
@@ -34,8 +34,8 @@ func newBlock(indent int, o *Output) *Block {
 }
 
 func (b *Block) Close() {
-	b.unwrapped.lock.Lock()
-	defer b.unwrapped.lock.Unlock()
+	b.unwrapped.Lock()
+	defer b.unwrapped.Unlock()
 
 	// This is a little tricky: output from Writer methods includes a trailing
 	// newline, so we need to trim that so we don't output extra blank lines.

--- a/internal/output/pending_tty.go
+++ b/internal/output/pending_tty.go
@@ -33,8 +33,8 @@ func (p *pendingTTY) VerboseLine(line FancyLine) {
 }
 
 func (p *pendingTTY) Write(s string) {
-	p.o.lock.Lock()
-	defer p.o.lock.Unlock()
+	p.o.Lock()
+	defer p.o.Unlock()
 
 	p.o.moveUp(1)
 	p.o.clearCurrentLine()
@@ -43,8 +43,8 @@ func (p *pendingTTY) Write(s string) {
 }
 
 func (p *pendingTTY) Writef(format string, args ...interface{}) {
-	p.o.lock.Lock()
-	defer p.o.lock.Unlock()
+	p.o.Lock()
+	defer p.o.Unlock()
 
 	p.o.moveUp(1)
 	p.o.clearCurrentLine()
@@ -54,8 +54,8 @@ func (p *pendingTTY) Writef(format string, args ...interface{}) {
 }
 
 func (p *pendingTTY) WriteLine(line FancyLine) {
-	p.o.lock.Lock()
-	defer p.o.lock.Unlock()
+	p.o.Lock()
+	defer p.o.Unlock()
 
 	p.o.moveUp(1)
 	p.o.clearCurrentLine()
@@ -64,8 +64,8 @@ func (p *pendingTTY) WriteLine(line FancyLine) {
 }
 
 func (p *pendingTTY) Update(s string) {
-	p.o.lock.Lock()
-	defer p.o.lock.Unlock()
+	p.o.Lock()
+	defer p.o.Unlock()
 
 	p.line.format = "%s"
 	p.line.args = []interface{}{s}
@@ -76,8 +76,8 @@ func (p *pendingTTY) Update(s string) {
 }
 
 func (p *pendingTTY) Updatef(format string, args ...interface{}) {
-	p.o.lock.Lock()
-	defer p.o.lock.Unlock()
+	p.o.Lock()
+	defer p.o.Unlock()
 
 	p.line.format = format
 	p.line.args = args
@@ -90,8 +90,8 @@ func (p *pendingTTY) Updatef(format string, args ...interface{}) {
 func (p *pendingTTY) Complete(message FancyLine) {
 	p.spinner.stop()
 
-	p.o.lock.Lock()
-	defer p.o.lock.Unlock()
+	p.o.Lock()
+	defer p.o.Unlock()
 
 	p.o.moveUp(1)
 	p.o.clearCurrentLine()
@@ -103,8 +103,8 @@ func (p *pendingTTY) Close() { p.Destroy() }
 func (p *pendingTTY) Destroy() {
 	p.spinner.stop()
 
-	p.o.lock.Lock()
-	defer p.o.lock.Unlock()
+	p.o.Lock()
+	defer p.o.Unlock()
 
 	p.o.moveUp(1)
 	p.o.clearCurrentLine()
@@ -122,8 +122,8 @@ func newPendingTTY(message FancyLine, o *Output) *pendingTTY {
 	go func() {
 		for s := range p.spinner.C {
 			func() {
-				p.o.lock.Lock()
-				defer p.o.lock.Unlock()
+				p.o.Lock()
+				defer p.o.Unlock()
 
 				p.updateEmoji(s)
 

--- a/internal/output/progress_tty.go
+++ b/internal/output/progress_tty.go
@@ -30,8 +30,8 @@ type progressTTY struct {
 func (p *progressTTY) Complete() {
 	p.spinner.stop()
 
-	p.o.lock.Lock()
-	defer p.o.lock.Unlock()
+	p.o.Lock()
+	defer p.o.Unlock()
 
 	for _, bar := range p.bars {
 		bar.Value = bar.Max
@@ -44,8 +44,8 @@ func (p *progressTTY) Close() { p.Destroy() }
 func (p *progressTTY) Destroy() {
 	p.spinner.stop()
 
-	p.o.lock.Lock()
-	defer p.o.lock.Unlock()
+	p.o.Lock()
+	defer p.o.Unlock()
 
 	p.moveToOrigin()
 	for i := 0; i < len(p.bars); i += 1 {
@@ -57,8 +57,8 @@ func (p *progressTTY) Destroy() {
 }
 
 func (p *progressTTY) SetLabel(i int, label string) {
-	p.o.lock.Lock()
-	defer p.o.lock.Unlock()
+	p.o.Lock()
+	defer p.o.Unlock()
 
 	p.bars[i].Label = label
 	p.bars[i].labelWidth = runewidth.StringWidth(label)
@@ -66,8 +66,8 @@ func (p *progressTTY) SetLabel(i int, label string) {
 }
 
 func (p *progressTTY) SetLabelAndRecalc(i int, label string) {
-	p.o.lock.Lock()
-	defer p.o.lock.Unlock()
+	p.o.Lock()
+	defer p.o.Unlock()
 
 	p.bars[i].Label = label
 	p.bars[i].labelWidth = runewidth.StringWidth(label)
@@ -77,8 +77,8 @@ func (p *progressTTY) SetLabelAndRecalc(i int, label string) {
 }
 
 func (p *progressTTY) SetValue(i int, v float64) {
-	p.o.lock.Lock()
-	defer p.o.lock.Unlock()
+	p.o.Lock()
+	defer p.o.Unlock()
 
 	p.bars[i].Value = v
 	p.drawInSitu()
@@ -103,8 +103,8 @@ func (p *progressTTY) VerboseLine(line FancyLine) {
 }
 
 func (p *progressTTY) Write(s string) {
-	p.o.lock.Lock()
-	defer p.o.lock.Unlock()
+	p.o.Lock()
+	defer p.o.Unlock()
 
 	p.moveToOrigin()
 	p.o.clearCurrentLine()
@@ -113,8 +113,8 @@ func (p *progressTTY) Write(s string) {
 }
 
 func (p *progressTTY) Writef(format string, args ...interface{}) {
-	p.o.lock.Lock()
-	defer p.o.lock.Unlock()
+	p.o.Lock()
+	defer p.o.Unlock()
 
 	p.moveToOrigin()
 	p.o.clearCurrentLine()
@@ -124,8 +124,8 @@ func (p *progressTTY) Writef(format string, args ...interface{}) {
 }
 
 func (p *progressTTY) WriteLine(line FancyLine) {
-	p.o.lock.Lock()
-	defer p.o.lock.Unlock()
+	p.o.Lock()
+	defer p.o.Unlock()
 
 	p.moveToOrigin()
 	p.o.clearCurrentLine()
@@ -151,8 +151,8 @@ func newProgressTTY(bars []*ProgressBar, o *Output, opts *ProgressOpts) *progres
 	p.determineEmojiWidth()
 	p.determineLabelWidth()
 
-	p.o.lock.Lock()
-	defer p.o.lock.Unlock()
+	p.o.Lock()
+	defer p.o.Unlock()
 
 	p.draw()
 
@@ -165,8 +165,8 @@ func newProgressTTY(bars []*ProgressBar, o *Output, opts *ProgressOpts) *progres
 			func() {
 				p.pendingEmoji = s
 
-				p.o.lock.Lock()
-				defer p.o.lock.Unlock()
+				p.o.Lock()
+				defer p.o.Unlock()
 
 				p.moveToOrigin()
 				p.draw()

--- a/internal/output/progress_with_status_bars_tty.go
+++ b/internal/output/progress_with_status_bars_tty.go
@@ -29,8 +29,8 @@ func newProgressWithStatusBarsTTY(bars []*ProgressBar, statusBars []*StatusBar, 
 	p.determineLabelWidth()
 	p.determineStatusBarLabelWidth()
 
-	p.o.lock.Lock()
-	defer p.o.lock.Unlock()
+	p.o.Lock()
+	defer p.o.Unlock()
 
 	p.draw()
 
@@ -43,8 +43,8 @@ func newProgressWithStatusBarsTTY(bars []*ProgressBar, statusBars []*StatusBar, 
 			func() {
 				p.pendingEmoji = s
 
-				p.o.lock.Lock()
-				defer p.o.lock.Unlock()
+				p.o.Lock()
+				defer p.o.Unlock()
 
 				p.moveToOrigin()
 				p.draw()
@@ -68,8 +68,8 @@ func (p *progressWithStatusBarsTTY) Close() { p.Destroy() }
 func (p *progressWithStatusBarsTTY) Destroy() {
 	p.spinner.stop()
 
-	p.o.lock.Lock()
-	defer p.o.lock.Unlock()
+	p.o.Lock()
+	defer p.o.Unlock()
 
 	p.moveToOrigin()
 
@@ -84,8 +84,8 @@ func (p *progressWithStatusBarsTTY) Destroy() {
 func (p *progressWithStatusBarsTTY) Complete() {
 	p.spinner.stop()
 
-	p.o.lock.Lock()
-	defer p.o.lock.Unlock()
+	p.o.Lock()
+	defer p.o.Unlock()
 
 	// +1 because of the line between progress and status bars
 	for i := 0; i < p.numPrintedStatusBars+1; i += 1 {
@@ -107,8 +107,8 @@ func (p *progressWithStatusBarsTTY) lines() int {
 }
 
 func (p *progressWithStatusBarsTTY) SetLabel(i int, label string) {
-	p.o.lock.Lock()
-	defer p.o.lock.Unlock()
+	p.o.Lock()
+	defer p.o.Unlock()
 
 	p.bars[i].Label = label
 	p.bars[i].labelWidth = runewidth.StringWidth(label)
@@ -116,16 +116,16 @@ func (p *progressWithStatusBarsTTY) SetLabel(i int, label string) {
 }
 
 func (p *progressWithStatusBarsTTY) SetValue(i int, v float64) {
-	p.o.lock.Lock()
-	defer p.o.lock.Unlock()
+	p.o.Lock()
+	defer p.o.Unlock()
 
 	p.bars[i].Value = v
 	p.drawInSitu()
 }
 
 func (p *progressWithStatusBarsTTY) StatusBarResetf(i int, label, format string, args ...interface{}) {
-	p.o.lock.Lock()
-	defer p.o.lock.Unlock()
+	p.o.Lock()
+	defer p.o.Unlock()
 
 	if p.statusBars[i] != nil {
 		p.statusBars[i].Resetf(label, format, args...)
@@ -136,8 +136,8 @@ func (p *progressWithStatusBarsTTY) StatusBarResetf(i int, label, format string,
 }
 
 func (p *progressWithStatusBarsTTY) StatusBarUpdatef(i int, format string, args ...interface{}) {
-	p.o.lock.Lock()
-	defer p.o.lock.Unlock()
+	p.o.Lock()
+	defer p.o.Unlock()
 
 	if p.statusBars[i] != nil {
 		p.statusBars[i].Updatef(format, args...)
@@ -147,8 +147,8 @@ func (p *progressWithStatusBarsTTY) StatusBarUpdatef(i int, format string, args 
 }
 
 func (p *progressWithStatusBarsTTY) StatusBarCompletef(i int, format string, args ...interface{}) {
-	p.o.lock.Lock()
-	defer p.o.lock.Unlock()
+	p.o.Lock()
+	defer p.o.Unlock()
 
 	if p.statusBars[i] != nil {
 		p.statusBars[i].Completef(format, args...)
@@ -158,8 +158,8 @@ func (p *progressWithStatusBarsTTY) StatusBarCompletef(i int, format string, arg
 }
 
 func (p *progressWithStatusBarsTTY) StatusBarFailf(i int, format string, args ...interface{}) {
-	p.o.lock.Lock()
-	defer p.o.lock.Unlock()
+	p.o.Lock()
+	defer p.o.Unlock()
 
 	if p.statusBars[i] != nil {
 		p.statusBars[i].Failf(format, args...)
@@ -273,8 +273,8 @@ func (p *progressWithStatusBarsTTY) VerboseLine(line FancyLine) {
 }
 
 func (p *progressWithStatusBarsTTY) Write(s string) {
-	p.o.lock.Lock()
-	defer p.o.lock.Unlock()
+	p.o.Lock()
+	defer p.o.Unlock()
 
 	p.moveToOrigin()
 	p.o.clearCurrentLine()
@@ -283,8 +283,8 @@ func (p *progressWithStatusBarsTTY) Write(s string) {
 }
 
 func (p *progressWithStatusBarsTTY) Writef(format string, args ...interface{}) {
-	p.o.lock.Lock()
-	defer p.o.lock.Unlock()
+	p.o.Lock()
+	defer p.o.Unlock()
 
 	p.moveToOrigin()
 	p.o.clearCurrentLine()
@@ -294,8 +294,8 @@ func (p *progressWithStatusBarsTTY) Writef(format string, args ...interface{}) {
 }
 
 func (p *progressWithStatusBarsTTY) WriteLine(line FancyLine) {
-	p.o.lock.Lock()
-	defer p.o.lock.Unlock()
+	p.o.Lock()
+	defer p.o.Unlock()
 
 	p.moveToOrigin()
 	p.o.clearCurrentLine()


### PR DESCRIPTION
I actually like the locking change here on `Output` as well, regardless of the merits of the cursor handling change.

This seems to improve things a bit on Windows and some, but not all, Linux terminal emulators.