### PR TITLE
campaigns: only pull the Docker image in volume mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ All notable changes to `src-cli` are documented in this file.
 
 ### Changed
 
+- The volume workspace Docker image is now only pulled if the volume workspace mode is in use. []()
+
 ### Fixed
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ All notable changes to `src-cli` are documented in this file.
 
 ### Changed
 
-- The volume workspace Docker image is now only pulled if the volume workspace mode is in use. []()
+- The volume workspace Docker image is now only pulled if the volume workspace mode is in use. [#477](https://github.com/sourcegraph/src-cli/pull/477)
 
 ### Fixed
 


### PR DESCRIPTION
This code went through a few iterations when we were developing it: originally, we only pulled the helper Docker image if volume mode was actually in use, but then we needed additional heuristics to determine when to enable volume mode based on the campaign's Docker images, which created a circular dependency between the Docker images and the workspace Docker image.

However, something changed right at the end of this that I hadn't fully thought through: originally, the workspace creator defines what Docker image(s) it required, but that was simplified into the service itself at some point. Additionally, pulling the helper image became a separate step in `SetDockerImages`, whereas before it was part of the same loop used for pulling campaign images.

The heuristic in `bestWorkspaceCreator()` requires that the Docker images be "set" within the campaign spec, but with those changes, we now actually have the right state in place within `SetDockerImages` to check which workspace creator will be used, so we've come full circle: we can prevent the helper image from being pulled if we _know_ it won't be used.

Or, in effect: you can ensure that the only Docker images that will be pulled by `src` when executing a campaign are encoded in the campaign spec with this change if you use `-workspace bind` on your command line, accepting that this may be slower on macOS and Windows than the default.

Fixes https://github.com/sourcegraph/customer/issues/213.