### PR TITLE
Also respect client flags in src login command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,13 +15,21 @@ All notable changes to `src-cli` are documented in this file.
 
 ### Changed
 
+### Fixed
+
+- The src login command now also properly respects the `-insecure-skip-verify` flag.
+
+### Removed
+
+## 3.25.2
+
+### Changed
+
 - The volume workspace Docker image is now only pulled if the volume workspace mode is in use. [#477](https://github.com/sourcegraph/src-cli/pull/477)
 
 ### Fixed
 
 - Using volume workspace mode could result in Git errors when used with Docker containers that do not run as root. These have been fixed. [#478](https://github.com/sourcegraph/src-cli/issues/478)
-
-### Removed
 
 ## 3.25.1
 

--- a/cmd/src/login_test.go
+++ b/cmd/src/login_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -15,7 +16,7 @@ func TestLogin(t *testing.T) {
 		t.Helper()
 
 		var out bytes.Buffer
-		err = loginCmd(context.Background(), cfg, endpointArg, &out)
+		err = loginCmd(context.Background(), cfg, cfg.apiClient(nil, ioutil.Discard), endpointArg, &out)
 		return strings.TrimSpace(out.String()), err
 	}
 


### PR DESCRIPTION
This wasn't respecting api flags.
I also had to update the logic for retrieving the endpoint a bit, since it could have picked up a flag.