### PR TITLE
Allow addressing changesets by branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to `src-cli` are documented in this file.
 ### Added
 
 - Experimental: [`workspaces` in campaign specs](https://docs.sourcegraph.com/campaigns/references/campaign_spec_yaml_reference#workspaces) is now available to allow users to define multiple workspaces in a single repository. [#442](https://github.com/sourcegraph/src-cli/pull/442)
-- The `changesetTemplate.published` field can now also be used to address a specific changeset in a repository by adding `@<branch-of-changeset` at the end of the pattern. See [#461](https://github.com/sourcegraph/src-cli/pull/461) for an example and details.
+- The `changesetTemplate.published` field can now also be used to address a specific changeset in a repository by adding `@branch-of-changeset` at the end of the pattern. See [#461](https://github.com/sourcegraph/src-cli/pull/461) for an example and details.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to `src-cli` are documented in this file.
 ### Added
 
 - Experimental: [`workspaces` in campaign specs](https://docs.sourcegraph.com/campaigns/references/campaign_spec_yaml_reference#workspaces) is now available to allow users to define multiple workspaces in a single repository. [#442](https://github.com/sourcegraph/src-cli/pull/442)
+- The `changesetTemplate.published` field can now also be used to address a specific changeset in a repository by adding `@<branch-of-changeset` at the end of the pattern. See [#461](https://github.com/sourcegraph/src-cli/pull/461) for an example and details.
 
 ### Changed
 

--- a/go.mod
+++ b/go.mod
@@ -37,3 +37,6 @@ replace github.com/gosuri/uilive v0.0.4 => github.com/mrnugget/uilive v0.0.4-fix
 
 // See: https://github.com/ghodss/yaml/pull/65
 replace github.com/ghodss/yaml => github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152
+
+// TODO: Remove this!
+replace github.com/sourcegraph/campaignutils => /Users/thorstenball/work/campaignutils

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/olekukonko/tablewriter v0.0.4 // indirect
 	github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4
 	github.com/pkg/errors v0.9.1
-	github.com/sourcegraph/campaignutils v0.0.0-20201124055807-2f9cfa9317e2
+	github.com/sourcegraph/campaignutils v0.0.0-20210209103213-27e58c3ce8d3
 	github.com/sourcegraph/codeintelutils v0.0.0-20210118231003-6698e102a8a1
 	github.com/sourcegraph/go-diff v0.6.1
 	github.com/sourcegraph/jsonx v0.0.0-20200629203448-1a936bd500cf
@@ -37,6 +37,3 @@ replace github.com/gosuri/uilive v0.0.4 => github.com/mrnugget/uilive v0.0.4-fix
 
 // See: https://github.com/ghodss/yaml/pull/65
 replace github.com/ghodss/yaml => github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152
-
-// TODO: Remove this!
-replace github.com/sourcegraph/campaignutils => github.com/sourcegraph/campaignutils v0.0.0-20210205165249-c8b8df3b8703

--- a/go.mod
+++ b/go.mod
@@ -39,4 +39,4 @@ replace github.com/gosuri/uilive v0.0.4 => github.com/mrnugget/uilive v0.0.4-fix
 replace github.com/ghodss/yaml => github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152
 
 // TODO: Remove this!
-replace github.com/sourcegraph/campaignutils => /Users/thorstenball/work/campaignutils
+replace github.com/sourcegraph/campaignutils => github.com/sourcegraph/campaignutils v0.0.0-20210205165249-c8b8df3b8703

--- a/go.sum
+++ b/go.sum
@@ -50,10 +50,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/shurcooL/go v0.0.0-20180423040247-9e1955d9fb6e/go.mod h1:TDJrrUr11Vxrven61rcy3hJMUqaf/CLWYhHNPmT14Lk=
 github.com/shurcooL/go-goon v0.0.0-20170922171312-37c2f522c041/go.mod h1:N5mDOmsrJOB+vfqUK+7DmDyjhSLIIBnXo9lvZJj3MWQ=
-github.com/sourcegraph/campaignutils v0.0.0-20201124055807-2f9cfa9317e2 h1:MJu/6WzWdPegzYnZLb04IS0u4VyUpPIAHQyWT5i2vR8=
-github.com/sourcegraph/campaignutils v0.0.0-20201124055807-2f9cfa9317e2/go.mod h1:xm6i78Mk2t4DBLQDqEFc/3x6IPf7yYZCgbNaTQGhJHA=
-github.com/sourcegraph/campaignutils v0.0.0-20210205165249-c8b8df3b8703 h1:Rn47uFWsJzvja3/LXtv9vZIPi+Eo1zdvItcgCRVhE2U=
-github.com/sourcegraph/campaignutils v0.0.0-20210205165249-c8b8df3b8703/go.mod h1:xm6i78Mk2t4DBLQDqEFc/3x6IPf7yYZCgbNaTQGhJHA=
+github.com/sourcegraph/campaignutils v0.0.0-20210209103213-27e58c3ce8d3 h1:yXTWFqaMCMgjG3zVRGXjvuaUDfw2XnI6JD5Rh4V04e4=
+github.com/sourcegraph/campaignutils v0.0.0-20210209103213-27e58c3ce8d3/go.mod h1:xm6i78Mk2t4DBLQDqEFc/3x6IPf7yYZCgbNaTQGhJHA=
 github.com/sourcegraph/codeintelutils v0.0.0-20210118231003-6698e102a8a1 h1:IPWruUo+BwPJqCHBVgjKxK6zTxMkOhwCSYpQ/jZHG/w=
 github.com/sourcegraph/codeintelutils v0.0.0-20210118231003-6698e102a8a1/go.mod h1:HplI8gRslTrTUUsSYwu28hSOderix7m5dHNca7xBzeo=
 github.com/sourcegraph/go-diff v0.6.1 h1:hmA1LzxW0n1c3Q4YbrFgg4P99GSnebYa3x8gr0HZqLQ=

--- a/go.sum
+++ b/go.sum
@@ -52,6 +52,8 @@ github.com/shurcooL/go v0.0.0-20180423040247-9e1955d9fb6e/go.mod h1:TDJrrUr11Vxr
 github.com/shurcooL/go-goon v0.0.0-20170922171312-37c2f522c041/go.mod h1:N5mDOmsrJOB+vfqUK+7DmDyjhSLIIBnXo9lvZJj3MWQ=
 github.com/sourcegraph/campaignutils v0.0.0-20201124055807-2f9cfa9317e2 h1:MJu/6WzWdPegzYnZLb04IS0u4VyUpPIAHQyWT5i2vR8=
 github.com/sourcegraph/campaignutils v0.0.0-20201124055807-2f9cfa9317e2/go.mod h1:xm6i78Mk2t4DBLQDqEFc/3x6IPf7yYZCgbNaTQGhJHA=
+github.com/sourcegraph/campaignutils v0.0.0-20210205165249-c8b8df3b8703 h1:Rn47uFWsJzvja3/LXtv9vZIPi+Eo1zdvItcgCRVhE2U=
+github.com/sourcegraph/campaignutils v0.0.0-20210205165249-c8b8df3b8703/go.mod h1:xm6i78Mk2t4DBLQDqEFc/3x6IPf7yYZCgbNaTQGhJHA=
 github.com/sourcegraph/codeintelutils v0.0.0-20210118231003-6698e102a8a1 h1:IPWruUo+BwPJqCHBVgjKxK6zTxMkOhwCSYpQ/jZHG/w=
 github.com/sourcegraph/codeintelutils v0.0.0-20210118231003-6698e102a8a1/go.mod h1:HplI8gRslTrTUUsSYwu28hSOderix7m5dHNca7xBzeo=
 github.com/sourcegraph/go-diff v0.6.1 h1:hmA1LzxW0n1c3Q4YbrFgg4P99GSnebYa3x8gr0HZqLQ=

--- a/internal/campaigns/executor.go
+++ b/internal/campaigns/executor.go
@@ -518,7 +518,7 @@ func createChangesetSpecs(task *Task, result executionResult, features featureFl
 						Diff:        diff,
 					},
 				},
-				Published: task.Template.Published.Value(repo),
+				Published: task.Template.Published.ValueWithSuffix(repo, branch),
 			},
 		}
 	}


### PR DESCRIPTION
This uses https://github.com/sourcegraph/campaignutils/pull/9 to extend the pattern syntax for the `published` field in the `changesetTemplate` to allow addressing specific changesets in a repository by their branch name.

Example:

```yaml
name: branch-addressing
description: Addressing a single changeset by branch name

on:
  - repository: github.com/sourcegraph/automation-testing

workspaces:
  - rootAtLocationOf: package.json
    in: github.com/sourcegraph/automation-testing

steps:
  - run: |
      echo "We are in $(basename $(pwd))" >> message.txt &&
      basename $(pwd)
    container: alpine:3
    outputs:
      directoryName:
        value: ${{ step.stdout }}

changesetTemplate:
  title: Branch addressing
  body: Addressing a single changeset by branch name
  commit:
    message: Branch addressing
  branch: thorsten/branch-addressing-${{ outputs.directoryName }}
  published:
    - github.com/sourcegraph/automation-*@thorsten/branch-addressing-project1: draft
```

The campaign spec produces 3 changesets in 3 different branches of `automation-testing`, but only the changeset on the `thorsten/branch-addressing-project1` is published as a draft:

![image](https://user-images.githubusercontent.com/1185253/107064963-78146280-67dc-11eb-97aa-d05e1c3cd51b.png)
