### PR TITLE
search: add support for streaming search

### DIFF
--- a/cmd/src/format.go
+++ b/cmd/src/format.go
@@ -60,6 +60,9 @@ func parseTemplate(text string) (*template.Template, error) {
 		"addFloat": func(x, y float64) float64 {
 			return x + y
 		},
+		"addInt32": func(x, y int32) int32 {
+			return x + y
+		},
 		"debug": func(v interface{}) string {
 			data, _ := marshalIndent(v)
 			fmt.Println(string(data))
@@ -90,6 +93,13 @@ func parseTemplate(text string) (*template.Template, error) {
 		"htmlToPlainText":                   searchTemplateFuncs["htmlToPlainText"],
 		"buildVersionHasNewSearchInterface": searchTemplateFuncs["buildVersionHasNewSearchInterface"],
 		"renderResult":                      searchTemplateFuncs["renderResult"],
+
+		// Register stream-search specific template functions.
+		"streamSearchSequentialLineNumber": streamSearchTemplateFuncs["streamSearchSequentialLineNumber"],
+		"streamSearchHighlightMatch":       streamSearchTemplateFuncs["streamSearchHighlightMatch"],
+		"streamSearchHighlightCommit":      streamSearchTemplateFuncs["streamSearchHighlightCommit"],
+		"streamSearchRenderCommitLabel":    streamSearchTemplateFuncs["streamSearchRenderCommitLabel"],
+		"matchOrMatches":                   streamSearchTemplateFuncs["matchOrMatches"],
 
 		// Alert rendering
 		"searchAlertRender": func(alert searchResultsAlert) string {

--- a/cmd/src/search.go
+++ b/cmd/src/search.go
@@ -54,11 +54,27 @@ Other tips:
 		explainJSONFlag = flagSet.Bool("explain-json", false, "Explain the JSON output schema and exit.")
 		apiFlags        = api.NewFlags(flagSet)
 		lessFlag        = flagSet.Bool("less", true, "Pipe output to 'less -R' (only if stdout is terminal, and not json flag)")
+		streamFlag      = flagSet.Bool("stream", false, "Consume results as stream.")
+
+		// Streaming.
+		_ = flagSet.Int("display", -1, "Limit the number of results shown. Only supported for streaming.")
 	)
 
 	handler := func(args []string) error {
 		if err := flagSet.Parse(args); err != nil {
 			return err
+		}
+
+		if *streamFlag {
+			// Remove -stream from args.
+			argsWOStream := make([]string, 0, len(args)-1)
+			for _, a := range args {
+				if a == "-stream" {
+					continue
+				}
+				argsWOStream = append(argsWOStream, a)
+			}
+			return streamHandler(argsWOStream)
 		}
 
 		if *explainJSONFlag {

--- a/cmd/src/search_alert.go
+++ b/cmd/src/search_alert.go
@@ -19,15 +19,18 @@ func init() {
 	}
 }
 
+// ProposedQuery is a suggested query to run when we emit an alert.
+type ProposedQuery struct {
+	Description string
+	Query       string
+}
+
 // searchResultsAlert is a type that can be used to unmarshal values returned by
 // the searchResultsAlertFragment GraphQL fragment below.
 type searchResultsAlert struct {
 	Title           string
 	Description     string
-	ProposedQueries []struct {
-		Description string
-		Query       string
-	}
+	ProposedQueries []ProposedQuery
 }
 
 // Render renders an alert to a string ready to be output to a console,

--- a/cmd/src/search_alert_test.go
+++ b/cmd/src/search_alert_test.go
@@ -13,10 +13,7 @@ func TestRender(t *testing.T) {
 	full := &searchResultsAlert{
 		Title:       "foo",
 		Description: "bar",
-		ProposedQueries: []struct {
-			Description string
-			Query       string
-		}{
+		ProposedQueries: []ProposedQuery{
 			{
 				Description: "quux",
 				Query:       "xyz:abc",

--- a/cmd/src/search_stream.go
+++ b/cmd/src/search_stream.go
@@ -233,7 +233,13 @@ const streamingTemplate = `
 	
 	{{- /* Repository > author name "commit subject" (time ago) */ -}}
 	{{- color "search-commit-subject"}}{{(streamSearchRenderCommitLabel .Label)}}{{color "nc" -}}
-	{{- color "success"}}{{matchOrMatches (len .Ranges)}}{{color "nc" -}}
+	{{- color "success" -}}
+		{{- if (len .Ranges) -}}
+			{{matchOrMatches (len .Ranges)}}
+		{{- else -}}
+			{{matchOrMatches 1}}
+		{{- end -}}
+	{{- color "nc" -}}
 	{{- "\n" -}}
 	{{- color "search-border"}}{{"--------------------------------------------------------------------------------\n"}}{{color "nc"}}
 	{{- color "search-border"}}{{color "nc"}}{{indent (streamSearchHighlightCommit .Content .Ranges) "  "}}

--- a/cmd/src/search_stream.go
+++ b/cmd/src/search_stream.go
@@ -1,0 +1,413 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"flag"
+	"fmt"
+	"net/url"
+	"os"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/sourcegraph/src-cli/internal/api"
+	"github.com/sourcegraph/src-cli/internal/streaming"
+)
+
+var labelRegexp *regexp.Regexp
+
+func init() {
+	labelRegexp, _ = regexp.Compile("(?:\\[)(.*?)(?:])")
+}
+
+// streamHandler handles search requests which contain the flag "stream".
+// Requests are sent to search/stream instead of the GraphQL api.
+func streamHandler(args []string) error {
+	flagSet := flag.NewFlagSet("streaming search", flag.ExitOnError)
+	var (
+		display  = flagSet.Int("display", -1, "Limit the number of results that are displayed. Note that the statistics continue to report all results.")
+		apiFlags = api.StreamingFlags(flagSet)
+	)
+	if err := flagSet.Parse(args); err != nil {
+		return err
+	}
+
+	query := flagSet.Arg(0)
+
+	t, err := parseTemplate(streamingTemplate)
+	if err != nil {
+		panic(err)
+	}
+
+	// Create request.
+	client := cfg.apiClient(apiFlags, flagSet.Output())
+	req, err := client.NewHTTPRequest(context.Background(), "GET", "search/stream?q="+url.QueryEscape(query), nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Accept", "text/event-stream")
+	if *display >= 0 {
+		q := req.URL.Query()
+		q.Add("display", strconv.Itoa(*display))
+		req.URL.RawQuery = q.Encode()
+	}
+
+	// Send request.
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("error sending request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Process response.
+	err = streaming.Decoder{
+		OnProgress: func(progress *streaming.Progress) {
+			// We only show the final progress.
+			if !progress.Done {
+				return
+			}
+			err = t.ExecuteTemplate(os.Stdout, "progress", progress)
+			if err != nil {
+				fmt.Printf("ExecuteTemplate: %s\n", err)
+			}
+			return
+		},
+		OnError: func(eventError *streaming.EventError) {
+			fmt.Printf("ERR: %s", eventError.Message)
+		},
+		OnAlert: func(alert *streaming.EventAlert) {
+			proposedQueries := make([]ProposedQuery, len(alert.ProposedQueries))
+			for _, pq := range alert.ProposedQueries {
+				proposedQueries = append(proposedQueries, ProposedQuery{
+					Description: pq.Description,
+					Query:       pq.Query,
+				})
+			}
+
+			err = t.ExecuteTemplate(os.Stdout, "alert", searchResultsAlert{
+				Title:           alert.Title,
+				Description:     alert.Description,
+				ProposedQueries: proposedQueries,
+			})
+			if err != nil {
+				fmt.Printf("ExecuteTemplate: %s\n", err)
+				return
+			}
+		},
+		OnMatches: func(matches []streaming.EventMatch) {
+			for _, match := range matches {
+				if file, ok := match.(*streaming.EventFileMatch); ok {
+					err = t.ExecuteTemplate(os.Stdout, "file", struct {
+						Query string
+						*streaming.EventFileMatch
+					}{
+						Query:          query,
+						EventFileMatch: file,
+					},
+					)
+					if err != nil {
+						fmt.Printf("ExecuteTemplate: %s\n", err)
+						return
+					}
+					continue
+				}
+
+				if repo, ok := match.(*streaming.EventRepoMatch); ok {
+					err = t.ExecuteTemplate(os.Stdout, "repo", struct {
+						SourcegraphEndpoint string
+						*streaming.EventRepoMatch
+					}{
+						SourcegraphEndpoint: cfg.Endpoint,
+						EventRepoMatch:      repo,
+					})
+					if err != nil {
+						fmt.Printf("ExecuteTemplate: %s\n", err)
+						return
+					}
+					continue
+				}
+
+				if commit, ok := match.(*streaming.EventCommitMatch); ok {
+					err = t.ExecuteTemplate(os.Stdout, "commit", struct {
+						SourcegraphEndpoint string
+						*streaming.EventCommitMatch
+					}{
+						SourcegraphEndpoint: cfg.Endpoint,
+						EventCommitMatch:    commit,
+					})
+					if err != nil {
+						fmt.Printf("ExecuteTemplate: %s\n", err)
+						return
+					}
+					continue
+				}
+
+				if symbol, ok := match.(*streaming.EventSymbolMatch); ok {
+					err = t.ExecuteTemplate(os.Stdout, "symbol", struct {
+						SourcegraphEndpoint string
+						*streaming.EventSymbolMatch
+					}{
+						SourcegraphEndpoint: cfg.Endpoint,
+						EventSymbolMatch:    symbol,
+					},
+					)
+					if err != nil {
+						fmt.Printf("ExecuteTemplate: %s\n", err)
+						return
+					}
+					continue
+				}
+			}
+		},
+	}.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("error during decoding: %w", err)
+	}
+
+	// Write trace to output.
+	if apiFlags.Trace() {
+		_, err := flagSet.Output().Write([]byte(fmt.Sprintf("x-trace: %s\n", resp.Header.Get("x-trace"))))
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+const streamingTemplate = `
+{{define "file"}}
+	{{- /* Repository and file name */ -}}
+	{{- color "search-repository"}}{{.Repository}}{{color "nc" -}}
+	{{- " › " -}}
+	{{- color "search-filename"}}{{.Path}}{{color "nc" -}}
+	{{- color "success"}}{{matchOrMatches (len .LineMatches)}}{{color "nc" -}}
+	{{- "\n" -}}
+	{{- color "search-border"}}{{"--------------------------------------------------------------------------------\n"}}{{color "nc"}}
+	
+	{{- /* Line matches */ -}}
+	{{- $lineMatches := .LineMatches -}}
+	{{- range $index, $match := $lineMatches -}}
+		{{- if not (streamSearchSequentialLineNumber $lineMatches $index) -}}
+			{{- color "search-border"}}{{"  ------------------------------------------------------------------------------\n"}}{{color "nc"}}
+		{{- end -}}
+		{{- "  "}}{{color "search-line-numbers"}}{{pad (addInt32 $match.LineNumber 1) 6 " "}}{{color "nc" -}}
+		{{- color "search-border"}}{{" |  "}}{{color "nc"}}{{streamSearchHighlightMatch $.Query $match }}
+	{{- end -}}
+	{{- "\n" -}}
+{{- end -}}
+
+{{define "symbol"}}
+	{{- /* Repository and file name */ -}}
+	{{- color "search-repository"}}{{.Repository}}{{color "nc" -}}
+	{{- " › " -}}
+	{{- color "search-filename"}}{{.Path}}{{color "nc" -}}
+	{{- color "success"}}{{matchOrMatches (len .Symbols)}}{{color "nc" -}}
+	{{- "\n" -}}
+	{{- color "search-border"}}{{"--------------------------------------------------------------------------------\n"}}{{color "nc"}}
+	
+	{{- /* Symbols */ -}}
+	{{- $symbols := .Symbols -}}
+	{{- range $index, $match := $symbols -}}
+		{{- color "success"}}{{.Name}}{{color "nc" -}} ({{.Kind}}{{if .ContainerName}}{{printf ", %s" .ContainerName}}{{end}})
+		{{- color "search-border"}}{{" ("}}{{color "nc" -}}
+		{{- color "search-repository"}}{{$.SourcegraphEndpoint}}/{{$match.URL}}{{color "nc" -}}
+		{{- color "search-border"}}{{")\n"}}{{color "nc" -}}
+	{{- end -}}
+	{{- "\n" -}}
+{{- end -}}
+
+{{define "repo"}}
+	{{- /* Link to the result */ -}}
+	{{- color "success"}}{{.Repository}}{{color "nc" -}}
+	{{- color "search-border"}}{{" ("}}{{color "nc" -}}
+	{{- color "search-repository"}}{{$.SourcegraphEndpoint}}/{{.Repository}}{{color "nc" -}}
+	{{- color "search-border"}}{{")"}}{{color "nc" -}}
+	{{- color "success"}}{{" ("}}{{"1 match)"}}{{color "nc" -}}
+	{{- "\n" -}}
+{{- end -}}
+
+{{define "commit"}}
+	{{- /* Link to the result */ -}}
+	{{- color "search-border"}}{{"("}}{{color "nc" -}}
+	{{- color "search-link"}}{{$.SourcegraphEndpoint}}{{.URL}}{{color "nc" -}}
+	{{- color "search-border"}}{{")\n"}}{{color "nc" -}}
+	{{- color "nc" -}}
+	
+	{{- /* Repository > author name "commit subject" (time ago) */ -}}
+	{{- color "search-commit-subject"}}{{(streamSearchRenderCommitLabel .Label)}}{{color "nc" -}}
+	{{- color "success"}}{{matchOrMatches (len .Ranges)}}{{color "nc" -}}
+	{{- "\n" -}}
+	{{- color "search-border"}}{{"--------------------------------------------------------------------------------\n"}}{{color "nc"}}
+	{{- color "search-border"}}{{color "nc"}}{{indent (streamSearchHighlightCommit .Content .Ranges) "  "}}
+{{end}}
+
+{{define "alert"}}
+	{{- searchAlertRender . -}}
+{{end}}
+
+{{define "progress"}}
+	{{- color "logo" -}}✱{{- color "nc" -}}
+	{{- " " -}}
+	{{- if eq .MatchCount 0 -}}
+		{{- color "warning" -}}
+	{{- else -}}
+		{{- color "success" -}}
+	{{- end -}}
+	{{- .MatchCount -}}{{if len .Skipped}}+{{end}} results{{- color "nc" -}}
+	{{- " in " -}}{{color "success"}}{{msDuration .DurationMs}}{{if .RepositoriesCount}}{{- color "nc" -}}
+	{{- " from " -}}{{color "success"}}{{.RepositoriesCount}}{{- " Repositories" -}}{{- color "nc" -}}{{end}}
+	{{- "\n" -}}
+	{{if len .Skipped}}
+		{{- "\n" -}}
+		{{- "Some results excluded:" -}}
+		{{- "\n" -}}
+		{{- range $index, $skipped := $.Skipped -}}
+			{{indent $skipped.Title "    "}}{{- "\n" -}}
+		{{- end -}}
+		{{- "\n" -}}
+	{{- end -}}
+{{- end -}}
+`
+
+var streamSearchTemplateFuncs = map[string]interface{}{
+	"streamSearchHighlightMatch": func(query string, match streaming.EventLineMatch) string {
+		var highlights []highlight
+		if strings.Contains(query, "patterntype:structural") {
+			highlights = streamConvertMatchToHighlights(match, false)
+			return applyHighlightsForFile(match.Line, highlights)
+		}
+
+		highlights = streamConvertMatchToHighlights(match, true)
+		return applyHighlights(match.Line, highlights, ansiColors["search-match"], ansiColors["nc"])
+	},
+
+	"streamSearchSequentialLineNumber": func(lineMatches []streaming.EventLineMatch, index int) bool {
+		prevIndex := index - 1
+		if prevIndex < 0 {
+			return true
+		}
+		prevLineNumber := lineMatches[prevIndex].LineNumber
+		lineNumber := lineMatches[index].LineNumber
+		return prevLineNumber == lineNumber-1
+	},
+
+	"streamSearchHighlightCommit": func(content string, ranges [][3]int32) string {
+		highlights := make([]highlight, len(ranges))
+		for _, r := range ranges {
+			highlights = append(highlights, highlight{
+				line:      int(r[0]),
+				character: int(r[1]),
+				length:    int(r[2]),
+			})
+		}
+		if strings.HasPrefix(content, "```diff") {
+			return streamSearchHighlightDiffPreview(content, highlights)
+		}
+		return applyHighlights(stripMarkdownMarkers(content), highlights, ansiColors["search-match"], ansiColors["nc"])
+	},
+
+	"streamSearchRenderCommitLabel": func(label string) string {
+		m := labelRegexp.FindAllStringSubmatch(label, -1)
+		if len(m) != 3 || len(m[0]) < 2 || len(m[1]) < 2 || len(m[2]) < 2 {
+			return label
+		}
+		return m[0][1] + " > " + m[1][1] + " : " + m[2][1]
+	},
+
+	"matchOrMatches": func(i int) string {
+		if i == 1 {
+			return " (1 match)"
+		}
+		return fmt.Sprintf(" (%d matches)", i)
+	},
+}
+
+func streamSearchHighlightDiffPreview(diffPreview string, highlights []highlight) string {
+	useColordiff, err := strconv.ParseBool(os.Getenv("COLORDIFF"))
+	if err != nil {
+		useColordiff = true
+	}
+	if colorDisabled || !useColordiff {
+		// Only highlight the matches.
+		return applyHighlights(stripMarkdownMarkers(diffPreview), highlights, ansiColors["search-match"], ansiColors["nc"])
+	}
+	path, err := exec.LookPath("colordiff")
+	if err != nil {
+		// colordiff not installed; only highlight the matches.
+		return applyHighlights(stripMarkdownMarkers(diffPreview), highlights, ansiColors["search-match"], ansiColors["nc"])
+	}
+
+	// First highlight the matches, but use a special "end of match" token
+	// instead of no color (so that we don'streamingTemplate terminate colors that colordiff
+	// adds).
+	uniqueStartOfMatchToken := "pXRdMhZbgnPL355429nsO4qFgX86LfXTSmqH4Nr3#*(@)!*#()@!APPJB8ZRutvZ5fdL01273i6OdzLDm0UMC9372891skfJTl2c52yR1v"
+	uniqueEndOfMatchToken := "v1Ry25c2lTJfks1982739CMU0mDLzdO6i37210Ldf5ZvtuRZ8BJPPA!@)(#*!)@(*#3rN4HqmSTXfL68XgFq4Osn924553LPngbZhMdRXp"
+	diff := applyHighlights(stripMarkdownMarkers(diffPreview), highlights, uniqueStartOfMatchToken, uniqueEndOfMatchToken)
+
+	// Now highlight our diff with colordiff.
+	var buf bytes.Buffer
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(diff)
+	cmd.Stdout = &buf
+	if err := cmd.Run(); err != nil {
+		fmt.Println("warning: colordiff failed to colorize diff:", err)
+		return diff
+	}
+	colorized := buf.String()
+	var final []string
+	for _, line := range strings.Split(colorized, "\n") {
+		// fmt.Println("LINE", line)
+		// Find where the start-of-match token is in the line.
+		somToken := strings.Index(line, uniqueStartOfMatchToken)
+
+		// Find which ANSI codes are to the left of our start-of-match token.
+		indices := ansiRegexp.FindAllStringIndex(line, -1)
+		matches := ansiRegexp.FindAllString(line, -1)
+		var left []string
+		for k, index := range indices {
+			if index[0] < somToken && index[1] < somToken {
+				left = append(left, matches[k])
+			}
+		}
+
+		// Replace our start-of-match token with the color we wish.
+		line = strings.Replace(line, uniqueStartOfMatchToken, ansiColors["search-match"], -1)
+
+		// Replace our end-of-match token with the color terminator,
+		// and start all colors that were previously started to the left.
+		line = strings.Replace(line, uniqueEndOfMatchToken, ansiColors["nc"]+strings.Join(left, ""), -1)
+
+		final = append(final, line)
+	}
+	return strings.Join(final, "\n")
+}
+
+func stripMarkdownMarkers(content string) string {
+	content = strings.TrimLeft(content, "```COMMIT_EDITMSG\n")
+	content = strings.TrimLeft(content, "```diff\n")
+	return strings.TrimRight(content, "\n```")
+}
+
+// convertMatchToHighlights converts a FileMatch m to a highlight data type.
+// When isPreview is true, it is assumed that the result to highlight is only on
+// one line, and the offets are relative to this line. When isPreview is false,
+// the lineNumber from the FileMatch data is used, which is relative to the file
+// content.
+func streamConvertMatchToHighlights(m streaming.EventLineMatch, isPreview bool) (highlights []highlight) {
+	var line int
+	for _, offsetAndLength := range m.OffsetAndLengths {
+		ol := offsetAndLength
+		offset := int(ol[0])
+		length := int(ol[1])
+		if isPreview {
+			line = 1
+		} else {
+			line = int(m.LineNumber)
+		}
+		highlights = append(highlights, highlight{line: line, character: offset, length: length})
+	}
+	return highlights
+}

--- a/cmd/src/search_stream.go
+++ b/cmd/src/search_stream.go
@@ -219,7 +219,6 @@ const streamingTemplate = `
 		{{- range $index, $skipped := $.Skipped -}}
 			{{indent $skipped.Title "    "}}{{- "\n" -}}
 		{{- end -}}
-		{{- "\n" -}}
 	{{- end -}}
 {{- end -}}
 `

--- a/cmd/src/search_stream.go
+++ b/cmd/src/search_stream.go
@@ -70,7 +70,7 @@ func streamHandler(args []string) error {
 			}
 			err = t.ExecuteTemplate(os.Stdout, "progress", progress)
 			if err != nil {
-				fmt.Printf("ExecuteTemplate: %s\n", err)
+				_, _ = flagSet.Output().Write([]byte(fmt.Sprintf("error when executing template: %s\n", err)))
 			}
 			return
 		},
@@ -92,7 +92,7 @@ func streamHandler(args []string) error {
 				ProposedQueries: proposedQueries,
 			})
 			if err != nil {
-				fmt.Printf("ExecuteTemplate: %s\n", err)
+				_, _ = flagSet.Output().Write([]byte(fmt.Sprintf("error when executing template: %s\n", err)))
 				return
 			}
 		},
@@ -100,15 +100,13 @@ func streamHandler(args []string) error {
 			for _, match := range matches {
 				if file, ok := match.(*streaming.EventFileMatch); ok {
 					err = t.ExecuteTemplate(os.Stdout, "file", struct {
-						Query string
 						*streaming.EventFileMatch
 					}{
-						Query:          query,
 						EventFileMatch: file,
 					},
 					)
 					if err != nil {
-						fmt.Printf("ExecuteTemplate: %s\n", err)
+						_, _ = flagSet.Output().Write([]byte(fmt.Sprintf("error when executing template: %s\n", err)))
 						return
 					}
 					continue
@@ -123,7 +121,7 @@ func streamHandler(args []string) error {
 						EventRepoMatch:      repo,
 					})
 					if err != nil {
-						fmt.Printf("ExecuteTemplate: %s\n", err)
+						_, _ = flagSet.Output().Write([]byte(fmt.Sprintf("error when executing template: %s\n", err)))
 						return
 					}
 					continue
@@ -138,7 +136,7 @@ func streamHandler(args []string) error {
 						EventCommitMatch:    commit,
 					})
 					if err != nil {
-						fmt.Printf("ExecuteTemplate: %s\n", err)
+						_, _ = flagSet.Output().Write([]byte(fmt.Sprintf("error when executing template: %s\n", err)))
 						return
 					}
 					continue
@@ -154,7 +152,7 @@ func streamHandler(args []string) error {
 					},
 					)
 					if err != nil {
-						fmt.Printf("ExecuteTemplate: %s\n", err)
+						_, _ = flagSet.Output().Write([]byte(fmt.Sprintf("error when executing template: %s\n", err)))
 						return
 					}
 					continue

--- a/cmd/src/search_stream_test.go
+++ b/cmd/src/search_stream_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
+	"github.com/sourcegraph/src-cli/internal/api"
 	"github.com/sourcegraph/src-cli/internal/streaming"
 )
 
@@ -117,11 +118,10 @@ func TestSearchStream(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	flagSet := flag.NewFlagSet("streaming search test", flag.ExitOnError)
-	flags := newStreamingFlags(flagSet)
-	client := cfg.apiClient(flags.apiFlags, flagSet.Output())
-
-	err = doStreamSearch("", flags, client, w)
+	flagSet := flag.NewFlagSet("test", flag.ExitOnError)
+	flags := api.NewFlags(flagSet)
+	client := cfg.apiClient(flags, flagSet.Output())
+	err = streamSearch("", streaming.Opts{}, client, w)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/src/search_stream_test.go
+++ b/cmd/src/search_stream_test.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"flag"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/sourcegraph/src-cli/internal/streaming"
+)
+
+var event []streaming.EventMatch
+
+func mockStreamHandler(w http.ResponseWriter, _ *http.Request) {
+	writer, _ := streaming.NewWriter(w)
+	writer.Event("matches", event)
+	writer.Event("done", nil)
+}
+
+func testServer(t *testing.T, handler http.Handler) *httptest.Server {
+	t.Helper()
+	// We need a stable port, because src-cli output contains references to the host.
+	// Here we exchange the standard listener with our own.
+	l, err := net.Listen("tcp", "127.0.0.1:55128")
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := httptest.NewUnstartedServer(handler)
+	s.Listener.Close()
+	s.Listener = l
+	s.Start()
+	return s
+}
+
+func TestSearchStream(t *testing.T) {
+	s := testServer(t, http.HandlerFunc(mockStreamHandler))
+	defer s.Close()
+
+	cfg = &config{
+		Endpoint: s.URL,
+	}
+	defer func() { cfg = nil }()
+
+	event = []streaming.EventMatch{
+		&streaming.EventFileMatch{
+			Type:       streaming.FileMatchType,
+			Path:       "path/to/file",
+			Repository: "org/repo",
+			Branches:   nil,
+			Version:    "",
+			LineMatches: []streaming.EventLineMatch{
+				{
+					Line:             "foo bar",
+					LineNumber:       4,
+					OffsetAndLengths: [][2]int32{{4, 3}},
+				},
+			},
+		},
+		&streaming.EventRepoMatch{
+			Type:       streaming.RepoMatchType,
+			Repository: "sourcegraph/sourcegraph",
+			Branches:   []string{},
+		},
+		&streaming.EventSymbolMatch{
+			Type:       streaming.SymbolMatchType,
+			Path:       "path/to/file",
+			Repository: "org/repo",
+			Branches:   []string{},
+			Version:    "",
+			Symbols: []streaming.Symbol{
+				{
+					URL:           "github.com/sourcegraph/sourcegraph/-/blob/cmd/frontend/graphqlbackend/search_results.go#L1591:26-1591:35",
+					Name:          "doResults",
+					ContainerName: "",
+					Kind:          "FUNCTION",
+				},
+				{
+					URL:           "github.com/sourcegraph/sourcegraph/-/blob/cmd/frontend/graphqlbackend/search_results.go#L1591:26-1591:35",
+					Name:          "Results",
+					ContainerName: "SearchResultsResolver",
+					Kind:          "FIELD",
+				},
+			},
+		},
+		&streaming.EventCommitMatch{
+			Type:    streaming.CommitMatchType,
+			Icon:    "",
+			Label:   "[sourcegraph/sourcegraph-atom](/github.com/sourcegraph/sourcegraph-atom) › [Stephen Gutekanst](/github.com/sourcegraph/sourcegraph-atom/-/commit/5b098d7fed963d88e23057ed99d73d3c7a33ad89): [all: release v1.0.5](/github.com/sourcegraph/sourcegraph-atom/-/commit/5b098d7fed963d88e23057ed99d73d3c7a33ad89)^",
+			URL:     "",
+			Detail:  "",
+			Content: "```COMMIT_EDITMSG\nfoo bar\n```",
+			Ranges: [][3]int32{
+				{1, 3, 3},
+			},
+		},
+		&streaming.EventCommitMatch{
+			Type:    streaming.CommitMatchType,
+			Icon:    "",
+			Label:   "[sourcegraph/sourcegraph-atom](/github.com/sourcegraph/sourcegraph-atom) › [Stephen Gutekanst](/github.com/sourcegraph/sourcegraph-atom/-/commit/5b098d7fed963d88e23057ed99d73d3c7a33ad89): [all: release v1.0.5](/github.com/sourcegraph/sourcegraph-atom/-/commit/5b098d7fed963d88e23057ed99d73d3c7a33ad89)^",
+			URL:     "",
+			Detail:  "",
+			Content: "```diff\nsrc/data.ts src/data.ts\n@@ -0,0 +11,4 @@\n+    return of<Data>({\n+        title: 'Acme Corp open-source code search',\n+        summary: 'Instant code search across all Acme Corp open-source code.',\n+        githubOrgs: ['sourcegraph'],\n```",
+			Ranges: [][3]int32{
+				{4, 44, 6},
+			},
+		},
+	}
+
+	// Capture output.
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	flagSet := flag.NewFlagSet("streaming search test", flag.ExitOnError)
+	flags := newStreamingFlags(flagSet)
+	client := cfg.apiClient(flags.apiFlags, flagSet.Output())
+
+	err = doStreamSearch("", flags, client, w)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = w.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := ioutil.ReadAll(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want, err := ioutil.ReadFile("./testdata/streaming_search_want.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d := cmp.Diff(want, got); d != "" {
+		t.Fatalf("(-want +got): %s", d)
+	}
+}

--- a/cmd/src/testdata/streaming_search_want.txt
+++ b/cmd/src/testdata/streaming_search_want.txt
@@ -1,0 +1,25 @@
+[38;5;23morg/repo[0m › [38;5;69mpath/to/file[0m[38;5;2m (1 match)[0m
+[38;5;239m--------------------------------------------------------------------------------
+[0m  [38;5;69m     5[0m[38;5;239m |  [0mfoo [38;5;0m[48;5;11mbar[0m
+
+[38;5;2msourcegraph/sourcegraph[0m[38;5;239m ([0m[38;5;23mhttp://127.0.0.1:55128/sourcegraph/sourcegraph[0m[38;5;239m)[0m[38;5;2m (1 match)[0m
+[38;5;23morg/repo[0m › [38;5;69mpath/to/file[0m[38;5;2m (2 matches)[0m
+[38;5;239m--------------------------------------------------------------------------------
+[0m[38;5;2mdoResults[0m(FUNCTION)[38;5;239m ([0m[38;5;23mhttp://127.0.0.1:55128/github.com/sourcegraph/sourcegraph/-/blob/cmd/frontend/graphqlbackend/search_results.go#L1591:26-1591:35[0m[38;5;239m)
+[0m[38;5;2mResults[0m(FIELD, SearchResultsResolver)[38;5;239m ([0m[38;5;23mhttp://127.0.0.1:55128/github.com/sourcegraph/sourcegraph/-/blob/cmd/frontend/graphqlbackend/search_results.go#L1591:26-1591:35[0m[38;5;239m)
+[0m
+[38;5;239m([0m[38;5;237mhttp://127.0.0.1:55128[0m[38;5;239m)
+[0m[0m[38;5;68msourcegraph/sourcegraph-atom > Stephen Gutekanst : all: release v1.0.5[0m[38;5;2m (1 match)[0m
+[38;5;239m--------------------------------------------------------------------------------
+[0m[38;5;239m[0m  oo [38;5;0m[48;5;11mbar[0m
+
+[38;5;239m([0m[38;5;237mhttp://127.0.0.1:55128[0m[38;5;239m)
+[0m[0m[38;5;68msourcegraph/sourcegraph-atom > Stephen Gutekanst : all: release v1.0.5[0m[38;5;2m (1 match)[0m
+[38;5;239m--------------------------------------------------------------------------------
+[0m[38;5;239m[0m  src/data.ts src/data.ts
+  @@ -0,0 +11,4 @@
+  +    return of<Data>({
+  +        title: 'Acme Corp open-source code [38;5;0m[48;5;11msearch[0m',
+  +        summary: 'Instant code search across all Acme Corp open-source code.',
+  +        githubOrgs: ['sourcegraph'],
+

--- a/internal/api/flags.go
+++ b/internal/api/flags.go
@@ -11,6 +11,13 @@ type Flags struct {
 	insecureSkipVerify *bool
 }
 
+func (f *Flags) Trace() bool {
+	if f.trace == nil {
+		return false
+	}
+	return *(f.trace)
+}
+
 // NewFlags instantiates a new Flags structure and attaches flags to the given
 // flag set.
 func NewFlags(flagSet *flag.FlagSet) *Flags {
@@ -29,5 +36,12 @@ func defaultFlags() *Flags {
 		getCurl:            &d,
 		trace:              &d,
 		insecureSkipVerify: &d,
+	}
+}
+
+func StreamingFlags(flagSet *flag.FlagSet) *Flags {
+	return &Flags{
+		trace:              flagSet.Bool("trace", false, "Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing"),
+		insecureSkipVerify: flagSet.Bool("insecure-skip-verify", false, "Skip validation of TLS certificates against trusted chains"),
 	}
 }

--- a/internal/api/flags.go
+++ b/internal/api/flags.go
@@ -38,10 +38,3 @@ func defaultFlags() *Flags {
 		insecureSkipVerify: &d,
 	}
 }
-
-func StreamingFlags(flagSet *flag.FlagSet) *Flags {
-	return &Flags{
-		trace:              flagSet.Bool("trace", false, "Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing"),
-		insecureSkipVerify: flagSet.Bool("insecure-skip-verify", false, "Skip validation of TLS certificates against trusted chains"),
-	}
-}

--- a/internal/streaming/search.go
+++ b/internal/streaming/search.go
@@ -46,7 +46,7 @@ func Search(query string, opts Opts, client api.Client, decoder Decoder) error {
 
 	// Output trace.
 	if opts.Trace {
-		_, err = fmt.Fprintf(os.Stderr, fmt.Sprintf("x-trace: %s\n", resp.Header.Get("x-trace")))
+		_, err = fmt.Fprintf(os.Stderr, fmt.Sprintf("\nx-trace: %s\n", resp.Header.Get("x-trace")))
 		if err != nil {
 			return err
 		}

--- a/internal/streaming/search.go
+++ b/internal/streaming/search.go
@@ -1,0 +1,55 @@
+package streaming
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+	"strconv"
+
+	"github.com/sourcegraph/src-cli/internal/api"
+)
+
+// Opts contains the search options supported by Search.
+type Opts struct {
+	Display int
+	Trace   bool
+}
+
+// Search calls the streaming search endpoint and uses decoder to decode the
+// response body.
+func Search(query string, opts Opts, client api.Client, decoder Decoder) error {
+	// Create request.
+	req, err := client.NewHTTPRequest(context.Background(), "GET", "search/stream?q="+url.QueryEscape(query), nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Accept", "text/event-stream")
+	if opts.Display >= 0 {
+		q := req.URL.Query()
+		q.Add("display", strconv.Itoa(opts.Display))
+		req.URL.RawQuery = q.Encode()
+	}
+
+	// Send request.
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("error sending request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Process response.
+	err = decoder.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("error during decoding: %w", err)
+	}
+
+	// Output trace.
+	if opts.Trace {
+		_, err = fmt.Fprintf(os.Stderr, fmt.Sprintf("x-trace: %s\n", resp.Header.Get("x-trace")))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Stacked on top of #484 

This adds the flag `-stream` to the `search` sub-command. Searches
submitted with `-stream` are routed to the endpoint `search/stream`
instead of the GraphQL api.

In addition, users can set `-display <int>` to set the display limit.

<img width="1481" alt="Screenshot 2021-03-04 at 13 43 53" src="https://user-images.githubusercontent.com/26413131/109965761-b32c8780-7cef-11eb-829c-f043deae8703.png">
We will add support for JSON in a follow-up PR.