### PR TITLE
campaigns: better handle non-root images in volume mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ All notable changes to `src-cli` are documented in this file.
 
 ### Fixed
 
+- Using volume workspace mode could result in Git errors when used with Docker containers that do not run as root. These have been fixed. [#478](https://github.com/sourcegraph/src-cli/issues/478)
+
 ### Removed
 
 ## 3.25.1

--- a/docker/campaign-volume-workspace/Dockerfile
+++ b/docker/campaign-volume-workspace/Dockerfile
@@ -4,10 +4,4 @@
 
 FROM alpine:3.13.1@sha256:08d6ca16c60fe7490c03d10dc339d9fd8ea67c6466dea8d558526b1330a85930
 
-# Note that we have to configure git's user.email and user.name settings to
-# avoid issues when committing changes. These values are not used when creating
-# changesets, since we only extract the diff from the container and not a full
-# patch, but need to be set to avoid git erroring out.
-RUN apk add --update curl git unzip && \
-    git config --global user.email campaigns@sourcegraph.com && \
-    git config --global user.name 'Sourcegraph Campaigns'
+RUN apk add --update git unzip

--- a/internal/campaigns/volume_workspace.go
+++ b/internal/campaigns/volume_workspace.go
@@ -70,6 +70,13 @@ set -e
 set -x
 
 git init
+
+# Note that we don't actually use these anywhere, since we're not creating the
+# real commits in this container, but we do need _something_ set to avoid Git
+# erroring out.
+git config user.name 'Sourcegraph Campaigns'
+git config user.email campaigns@sourcegraph.com
+
 # --force because we want previously "gitignored" files in the repository
 git add --force --all
 git commit --quiet --all --allow-empty -m src-action-exec
@@ -281,6 +288,10 @@ func (w *dockerVolumeWorkspace) runScript(ctx context.Context, target, script st
 		return nil, errors.Wrap(err, "writing run script")
 	}
 	f.Close()
+
+	// Sidestep any umask issues on the temporary file by always making it
+	// executable by everyone.
+	os.Chmod(name, 0755)
 
 	common, err := w.DockerRunOpts(ctx, target)
 	if err != nil {


### PR DESCRIPTION
#478 has the details on what's being fixed here. I also realised that we don't use `curl` any more within the volume workspace itself, so we can reduce the size of the helper image.