### PR TITLE
Fix additional files being deleted prematurely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ All notable changes to `src-cli` are documented in this file.
 
 ### Fixed
 
-- Workspaces could sometimes fail set up with docker bind mount errors.
+- Workspaces could sometimes fail with docker bind mount errors, due to a race condition of multiple workspaces accessing the same auxilliary files. [#468](https://github.com/sourcegraph/src-cli/pull/468)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ All notable changes to `src-cli` are documented in this file.
 
 ### Fixed
 
+- Workspaces could sometimes fail set up with docker bind mount errors.
+
 ### Removed
 
 ## 3.24.5

--- a/internal/campaigns/repo_fetcher.go
+++ b/internal/campaigns/repo_fetcher.go
@@ -96,7 +96,7 @@ func (rf *repoFetcher) zipFor(repo *graphql.Repository, workspacePath string) *r
 			for _, component := range pathComponents {
 				for _, name := range []string{".gitignore", ".gitattributes"} {
 					filename := path.Join(currentPath, name)
-					localPath := filepath.Join(rf.dir, repo.SlugForPath(filename))
+					localPath := filepath.Join(rf.dir, repo.SlugForPath(workspacePath+filename))
 
 					zip.additionalFiles = append(zip.additionalFiles, &additionalFile{
 						filename:  filename,


### PR DESCRIPTION
When multiple containers use the same additional files, they could sometimes be deleted before the last container was done using them. Docker bind mount errors were happening then.
This fixes it by taking the workspace path into account for the local file path, making it truly unique between workspace runs.