### PR TITLE
Add flag to insecurely skip certificate validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to `src-cli` are documented in this file.
 
 ### Added
 
+- Added a flag `-insecure-skip-verify` to disable TLS certificate validation.
+
 ### Changed
 
 - Deprecated cache file formats are not read by `src campaign [apply|preview]` anymore.

--- a/cmd/src/version.go
+++ b/cmd/src/version.go
@@ -60,7 +60,7 @@ func getRecommendedVersion(ctx context.Context, client api.Client) (string, erro
 		return "", err
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := client.Do(req)
 	if err != nil {
 		return "", err
 	}

--- a/internal/api/flags.go
+++ b/internal/api/flags.go
@@ -5,26 +5,29 @@ import "flag"
 // Flags encapsulates the standard flags that should be added to all commands
 // that issue API requests.
 type Flags struct {
-	dump    *bool
-	getCurl *bool
-	trace   *bool
+	dump               *bool
+	getCurl            *bool
+	trace              *bool
+	insecureSkipVerify *bool
 }
 
 // NewFlags instantiates a new Flags structure and attaches flags to the given
 // flag set.
 func NewFlags(flagSet *flag.FlagSet) *Flags {
 	return &Flags{
-		dump:    flagSet.Bool("dump-requests", false, "Log GraphQL requests and responses to stdout"),
-		getCurl: flagSet.Bool("get-curl", false, "Print the curl command for executing this query and exit (WARNING: includes printing your access token!)"),
-		trace:   flagSet.Bool("trace", false, "Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing"),
+		dump:               flagSet.Bool("dump-requests", false, "Log GraphQL requests and responses to stdout"),
+		getCurl:            flagSet.Bool("get-curl", false, "Print the curl command for executing this query and exit (WARNING: includes printing your access token!)"),
+		trace:              flagSet.Bool("trace", false, "Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing"),
+		insecureSkipVerify: flagSet.Bool("insecure-skip-verify", false, "Skip validating x.509 certificates against trusted chains"),
 	}
 }
 
 func defaultFlags() *Flags {
 	d := false
 	return &Flags{
-		dump:    &d,
-		getCurl: &d,
-		trace:   &d,
+		dump:               &d,
+		getCurl:            &d,
+		trace:              &d,
+		insecureSkipVerify: &d,
 	}
 }

--- a/internal/campaigns/repo_fetcher.go
+++ b/internal/campaigns/repo_fetcher.go
@@ -303,7 +303,7 @@ func fetchRepositoryFile(ctx context.Context, client api.Client, repo *graphql.R
 		req.Header.Set("Accept", "application/zip")
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := client.Do(req)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
This adds an optional flag to disable certificate validation. Given that, I think it should fix https://github.com/sourcegraph/src-cli/issues/463. I don't know how I feel about this, but it seems to work ok:

![image](https://user-images.githubusercontent.com/19534377/108751901-1c1f3d00-7543-11eb-8a51-0dd5fee6142f.png)
