### PR TITLE
Deprecate old ExecutionCache file formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ All notable changes to `src-cli` are documented in this file.
 
 ### Changed
 
+- Deprecated cache file formats are not read by `src campaign [apply|preview]` anymore.
+
 ### Fixed
 
 ### Removed

--- a/internal/campaigns/execution_cache.go
+++ b/internal/campaigns/execution_cache.go
@@ -5,7 +5,6 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -91,75 +90,15 @@ func (c ExecutionDiskCache) Get(ctx context.Context, key ExecutionCacheKey) (exe
 		return result, false, err
 	}
 
-	// We try to be backwards compatible and see if we also find older cache
-	// files.
-	//
-	// There are three different cache versions out in the wild and to be
-	// backwards compatible we read all of them.
-	//
-	// In Sourcegraph/src-cli 3.26 we can remove the code here and simply read
-	// the cache from `path`, since all the old cache files should be deleted
-	// until then.
-	globPattern := strings.TrimSuffix(path, cacheFileExt) + ".*"
-	matches, err := filepath.Glob(globPattern)
-	if err != nil {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return result, false, nil
+	}
+
+	if err := c.readCacheFile(path, &result); err != nil {
 		return result, false, err
 	}
 
-	switch len(matches) {
-	case 0:
-		// Nothing found
-		return result, false, nil
-	case 1:
-		// One cache file found
-		if err := c.readCacheFile(matches[0], &result); err != nil {
-			return result, false, err
-		}
-
-		// If it's an old cache file, we rewrite the cache and delete the old file
-		if isOldCacheFile(matches[0]) {
-			if err := c.Set(ctx, key, result); err != nil {
-				return result, false, errors.Wrap(err, "failed to rewrite cache in new format")
-			}
-			if err := os.Remove(matches[0]); err != nil {
-				return result, false, errors.Wrap(err, "failed to remove old cache file")
-			}
-		}
-
-		return result, true, err
-
-	default:
-		// More than one cache file found.
-		// Sort them so that we'll can possibly read from the one with the most
-		// current version.
-		sortCacheFiles(matches)
-
-		newest := matches[0]
-		toDelete := matches[1:]
-
-		// Read from newest
-		if err := c.readCacheFile(newest, &result); err != nil {
-			return result, false, err
-		}
-
-		// If the newest was also an older version, we write a new version...
-		if isOldCacheFile(newest) {
-			if err := c.Set(ctx, key, result); err != nil {
-				return result, false, errors.Wrap(err, "failed to rewrite cache in new format")
-			}
-			// ... and mark the file also as to-be-deleted
-			toDelete = append(toDelete, newest)
-		}
-
-		// Now we clean up the old ones
-		for _, path := range toDelete {
-			if err := os.Remove(path); err != nil {
-				return result, false, errors.Wrap(err, "failed to remove old cache file")
-			}
-		}
-
-		return result, true, nil
-	}
+	return result, true, nil
 }
 
 // sortCacheFiles sorts cache file paths by their "version", so that files
@@ -178,50 +117,14 @@ func (c ExecutionDiskCache) readCacheFile(path string, result *executionResult) 
 		return err
 	}
 
