### PR TITLE
Ask user for confirmation before deleting all users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to `src-cli` are documented in this file.
 
 ### Added
 
+- `src users delete` now asks for confirmation to delete all users when no user ID is provided. [#470](https://github.com/sourcegraph/src-cli/pull/470)
+
 ### Changed
 
 ### Fixed


### PR DESCRIPTION
This fixes https://github.com/sourcegraph/sourcegraph/issues/17859 by asking the user for confirmation before deleting all users on an instance.