### PR TITLE
Only fetch archive of subdirectories in workspaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ All notable changes to `src-cli` are documented in this file.
 
 ### Added
 
-- Experimental: [`workspaces` in campaign specs](https://docs.sourcegraph.com/campaigns/references/campaign_spec_yaml_reference#workspaces) is now available to allow users to define multiple workspaces in a single repository. [#442](https://github.com/sourcegraph/src-cli/pull/442)
+- Experimental (requires Sourcegraph 3.25 or later): [`workspaces` in campaign specs](https://docs.sourcegraph.com/campaigns/references/campaign_spec_yaml_reference#workspaces) is now available to allow users to define multiple workspaces in a single repository. [#442](https://github.com/sourcegraph/src-cli/pull/442) and [#462](https://github.com/sourcegraph/src-cli/pull/462).
 - The `changesetTemplate.published` field can now also be used to address a specific changeset in a repository by adding `@branch-of-changeset` at the end of the pattern. See [#461](https://github.com/sourcegraph/src-cli/pull/461) for an example and details.
 
 ### Changed

--- a/cmd/src/campaigns_common.go
+++ b/cmd/src/campaigns_common.go
@@ -237,7 +237,7 @@ func campaignsExecute(ctx context.Context, out *output.Output, svc *campaigns.Se
 
 	fetcher := svc.NewRepoFetcher(flags.cacheDir, flags.cleanArchives)
 	for _, task := range tasks {
-		task.Archive = fetcher.Checkout(task.Repository, task.Path)
+		task.Archive = fetcher.Checkout(task.Repository, task.ArchivePathToFetch())
 	}
 
 	opts := campaigns.ExecutorOpts{

--- a/cmd/src/campaigns_common.go
+++ b/cmd/src/campaigns_common.go
@@ -237,7 +237,7 @@ func campaignsExecute(ctx context.Context, out *output.Output, svc *campaigns.Se
 
 	fetcher := svc.NewRepoFetcher(flags.cacheDir, flags.cleanArchives)
 	for _, task := range tasks {
-		task.Archive = fetcher.Checkout(task.Repository)
+		task.Archive = fetcher.Checkout(task.Repository, task.Path)
 	}
 
 	opts := campaigns.ExecutorOpts{

--- a/internal/campaigns/bind_workspace.go
+++ b/internal/campaigns/bind_workspace.go
@@ -79,7 +79,7 @@ func (wc *dockerBindWorkspaceCreator) copyToWorkspace(ctx context.Context, w *do
 
 		destPath := path.Join(w.dir, name)
 
-		destFile, err := prepareCopyDestinationFile(src, srcStat, destPath)
+		destFile, err := prepareCopyDestinationFile(srcStat, destPath)
 		if err != nil {
 			return err
 		}
@@ -194,7 +194,7 @@ func unzip(zipFile, dest string) error {
 			continue
 		}
 
-		outFile, err := prepareCopyDestinationFile(f.Name, f.FileInfo(), fpath)
+		outFile, err := prepareCopyDestinationFile(f.FileInfo(), fpath)
 		if err != nil {
 			return err
 		}
@@ -224,8 +224,8 @@ type moder interface {
 	Mode() os.FileMode
 }
 
-func prepareCopyDestinationFile(sourcePath string, sourceInfo moder, dest string) (*os.File, error) {
-	if err := mkdirAll(filepath.Dir(dest), filepath.Dir(sourcePath), 0777); err != nil {
+func prepareCopyDestinationFile(sourceInfo moder, dest string) (*os.File, error) {
+	if err := mkdirAll(filepath.Dir(dest), "", 0777); err != nil {
 		return nil, err
 	}
 

--- a/internal/campaigns/bind_workspace.go
+++ b/internal/campaigns/bind_workspace.go
@@ -68,6 +68,7 @@ func (wc *dockerBindWorkspaceCreator) copyToWorkspace(ctx context.Context, w *do
 			return err
 		}
 
+		// TODO: This should use prepareCopyDestinationFile
 		if !srcStat.Mode().IsRegular() {
 			return fmt.Errorf("%s is not a regular file", src)
 		}
@@ -189,6 +190,7 @@ func unzip(zipFile, dest string) error {
 			continue
 		}
 
+		// TODO: This should use prepareCopyDestinationFile
 		if err := mkdirAll(dest, filepath.Dir(f.Name), 0777); err != nil {
 			return err
 		}

--- a/internal/campaigns/bind_workspace_test.go
+++ b/internal/campaigns/bind_workspace_test.go
@@ -30,15 +30,14 @@ func TestDockerBindWorkspaceCreator_Create(t *testing.T) {
 		DefaultBranch: &graphql.Branch{Name: "main", Target: graphql.Target{OID: "d34db33f"}},
 	}
 
-	archive := mockRepoArchive{
-		repo: repo,
-		files: map[string]string{
-			"README.md": "# Welcome to the README\n",
-		},
+	filesInZip := map[string]string{
+		"README.md": "# Welcome to the README\n",
 	}
 
+	fakeFilesTmpDir := workspaceTmpDir(t)
+
 	// Create a zip file for all the other tests to use.
-	f, err := ioutil.TempFile(workspaceTmpDir(t), "repo-zip-*")
+	f, err := ioutil.TempFile(fakeFilesTmpDir, "repo-zip-*")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -46,7 +45,7 @@ func TestDockerBindWorkspaceCreator_Create(t *testing.T) {
 	t.Cleanup(func() { os.Remove(archivePath) })
 
 	zw := zip.NewWriter(f)
-	for name, body := range archive.files {
+	for name, body := range filesInZip {
 		f, err := zw.Create(name)
 		if err != nil {
 			t.Fatal(err)
@@ -58,11 +57,34 @@ func TestDockerBindWorkspaceCreator_Create(t *testing.T) {
 	zw.Close()
 	f.Close()
 
+	// Create "additional files" for the tests to use
+	additionalFiles := map[string]string{
+		".gitignore":   "This is the gitignore\n",
+		"another-file": "This is another file",
+	}
+	additionalFilePaths := map[string]string{}
+	for name, content := range additionalFiles {
+		f, err := ioutil.TempFile(fakeFilesTmpDir, name+"-*")
+		if err != nil {
+			t.Fatal(err)
+		}
+		filePath := f.Name()
+		t.Cleanup(func() { os.Remove(filePath) })
+
+		if _, err := f.Write([]byte(content)); err != nil {
+			t.Fatal(err)
+		}
+
+		additionalFilePaths[name] = filePath
+		f.Close()
+	}
+
 	t.Run("success", func(t *testing.T) {
 		testTempDir := workspaceTmpDir(t)
 
+		archive := &fakeRepoArchive{mockPath: archivePath}
 		creator := &dockerBindWorkspaceCreator{dir: testTempDir}
-		workspace, err := creator.Create(context.Background(), repo, nil, archivePath)
+		workspace, err := creator.Create(context.Background(), repo, nil, archive)
 		if err != nil {
 			t.Fatalf("unexpected error: %s", err)
 		}
@@ -72,8 +94,8 @@ func TestDockerBindWorkspaceCreator_Create(t *testing.T) {
 			t.Fatalf("error walking workspace: %s", err)
 		}
 
-		if !cmp.Equal(archive.files, haveUnzippedFiles) {
-			t.Fatalf("wrong files in workspace:\n%s", cmp.Diff(archive.files, haveUnzippedFiles))
+		if !cmp.Equal(filesInZip, haveUnzippedFiles) {
+			t.Fatalf("wrong files in workspace:\n%s", cmp.Diff(filesInZip, haveUnzippedFiles))
 		}
 	})
 
@@ -89,9 +111,42 @@ func TestDockerBindWorkspaceCreator_Create(t *testing.T) {
 		t.Cleanup(func() { os.Remove(badZipFile) })
 		badZip.Close()
 
+		badArchive := &fakeRepoArchive{mockPath: badZipFile}
+
 		creator := &dockerBindWorkspaceCreator{dir: testTempDir}
-		if _, err := creator.Create(context.Background(), repo, nil, badZipFile); err == nil {
+		if _, err := creator.Create(context.Background(), repo, nil, badArchive); err == nil {
 			t.Error("unexpected nil error")
+		}
+	})
+
+	t.Run("additional files", func(t *testing.T) {
+		testTempDir := workspaceTmpDir(t)
+
+		archive := &fakeRepoArchive{
+			mockPath:                archivePath,
+			mockAdditionalFilePaths: additionalFilePaths,
+		}
+
+		creator := &dockerBindWorkspaceCreator{dir: testTempDir}
+		workspace, err := creator.Create(context.Background(), repo, nil, archive)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+
+		haveUnzippedFiles, err := readWorkspaceFiles(workspace)
+		if err != nil {
+			t.Fatalf("error walking workspace: %s", err)
+		}
+
+		wantFiles := map[string]string{}
+		for name, content := range filesInZip {
+			wantFiles[name] = content
+		}
+		for name, content := range additionalFiles {
+			wantFiles[name] = content
+		}
+		if !cmp.Equal(wantFiles, haveUnzippedFiles) {
+			t.Fatalf("wrong files in workspace:\n%s", cmp.Diff(wantFiles, haveUnzippedFiles))
 		}
 	})
 }
@@ -250,7 +305,7 @@ func readWorkspaceFiles(workspace Workspace) (map[string]string, error) {
 			return err
 		}
 
-		if strings.HasPrefix(rel, ".git") {
+		if rel == ".git" || strings.HasPrefix(rel, ".git/") {
 			return nil
 		}
 
@@ -274,4 +329,21 @@ func dirContains(dir, filename string) (bool, error) {
 	}
 
 	return false, nil
+}
+
+var _ RepoZip = &fakeRepoArchive{}
+
+type fakeRepoArchive struct {
+	mockPath                string
+	mockAdditionalFilePaths map[string]string
+}
+
+func (f *fakeRepoArchive) Fetch(context.Context) error { return nil }
+func (f *fakeRepoArchive) Close() error                { return nil }
+func (f *fakeRepoArchive) Path() string                { return f.mockPath }
+func (f *fakeRepoArchive) AdditionalFilePaths() map[string]string {
+	if f.mockAdditionalFilePaths != nil {
+		return f.mockAdditionalFilePaths
+	}
+	return map[string]string{}
 }

--- a/internal/campaigns/bind_workspace_test.go
+++ b/internal/campaigns/bind_workspace_test.go
@@ -305,7 +305,7 @@ func readWorkspaceFiles(workspace Workspace) (map[string]string, error) {
 			return err
 		}
 
-		if rel == ".git" || strings.HasPrefix(rel, ".git/") {
+		if rel == ".git" || strings.HasPrefix(rel, ".git"+string(os.PathSeparator)) {
 			return nil
 		}
 

--- a/internal/campaigns/campaign_spec.go
+++ b/internal/campaigns/campaign_spec.go
@@ -64,8 +64,9 @@ type ImportChangeset struct {
 }
 
 type WorkspaceConfiguration struct {
-	RootAtLocationOf string `json:"rootAtLocationOf,omitempty" yaml:"rootAtLocationOf"`
-	In               string `json:"in,omitempty" yaml:"in"`
+	RootAtLocationOf   string `json:"rootAtLocationOf,omitempty" yaml:"rootAtLocationOf"`
+	In                 string `json:"in,omitempty" yaml:"in"`
+	OnlyFetchWorkspace bool   `json:"onlyFetchWorkspace,omitempty" yaml:"onlyFetchWorkspace"`
 
 	glob glob.Glob
 }

--- a/internal/campaigns/executor.go
+++ b/internal/campaigns/executor.go
@@ -56,7 +56,15 @@ type Executor interface {
 
 type Task struct {
 	Repository *graphql.Repository
-	Path       string
+
+	// Path is the folder relative to the repository's root in which the steps
+	// should be executed.
+	Path string
+	// OnlyFetchWorkspace determines whether the repository archive contains
+	// the complete repository or just the files in Path (and additional files,
+	// see RepoFetcher).
+	// If Path is "" then this setting has no effect.
+	OnlyFetchWorkspace bool
 
 	Steps   []Step
 	Outputs map[string]interface{}
@@ -65,6 +73,13 @@ type Task struct {
 	TransformChanges *TransformChanges  `json:"-"`
 
 	Archive RepoZip `json:"-"`
+}
+
+func (t *Task) ArchivePathToFetch() string {
+	if t.OnlyFetchWorkspace {
+		return t.Path
+	}
+	return ""
 }
 
 func (t *Task) cacheKey() ExecutionCacheKey {

--- a/internal/campaigns/executor_test.go
+++ b/internal/campaigns/executor_test.go
@@ -299,10 +299,12 @@ repository_name=github.com/sourcegraph/src-cli`,
 					".gitignore":      "node_modules",
 					"message.txt":     "root-dir",
 					"a/message.txt":   "a-dir",
+					"a/.gitignore":    "node_modules-in-a",
 					"a/b/message.txt": "b-dir",
 				}},
 				{repo: srcCLIRepo, path: "a", files: map[string]string{
 					"a/message.txt":   "a-dir",
+					"a/.gitignore":    "node_modules-in-a",
 					"a/b/message.txt": "b-dir",
 				}},
 				{repo: srcCLIRepo, path: "a/b", files: map[string]string{
@@ -311,7 +313,8 @@ repository_name=github.com/sourcegraph/src-cli`,
 			},
 			additionalFiles: []mockRepoAdditionalFiles{
 				{repo: srcCLIRepo, additionalFiles: map[string]string{
-					".gitignore": "node_modules",
+					".gitignore":   "node_modules",
+					"a/.gitignore": "node_modules-in-a",
 				}},
 			},
 			steps: []Step{
@@ -332,8 +335,13 @@ repository_name=github.com/sourcegraph/src-cli`,
 					Run:       `if [[ $(basename $(pwd)) == "a" && -f "../.gitignore" ]]; then echo "yes" >> gitignore-exists; fi`,
 					Container: "doesntmatter:13",
 				},
+				// In `a/b` we want the `.gitignore` file in the root folder and in `a` to be fetched:
 				{
 					Run:       `if [[ $(basename $(pwd)) == "b" && -f "../../.gitignore" ]]; then echo "yes" >> gitignore-exists; fi`,
+					Container: "doesntmatter:13",
+				},
+				{
+					Run:       `if [[ $(basename $(pwd)) == "b" && -f "../.gitignore" ]]; then echo "yes" >> gitignore-exists-in-a; fi`,
 					Container: "doesntmatter:13",
 				},
 			},
@@ -361,7 +369,7 @@ repository_name=github.com/sourcegraph/src-cli`,
 				srcCLIRepo.ID: filesByBranch{
 					"workspace-root-dir": []string{"hello.txt", "gitignore-exists"},
 					"workspace-a-dir":    []string{"a/hello.txt", "a/gitignore-exists"},
-					"workspace-b-dir":    []string{"a/b/hello.txt", "a/b/gitignore-exists"},
+					"workspace-b-dir":    []string{"a/b/hello.txt", "a/b/gitignore-exists", "a/b/gitignore-exists-in-a"},
 				},
 			},
 		},

--- a/internal/campaigns/executor_test.go
+++ b/internal/campaigns/executor_test.go
@@ -944,6 +944,7 @@ type mockRepoAdditionalFiles struct {
 func handleAdditionalFiles(mux *http.ServeMux, files mockRepoAdditionalFiles, middle middleware) {
 	for name, content := range files.additionalFiles {
 		path := fmt.Sprintf("/%s@%s/-/raw/%s", files.repo.Name, files.repo.BaseRef(), name)
+		fmt.Printf("Setting up handler for path %s\n", path)
 		handler := func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "text/plain")
 

--- a/internal/campaigns/executor_test.go
+++ b/internal/campaigns/executor_test.go
@@ -944,7 +944,6 @@ type mockRepoAdditionalFiles struct {
 func handleAdditionalFiles(mux *http.ServeMux, files mockRepoAdditionalFiles, middle middleware) {
 	for name, content := range files.additionalFiles {
 		path := fmt.Sprintf("/%s@%s/-/raw/%s", files.repo.Name, files.repo.BaseRef(), name)
-		fmt.Printf("Setting up handler for path %s\n", path)
 		handler := func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "text/plain")
 

--- a/internal/campaigns/executor_test.go
+++ b/internal/campaigns/executor_test.go
@@ -934,19 +934,14 @@ type mockRepoAdditionalFiles struct {
 }
 
 func handleAdditionalFiles(mux *http.ServeMux, files mockRepoAdditionalFiles, middle middleware) {
-	var requestedFiles []string
 	for name, content := range files.additionalFiles {
-		// Copy we can use inside closure
-		nameCopy := name
-
 		path := fmt.Sprintf("/%s@%s/-/raw/%s", files.repo.Name, files.repo.BaseRef(), name)
 		handler := func(w http.ResponseWriter, r *http.Request) {
-			requestedFiles = append(requestedFiles, nameCopy)
-
 			w.Header().Set("Content-Type", "text/plain")
 
 			w.Write([]byte(content))
 		}
+
 		if middle != nil {
 			mux.Handle(path, middle(http.HandlerFunc(handler)))
 		} else {

--- a/internal/campaigns/graphql/repository.go
+++ b/internal/campaigns/graphql/repository.go
@@ -81,6 +81,14 @@ func (r *Repository) Slug() string {
 	return strings.ReplaceAll(r.Name, "/", "-") + "-" + r.Rev()
 }
 
+func (r *Repository) SlugForPath(path string) string {
+	name := r.Name
+	if path != "" {
+		name = name + "-" + path
+	}
+	return strings.ReplaceAll(name, "/", "-") + "-" + r.Rev()
+}
+
 func (r *Repository) SearchResultPaths() (list fileMatchPathList) {
 	var files []string
 	for f := range r.FileMatches {

--- a/internal/campaigns/graphql/repository.go
+++ b/internal/campaigns/graphql/repository.go
@@ -1,6 +1,8 @@
 package graphql
 
 import (
+	"crypto/sha256"
+	"encoding/base64"
 	"sort"
 	"strings"
 )
@@ -84,7 +86,10 @@ func (r *Repository) Slug() string {
 func (r *Repository) SlugForPath(path string) string {
 	name := r.Name
 	if path != "" {
-		name = name + "-" + path
+		// Since path can contain os.PathSeparator or other characters that
+		// don't translate well between Windows and Unix systems, we hash it.
+		hash := sha256.Sum256([]byte(path))
+		name = name + "-" + base64.RawURLEncoding.EncodeToString(hash[:32])
 	}
 	return strings.ReplaceAll(name, "/", "-") + "-" + r.Rev()
 }

--- a/internal/campaigns/repo_fetcher.go
+++ b/internal/campaigns/repo_fetcher.go
@@ -88,7 +88,9 @@ func (rf *repoFetcher) zipFor(repo *graphql.Repository, path string) *repoZip {
 			// /examples/cool/.gitignore
 			// /examples/cool/.gitattributes
 
-			pathComponents := strings.Split(path, string(os.PathSeparator))
+			// Split on '/' because the path comes from Sourcegraph and always
+			// has a "/".
+			pathComponents := strings.Split(path, "/")
 
 			var currentPath string
 			for _, component := range pathComponents {

--- a/internal/campaigns/repo_fetcher.go
+++ b/internal/campaigns/repo_fetcher.go
@@ -20,9 +20,9 @@ import (
 // repository.
 type RepoFetcher interface {
 	// Checkout returns a RepoZip for the given repository and the given
-	// relative path in the repository. The RepoZip s possibly unfetched. Users
-	// need to call `Fetch()` on the RepoZip before using it and `Close()` once
-	// they're done using it.
+	// relative path in the repository. The RepoZip is possibly unfetched.
+	// Users need to call `Fetch()` on the RepoZip before using it and
+	// `Close()` once // they're done using it.
 	Checkout(repo *graphql.Repository, path string) RepoZip
 }
 

--- a/internal/campaigns/repo_fetcher.go
+++ b/internal/campaigns/repo_fetcher.go
@@ -237,10 +237,6 @@ func (rz *repoZip) fetchArchiveAndFiles(ctx context.Context) (err error) {
 	}
 
 	for _, addFile := range rz.additionalFiles {
-		if addFile.fetched {
-			continue
-		}
-
 		exists, err := fileExists(addFile.localPath)
 		if err != nil {
 			return err
@@ -253,10 +249,10 @@ func (rz *repoZip) fetchArchiveAndFiles(ctx context.Context) (err error) {
 
 		ok, err := fetchRepositoryFile(ctx, rz.client, rz.repo, addFile.filename, addFile.localPath)
 		if err != nil {
-			os.Remove(addFile.localPath)
-
 			return errors.Wrapf(err, "fetching %s for repository archive", addFile.filename)
 		}
+		// We don't return an error here, because downloading the additional
+		// files is best effort. If they don't exist we skip them.
 		addFile.fetched = ok
 	}
 

--- a/internal/campaigns/repo_fetcher.go
+++ b/internal/campaigns/repo_fetcher.go
@@ -276,6 +276,7 @@ func (rz *repoZip) fetchArchiveAndFiles(ctx context.Context) (err error) {
 			continue
 		}
 
+		fmt.Printf("DEBUG! Fetching file %s\n", addFile.filename)
 		ok, err := fetchRepositoryFile(ctx, rz.client, rz.repo, addFile.filename, addFile.localPath)
 		if err != nil {
 			return errors.Wrapf(err, "fetching %s for repository archive", addFile.filename)

--- a/internal/campaigns/repo_fetcher_test.go
+++ b/internal/campaigns/repo_fetcher_test.go
@@ -227,10 +227,14 @@ func TestRepoFetcher_Fetch(t *testing.T) {
 	})
 
 	t.Run("path in repository", func(t *testing.T) {
-		additionalFiles := map[string]string{
-			".gitignore":     "node_modules",
-			".gitattributes": "* -text",
+		additionalFiles := mockRepoAdditionalFiles{
+			repo: repo,
+			additionalFiles: map[string]string{
+				".gitignore":     "node_modules",
+				".gitattributes": "* -text",
+			},
 		}
+
 		path := "a/b"
 		archive := mockRepoArchive{
 			repo: repo,
@@ -258,7 +262,7 @@ func TestRepoFetcher_Fetch(t *testing.T) {
 		}
 
 		mux := newZipArchivesMux(t, callback, archive)
-		handleAdditionalFiles(mux, repo, additionalFiles, middle)
+		handleAdditionalFiles(mux, additionalFiles, middle)
 
 		ts := httptest.NewServer(mux)
 		defer ts.Close()

--- a/internal/campaigns/repo_fetcher_test.go
+++ b/internal/campaigns/repo_fetcher_test.go
@@ -232,6 +232,7 @@ func TestRepoFetcher_Fetch(t *testing.T) {
 			additionalFiles: map[string]string{
 				".gitignore":     "node_modules",
 				".gitattributes": "* -text",
+				"a/.gitignore":   "node_modules-in-a",
 			},
 		}
 
@@ -286,7 +287,7 @@ func TestRepoFetcher_Fetch(t *testing.T) {
 			t.Errorf("wrong paths requested (-want +got):\n%s", cmp.Diff(path, requestedArchivePath))
 		}
 
-		wantRequestedFiles := []string{".gitignore", ".gitattributes"}
+		wantRequestedFiles := []string{".gitignore", ".gitattributes", "a/.gitignore"}
 		if !cmp.Equal(wantRequestedFiles, requestedFiles, cmpopts.SortSlices(sortStrings)) {
 			t.Errorf("wrong paths requested (-want +got):\n%s", cmp.Diff(wantRequestedFiles, requestedFiles))
 		}

--- a/internal/campaigns/run_steps.go
+++ b/internal/campaigns/run_steps.go
@@ -59,7 +59,7 @@ func runSteps(ctx context.Context, opts *executionOpts) (result executionResult,
 	defer opts.archive.Close()
 
 	opts.reportProgress("Initializing workspace")
-	workspace, err := opts.wc.Create(ctx, opts.repo, opts.steps, opts.archive.Path())
+	workspace, err := opts.wc.Create(ctx, opts.repo, opts.steps, opts.archive)
 	if err != nil {
 		return executionResult{}, errors.Wrap(err, "creating workspace")
 	}

--- a/internal/campaigns/volume_workspace.go
+++ b/internal/campaigns/volume_workspace.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"sort"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -156,9 +157,16 @@ func (wc *dockerVolumeWorkspaceCreator) copyFilesIntoVolumes(ctx context.Context
 		"--workdir", "/work",
 	}, w.dockerRunOptsWithUser(w.uidGid, "/work")...)
 
-	var copyCmds []string
+	// We sort these so our tests don't break. Sorry.
+	var names []string
+	for name := range files {
+		names = append(names, name)
+	}
+	sort.Strings(names)
 
-	for name, localPath := range files {
+	var copyCmds []string
+	for _, name := range names {
+		localPath := files[name]
 		opts = append(opts, []string{
 			"--mount", "type=bind,source=" + localPath + ",target=/tmp/" + name + ",ro",
 		}...)

--- a/internal/campaigns/volume_workspace.go
+++ b/internal/campaigns/volume_workspace.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"strings"
 
 	"github.com/pkg/errors"
 
@@ -21,7 +22,7 @@ type dockerVolumeWorkspaceCreator struct{ tempDir string }
 
 var _ WorkspaceCreator = &dockerVolumeWorkspaceCreator{}
 
-func (wc *dockerVolumeWorkspaceCreator) Create(ctx context.Context, repo *graphql.Repository, steps []Step, zip string) (Workspace, error) {
+func (wc *dockerVolumeWorkspaceCreator) Create(ctx context.Context, repo *graphql.Repository, steps []Step, archive RepoZip) (Workspace, error) {
 	volume, err := wc.createVolume(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "creating Docker volume")
@@ -41,8 +42,12 @@ func (wc *dockerVolumeWorkspaceCreator) Create(ctx context.Context, repo *graphq
 		volume:  volume,
 		uidGid:  ug,
 	}
-	if err := wc.unzipRepoIntoVolume(ctx, w, zip); err != nil {
+	if err := wc.unzipRepoIntoVolume(ctx, w, archive.Path()); err != nil {
 		return nil, errors.Wrap(err, "unzipping repo into workspace")
+	}
+
+	if err := wc.copyFilesIntoVolumes(ctx, w, archive.AdditionalFilePaths()); err != nil {
+		return nil, errors.Wrap(err, "copying additional files into workspace")
 	}
 
 	return w, errors.Wrap(wc.prepareGitRepo(ctx, w), "preparing local git repo")
@@ -136,6 +141,41 @@ func (wc *dockerVolumeWorkspaceCreator) unzipRepoIntoVolume(ctx context.Context,
 		return errors.Wrapf(err, "unzip output:\n\n%s\n\n", string(out))
 	}
 
+	return nil
+}
+
+func (wc *dockerVolumeWorkspaceCreator) copyFilesIntoVolumes(ctx context.Context, w *dockerVolumeWorkspace, files map[string]string) error {
+	if len(files) == 0 {
+		return nil
+	}
+
+	opts := append([]string{
+		"run",
+		"--rm",
+		"--init",
+		"--workdir", "/work",
+	}, w.dockerRunOptsWithUser(w.uidGid, "/work")...)
+
+	var copyCmds []string
+
+	for name, localPath := range files {
+		opts = append(opts, []string{
+			"--mount", "type=bind,source=" + localPath + ",target=/tmp/" + name + ",ro",
+		}...)
+
+		copyCmds = append(copyCmds, "cp /tmp/"+name+" /work/"+name)
+	}
+
+	opts = append(
+		opts,
+		dockerVolumeWorkspaceImage,
+		"sh", "-c",
+		strings.Join(copyCmds, " && ")+";",
+	)
+
+	if out, err := exec.CommandContext(ctx, "docker", opts...).CombinedOutput(); err != nil {
+		return errors.Wrapf(err, "unzip output:\n\n%s\n\n", string(out))
+	}
 	return nil
 }
 

--- a/internal/campaigns/volume_workspace_test.go
+++ b/internal/campaigns/volume_workspace_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -37,17 +38,14 @@ func TestVolumeWorkspaceCreator(t *testing.T) {
 		mockAdditionalFilePaths: map[string]string{},
 	}
 	for _, name := range []string{".gitignore", "another-file"} {
-		f, err := ioutil.TempFile(os.TempDir(), "volume-workspace-*-"+name)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if _, err := f.WriteString("this is " + name); err != nil {
-			t.Fatalf("failed to create temp file %s", name)
-		}
-		f.Close()
-		defer os.Remove(f.Name())
+		// Since we don't read the files and mock the Docker commands,
+		// we don't need to create them.
+		path := filepath.Join(os.TempDir(), "additional-file"+name)
+		// Instead we create a real-looking path that we sanitize so
+		// it doesn't trip up the globbing expecations below:
+		path = strings.ReplaceAll(path, string(os.PathSeparator), "-")
 
-		archiveWithAdditionalFiles.mockAdditionalFilePaths[name] = f.Name()
+		archiveWithAdditionalFiles.mockAdditionalFilePaths[name] = path
 	}
 
 	wc := &dockerVolumeWorkspaceCreator{}

--- a/internal/campaigns/volume_workspace_test.go
+++ b/internal/campaigns/volume_workspace_test.go
@@ -28,12 +28,29 @@ func TestVolumeWorkspaceCreator(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	zip := f.Name()
+	defaultArchive := &fakeRepoArchive{mockPath: f.Name()}
 	f.Close()
-	defer os.Remove(zip)
+	defer os.Remove(defaultArchive.Path())
+
+	archiveWithAdditionalFiles := &fakeRepoArchive{
+		mockPath:                f.Name(),
+		mockAdditionalFilePaths: map[string]string{},
+	}
+	for _, name := range []string{".gitignore", "another-file"} {
+		f, err := ioutil.TempFile(os.TempDir(), "volume-workspace-*-"+name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := f.WriteString("this is " + name); err != nil {
+			t.Fatalf("failed to create temp file %s", name)
+		}
+		f.Close()
+		defer os.Remove(f.Name())
+
+		archiveWithAdditionalFiles.mockAdditionalFilePaths[name] = f.Name()
+	}
 
 	wc := &dockerVolumeWorkspaceCreator{}
-
 	// We'll set up a fake repository with just enough fields defined for init()
 	// and friends.
 	repo := &graphql.Repository{
@@ -41,6 +58,7 @@ func TestVolumeWorkspaceCreator(t *testing.T) {
 	}
 
 	for name, tc := range map[string]struct {
+		archive      *fakeRepoArchive
 		expectations []*expect.Expectation
 		steps        []Step
 		wantErr      bool
@@ -258,10 +276,65 @@ func TestVolumeWorkspaceCreator(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		"additional files": {
+			archive: archiveWithAdditionalFiles,
+			expectations: []*expect.Expectation{
+				expect.NewGlob(
+					expect.Behaviour{Stdout: []byte(volumeID)},
+					"docker", "volume", "create",
+				),
+				expect.NewGlob(
+					expect.Success,
+					"docker", "run", "--rm", "--init", "--workdir", "/work",
+					"--user", "0:0",
+					"--mount", "type=volume,source="+volumeID+",target=/work",
+					dockerVolumeWorkspaceImage,
+					"sh", "-c", "touch /work/*; chown -R 0:0 /work",
+				),
+				expect.NewGlob(
+					expect.Success,
+					"docker", "run", "--rm", "--init",
+					"--workdir", "/work",
+					"--mount", "type=bind,source=*,target=/tmp/zip,ro",
+					"--user", "0:0",
+					"--mount", "type=volume,source="+volumeID+",target=/work",
+					dockerVolumeWorkspaceImage,
+					"sh", "-c", "unzip /tmp/zip; rm /work/*",
+				),
+				expect.NewGlob(
+					expect.Success,
+					"docker", "run", "--rm", "--init",
+					"--workdir", "/work",
+					"--user", "0:0",
+					"--mount", "type=volume,source="+volumeID+",target=/work",
+					"--mount", "type=bind,source="+archiveWithAdditionalFiles.mockAdditionalFilePaths[".gitignore"]+",target=/tmp/.gitignore,ro",
+					"--mount", "type=bind,source="+archiveWithAdditionalFiles.mockAdditionalFilePaths["another-file"]+",target=/tmp/another-file,ro",
+					dockerVolumeWorkspaceImage,
+					"sh", "-c", "cp /tmp/.gitignore /work/.gitignore && cp /tmp/another-file /work/another-file;",
+				),
+				expect.NewGlob(
+					expect.Success,
+					"docker", "run", "--rm", "--init", "--workdir", "/work",
+					"--mount", "type=bind,source=*,target=/run.sh,ro",
+					"--user", "0:0",
+					"--mount", "type=volume,source="+volumeID+",target=/work",
+					dockerVolumeWorkspaceImage,
+					"sh", "/run.sh",
+				),
+			},
+			steps: []Step{
+				{image: &mockImage{uidGid: docker.Root}},
+			},
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			expect.Commands(t, tc.expectations...)
-			w, err := wc.Create(ctx, repo, tc.steps, zip)
+			a := defaultArchive
+			if tc.archive != nil {
+				a = tc.archive
+			}
+
+			w, err := wc.Create(ctx, repo, tc.steps, a)
 			if tc.wantErr {
 				if err == nil {
 					t.Error("unexpected nil error")

--- a/internal/campaigns/workspace.go
+++ b/internal/campaigns/workspace.go
@@ -11,8 +11,8 @@ import (
 // per-changeset persistent storage when executing campaign steps and are
 // responsible for ultimately generating a diff.
 type WorkspaceCreator interface {
-	// Create creates a new workspace for the given repository and ZIP file.
-	Create(ctx context.Context, repo *graphql.Repository, steps []Step, zip string) (Workspace, error)
+	// Create creates a new workspace for the given repository and archive file.
+	Create(ctx context.Context, repo *graphql.Repository, steps []Step, archive RepoZip) (Workspace, error)
 }
 
 // Workspace implementations manage per-changeset storage when executing

--- a/internal/exec/expect/expect.go
+++ b/internal/exec/expect/expect.go
@@ -206,6 +206,10 @@ func NewGlobValidator(wantName string, wantArg ...string) CommandValidator {
 		} else {
 			for i, g := range wantArgGlobs {
 				if !g.Match(haveArg[i]) {
+					for j := range wantArg {
+						fmt.Printf("wantArg[%d]=%q\n", j, wantArg[j])
+						fmt.Printf("haveArg[%d]=%q\n", j, haveArg[j])
+					}
 					errs = multierror.Append(errs, errors.Errorf("unexpected argument at position %d:\nhave=%q\nwant=%q\ndiff=%q", i, haveArg[i], wantArg[i], cmp.Diff(haveArg[i], wantArg[i])))
 				}
 			}

--- a/internal/exec/expect/expect.go
+++ b/internal/exec/expect/expect.go
@@ -201,7 +201,7 @@ func NewGlobValidator(wantName string, wantArg ...string) CommandValidator {
 		}
 
 		if len(haveArg) != len(wantArgGlobs) {
-			errs = multierror.Append(errs, errors.Errorf("unexpected number of arguments: have=%v want=%v", haveArg, wantArg))
+			errs = multierror.Append(errs, errors.Errorf("unexpected number of arguments:\nhave=%v\nwant=%v", haveArg, wantArg))
 		} else {
 			for i, g := range wantArgGlobs {
 				if !g.Match(haveArg[i]) {

--- a/internal/exec/expect/expect.go
+++ b/internal/exec/expect/expect.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"github.com/gobwas/glob"
+	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 
@@ -205,7 +206,7 @@ func NewGlobValidator(wantName string, wantArg ...string) CommandValidator {
 		} else {
 			for i, g := range wantArgGlobs {
 				if !g.Match(haveArg[i]) {
-					errs = multierror.Append(errs, errors.Errorf("unexpected argument at position %d: have=%q want=%q", i, haveArg[i], wantArg[i]))
+					errs = multierror.Append(errs, errors.Errorf("unexpected argument at position %d:\nhave=%q\nwant=%q\ndiff=%q", i, haveArg[i], wantArg[i], cmp.Diff(haveArg[i], wantArg[i])))
 				}
 			}
 		}

--- a/internal/exec/expect/expect.go
+++ b/internal/exec/expect/expect.go
@@ -206,10 +206,6 @@ func NewGlobValidator(wantName string, wantArg ...string) CommandValidator {
 		} else {
 			for i, g := range wantArgGlobs {
 				if !g.Match(haveArg[i]) {
-					for j := range wantArg {
-						fmt.Printf("wantArg[%d]=%q\n", j, wantArg[j])
-						fmt.Printf("haveArg[%d]=%q\n", j, haveArg[j])
-					}
 					errs = multierror.Append(errs, errors.Errorf("unexpected argument at position %d:\nhave=%q\nwant=%q\ndiff=%q", i, haveArg[i], wantArg[i], cmp.Diff(haveArg[i], wantArg[i])))
 				}
 			}

--- a/schema/campaign_spec.schema.json
+++ b/schema/campaign_spec.schema.json
@@ -78,6 +78,7 @@
           },
           "onlyFetchWorkspace": {
             "type": "boolean",
+            "description": "If this is true only the files in the workspace (and additional .gitignore) are downloaded instead of an archive of the full repository.",
             "default": false
           }
         }

--- a/schema/campaign_spec.schema.json
+++ b/schema/campaign_spec.schema.json
@@ -75,6 +75,10 @@
             "type": "string",
             "description": "The repositories in which to apply the workspace configuration. Supports globbing.",
             "examples": ["github.com/sourcegraph/src-cli", "github.com/sourcegraph/*"]
+          },
+          "onlyFetchWorkspace": {
+            "type": "boolean",
+            "default": false
           }
         }
       }
@@ -216,8 +220,14 @@
       "additionalProperties": false,
       "required": ["title", "branch", "commit", "published"],
       "properties": {
-        "title": { "type": "string", "description": "The title of the changeset." },
-        "body": { "type": "string", "description": "The body (description) of the changeset." },
+        "title": {
+          "type": "string",
+          "description": "The title of the changeset."
+        },
+        "body": {
+          "type": "string",
+          "description": "The body (description) of the changeset."
+        },
         "branch": {
           "type": "string",
           "description": "The name of the Git branch to create or update on each repository with the changes."

--- a/schema/campaign_spec_stringdata.go
+++ b/schema/campaign_spec_stringdata.go
@@ -83,6 +83,7 @@ const CampaignSpecJSON = `{
           },
           "onlyFetchWorkspace": {
             "type": "boolean",
+            "description": "If this is true only the files in the workspace (and additional .gitignore) are downloaded instead of an archive of the full repository.",
             "default": false
           }
         }

--- a/schema/campaign_spec_stringdata.go
+++ b/schema/campaign_spec_stringdata.go
@@ -80,6 +80,10 @@ const CampaignSpecJSON = `{
             "type": "string",
             "description": "The repositories in which to apply the workspace configuration. Supports globbing.",
             "examples": ["github.com/sourcegraph/src-cli", "github.com/sourcegraph/*"]
+          },
+          "onlyFetchWorkspace": {
+            "type": "boolean",
+            "default": false
           }
         }
       }
@@ -221,8 +225,14 @@ const CampaignSpecJSON = `{
       "additionalProperties": false,
       "required": ["title", "branch", "commit", "published"],
       "properties": {
-        "title": { "type": "string", "description": "The title of the changeset." },
-        "body": { "type": "string", "description": "The body (description) of the changeset." },
+        "title": {
+          "type": "string",
+          "description": "The title of the changeset."
+        },
+        "body": {
+          "type": "string",
+          "description": "The body (description) of the changeset."
+        },
         "branch": {
           "type": "string",
           "description": "The name of the Git branch to create or update on each repository with the changes."


### PR DESCRIPTION
This does two things:

1. When `workspaces` are used in the campaign spec, _only_ an archive of the workspace (including all subdirectories and subworkspaces) is downloaded. That helps a lot with monorepos where it's unfeasible to download the whole repository.
2. When only the workspace is downloaded two files from the root of the repository are additionally downloaded, if they exist: `.gitignore` and `.gitattributes`.

---

The code is by not polished yet, but it works, I added a lot of tests and hope to get a first round of reviews that I can then work off tomorrow.

What's missing:
- [x] I haven't tested the volume workspace mode manually yet
- [x] I want to remove the duplication between `unzip` and `(wc *dockerBindWorkspaceCreator) copyToWorkspace` and already have `prepareCopyDestinationFile`
- [x] Changelog entry
- [x] Make `fetchOnlyWorkspace` a flag that enables this feature
- [ ] Documentation in `sourcegraph/sourcegraph`

---

Big questions:

- [x] Do we want to make only-download-workspace-archive the default behaviour?
- [x] Do we want to make download-additional-files the default behaviour?

---

Thank you for reviewing.

Yours truly,

![image](https://user-images.githubusercontent.com/1185253/107623707-0a43bd00-6c5a-11eb-90c1-ac1091718411.png)