-	switch {
-	case strings.HasSuffix(path, ".v3.json"):
-		// v3 of the cache: we cache the diff and the outputs produced by the step.
-		if err := json.Unmarshal(data, result); err != nil {
-			// Delete the invalid data to avoid causing an error for next time.
-			if err := os.Remove(path); err != nil {
-				return errors.Wrap(err, "while deleting cache file with invalid JSON")
-			}
-			return errors.Wrapf(err, "reading cache file %s", path)
+	if err := json.Unmarshal(data, result); err != nil {
+		// Delete the invalid data to avoid causing an error for next time.
+		if err := os.Remove(path); err != nil {
+			return errors.Wrap(err, "while deleting cache file with invalid JSON")
 		}
-		return nil
-
-	case strings.HasSuffix(path, ".diff"):
-		// v2 of the cache: we only cached the diff, since that's the
-		// only bit of data we were interested in.
-		result.Diff = string(data)
-		result.Outputs = map[string]interface{}{}
-		// Conversion is lossy, though: we don't populate result.StepChanges.
-		result.ChangedFiles = &StepChanges{}
-
-		return nil
-
-	case strings.HasSuffix(path, ".json"):
-		// v1 of the cache: we cached the complete ChangesetSpec instead of just the diffs.
-		var spec ChangesetSpec
-		if err := json.Unmarshal(data, &spec); err != nil {
-			// Delete the invalid data to avoid causing an error for next time.
-			if err := os.Remove(path); err != nil {
-				return errors.Wrap(err, "while deleting cache file with invalid JSON")
-			}
-			return errors.Wrapf(err, "reading cache file %s", path)
-		}
-		if len(spec.Commits) != 1 {
-			return errors.New("cached result has no commits")
-		}
-
-		result.Diff = spec.Commits[0].Diff
-		result.Outputs = map[string]interface{}{}
-		result.ChangedFiles = &StepChanges{}
-
-		return nil
+		return errors.Wrapf(err, "reading cache file %s", path)
 	}
-
-	return fmt.Errorf("unknown file format for cache file %q", path)
+	return nil
 }
 
 func (c ExecutionDiskCache) Set(ctx context.Context, key ExecutionCacheKey, result executionResult) error {

--- a/internal/campaigns/execution_cache_test.go
+++ b/internal/campaigns/execution_cache_test.go
@@ -139,12 +139,6 @@ func TestExecutionDiskCache(t *testing.T) {
 		Outputs: map[string]interface{}{},
 	}
 
-	onlyDiff := executionResult{
-		Diff:         testDiff,
-		ChangedFiles: &StepChanges{},
-		Outputs:      map[string]interface{}{},
-	}
-
 	t.Run("cache contains v3 cache file", func(t *testing.T) {
 		cache := ExecutionDiskCache{Dir: cacheTmpDir(t)}
 
@@ -168,76 +162,6 @@ func TestExecutionDiskCache(t *testing.T) {
 			t.Fatalf("cache.Get returned unexpected error: %s", err)
 		}
 		assertCacheMiss(t, cache, cacheKey1)
-	})
-
-	t.Run("cache contains v1 cache file", func(t *testing.T) {
-		cache := ExecutionDiskCache{Dir: cacheTmpDir(t)}
-
-		// Empty cache, no hit
-		assertCacheMiss(t, cache, cacheKey1)
-
-		// Simulate old cache file lying around in cache
-		oldFilePath := writeV1CacheFile(t, cache, cacheKey1, testDiff)
-
-		// Cache hit, but only for the diff
-		assertCacheHit(t, cache, cacheKey1, onlyDiff)
-
-		// And the old file should be deleted
-		assertFileDeleted(t, oldFilePath)
-		// .. but we should still get a cache hit, because we rewrote the cache
-		assertCacheHit(t, cache, cacheKey1, onlyDiff)
-	})
-
-	t.Run("cache contains v2 cache file", func(t *testing.T) {
-		cache := ExecutionDiskCache{Dir: cacheTmpDir(t)}
-
-		// Empty cache, no hit
-		assertCacheMiss(t, cache, cacheKey1)
-
-		// Simulate old cache file lying around in cache
-		oldFilePath := writeV2CacheFile(t, cache, cacheKey1, testDiff)
-
-		// Now we get a cache hit, but only for the diff
-		assertCacheHit(t, cache, cacheKey1, onlyDiff)
-
-		// And the old file should be deleted
-		assertFileDeleted(t, oldFilePath)
-		// .. but we should still get a cache hit, because we rewrote the cache
-		assertCacheHit(t, cache, cacheKey1, onlyDiff)
-	})
-
-	t.Run("cache contains one old and one v3 cache file", func(t *testing.T) {
-		cache := ExecutionDiskCache{Dir: cacheTmpDir(t)}
-
-		// Simulate v2 and v3 files in cache
-		oldFilePath := writeV1CacheFile(t, cache, cacheKey1, testDiff)
-
-		if err := cache.Set(ctx, cacheKey1, value); err != nil {
-			t.Fatalf("cache.Set returned unexpected error: %s", err)
-		}
-
-		// Cache hit
-		assertCacheHit(t, cache, cacheKey1, value)
-
-		// And the old file should be deleted
-		assertFileDeleted(t, oldFilePath)
-	})
-
-	t.Run("cache contains multiple old cache files", func(t *testing.T) {
-		cache := ExecutionDiskCache{Dir: cacheTmpDir(t)}
-
-		// Simulate v1 and v2 files in cache
-		oldFilePath1 := writeV1CacheFile(t, cache, cacheKey1, testDiff)
-		oldFilePath2 := writeV1CacheFile(t, cache, cacheKey1, testDiff)
-
-		// Now we get a cache hit, but only for the diff
-		assertCacheHit(t, cache, cacheKey1, onlyDiff)
-
-		// And the old files should be deleted
-		assertFileDeleted(t, oldFilePath1)
-		assertFileDeleted(t, oldFilePath2)
-		// .. but we should still get a cache hit, because we rewrote the cache
-		assertCacheHit(t, cache, cacheKey1, onlyDiff)
 	})
 }
 


### PR DESCRIPTION
This fixes sourcegraph/sourcegraph#17306 by deleting support for old cache files.

The ticket is slightly wrong, since the previous code did already delete
these files, so we don't have to deprecate and then delete support. We
already transitioned to the new cache file format in 3.24 and 3.25 now.

The next release, 3.26, will only read the new cache format.