### PR TITLE
Add batch_change.{name,description} as templating variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to `src-cli` are documented in this file.
 
 ### Added
 
+- Two new [templating](https://docs.sourcegraph.com/campaigns/references/batch_spec_templating) variables have been added: `batch_change.name` and `batch_change.description`.
+
 ### Changed
 
 - Campaigns are now known as Batch Changes! The `src campaign` set of commands have been renamed to `src batch`; however, `src campaign` and `src campaigns` will be retained as aliases for `src batch` until the next major version of Sourcegraph. There should be no breaking changes as a result of this change. [#489](https://github.com/sourcegraph/src-cli/pull/489)

--- a/internal/batches/executor.go
+++ b/internal/batches/executor.go
@@ -69,8 +69,9 @@ type Task struct {
 	Steps   []Step
 	Outputs map[string]interface{}
 
-	Template         *ChangesetTemplate `json:"-"`
-	TransformChanges *TransformChanges  `json:"-"`
+	BatchChangeAttributes *BatchChangeAttributes `json:"-"`
+	Template              *ChangesetTemplate     `json:"-"`
+	TransformChanges      *TransformChanges      `json:"-"`
 
 	Archive RepoZip `json:"-"`
 }
@@ -363,13 +364,14 @@ func (x *executor) do(ctx context.Context, task *Task) (err error) {
 
 	// Actually execute the steps.
 	opts := &executionOpts{
-		archive: task.Archive,
-		wc:      x.creator,
-		repo:    task.Repository,
-		path:    task.Path,
-		steps:   task.Steps,
-		logger:  log,
-		tempDir: x.tempDir,
+		archive:               task.Archive,
+		wc:                    x.creator,
+		batchChangeAttributes: task.BatchChangeAttributes,
+		repo:                  task.Repository,
+		path:                  task.Path,
+		steps:                 task.Steps,
+		logger:                log,
+		tempDir:               x.tempDir,
 		reportProgress: func(currentlyExecuting string) {
 			x.updateTaskStatus(task, func(status *TaskStatus) {
 				status.CurrentlyExecuting = currentlyExecuting
@@ -463,6 +465,7 @@ func createChangesetSpecs(task *Task, result executionResult, features featureFl
 	repo := task.Repository.Name
 
 	tmplCtx := &ChangesetTemplateContext{
+		BatchChangeAttributes: *task.BatchChangeAttributes,
 		Steps: StepsContext{
 			Changes: result.ChangedFiles,
 			Path:    result.Path,

--- a/internal/batches/run_steps.go
+++ b/internal/batches/run_steps.go
@@ -41,8 +41,9 @@ type executionOpts struct {
 	wc   WorkspaceCreator
 	path string
 
-	repo  *graphql.Repository
-	steps []Step
+	batchChangeAttributes *BatchChangeAttributes
+	repo                  *graphql.Repository
+	steps                 []Step
 
 	tempDir string
 
@@ -74,7 +75,7 @@ func runSteps(ctx context.Context, opts *executionOpts) (result executionResult,
 	for i, step := range opts.steps {
 		opts.reportProgress(fmt.Sprintf("Preparing step %d", i+1))
 
-		stepContext := StepContext{Repository: *opts.repo, Outputs: execResult.Outputs}
+		stepContext := StepContext{BatchChange: *opts.batchChangeAttributes, Repository: *opts.repo, Outputs: execResult.Outputs}
 		if i > 0 {
 			stepContext.PreviousStep = results[i-1]
 		}

--- a/internal/batches/service.go
+++ b/internal/batches/service.go
@@ -256,6 +256,8 @@ func (svc *Service) BuildTasks(ctx context.Context, repos []*graphql.Repository,
 
 	var tasks []*Task
 
+	attr := &BatchChangeAttributes{Name: spec.Name, Description: spec.Description}
+
 	for configIndex, repos := range reposByWorkspaceConfig {
 		workspaceConfig := workspaceConfigs[configIndex]
 		repoDirs, err := svc.FindDirectoriesInRepos(ctx, workspaceConfig.RootAtLocationOf, repos...)
@@ -276,12 +278,13 @@ func (svc *Service) BuildTasks(ctx context.Context, repos []*graphql.Repository,
 				}
 
 				tasks = append(tasks, &Task{
-					Repository:         repo,
-					Path:               d,
-					Steps:              spec.Steps,
-					TransformChanges:   spec.TransformChanges,
-					Template:           spec.ChangesetTemplate,
-					OnlyFetchWorkspace: workspaceConfig.OnlyFetchWorkspace,
+					Repository:            repo,
+					Path:                  d,
+					Steps:                 spec.Steps,
+					TransformChanges:      spec.TransformChanges,
+					Template:              spec.ChangesetTemplate,
+					BatchChangeAttributes: attr,
+					OnlyFetchWorkspace:    workspaceConfig.OnlyFetchWorkspace,
 				})
 			}
 		}
@@ -289,11 +292,12 @@ func (svc *Service) BuildTasks(ctx context.Context, repos []*graphql.Repository,
 
 	for r := range rootWorkspace {
 		tasks = append(tasks, &Task{
-			Repository:       r,
-			Path:             "",
-			Steps:            spec.Steps,
-			TransformChanges: spec.TransformChanges,
-			Template:         spec.ChangesetTemplate,
+			Repository:            r,
+			Path:                  "",
+			Steps:                 spec.Steps,
+			TransformChanges:      spec.TransformChanges,
+			Template:              spec.ChangesetTemplate,
+			BatchChangeAttributes: attr,
 		})
 	}
 

--- a/internal/batches/templating.go
+++ b/internal/batches/templating.go
@@ -40,9 +40,16 @@ func renderStepMap(m map[string]string, stepCtx *StepContext) (map[string]string
 	return rendered, nil
 }
 
+type BatchChangeAttributes struct {
+	Name        string
+	Description string
+}
+
 // StepContext represents the contextual information available when rendering a
 // step's fields, such as "run" or "outputs", as templates.
 type StepContext struct {
+	// BatchChange are the attributes in the BatchSpec that are set on the BatchChange.
+	BatchChange BatchChangeAttributes
 	// Outputs are the outputs set by the current and all previous steps.
 	Outputs map[string]interface{}
 	// Step is the result of the current step. Empty when evaluating the "run" field
@@ -115,6 +122,12 @@ func (stepCtx *StepContext) ToFuncMap() template.FuncMap {
 				"name":                stepCtx.Repository.Name,
 			}
 		},
+		"batch_change": func() map[string]interface{} {
+			return map[string]interface{}{
+				"name":        stepCtx.BatchChange.Name,
+				"description": stepCtx.BatchChange.Description,
+			}
+		},
 	}
 }
 
@@ -180,6 +193,10 @@ type StepsContext struct {
 // ChangesetTemplateContext represents the contextual information available
 // when rendering a field of the ChangesetTemplate as a template.
 type ChangesetTemplateContext struct {
+	// BatchChangeAttributes are the attributes of the BatchChange that will be
+	// created/updated.
+	BatchChangeAttributes BatchChangeAttributes
+
 	// Steps are the changes made by all steps that were executed.
 	Steps StepsContext
 
@@ -210,6 +227,12 @@ func (tmplCtx *ChangesetTemplateContext) ToFuncMap() template.FuncMap {
 			return map[string]interface{}{
 				"search_result_paths": tmplCtx.Repository.SearchResultPaths(),
 				"name":                tmplCtx.Repository.Name,
+			}
+		},
+		"batch_change": func() map[string]interface{} {
+			return map[string]interface{}{
+				"name":        tmplCtx.BatchChangeAttributes.Name,
+				"description": tmplCtx.BatchChangeAttributes.Description,
 			}
 		},
 		"outputs": func() map[string]interface{} {

--- a/internal/batches/templating_test.go
+++ b/internal/batches/templating_test.go
@@ -55,6 +55,10 @@ func TestRenderStepTemplate(t *testing.T) {
 	}
 
 	stepCtx := &StepContext{
+		BatchChange: BatchChangeAttributes{
+			Name:        "test-batch-change",
+			Description: "This batch change is just an experiment",
+		},
 		PreviousStep: StepResult{
 			files: &StepChanges{
 				Modified: []string{"go.mod"},
@@ -99,6 +103,8 @@ func TestRenderStepTemplate(t *testing.T) {
 			stepCtx: stepCtx,
 			run: `${{ repository.search_result_paths }}
 ${{ repository.name }}
+${{ batch_change.name }}
+${{ batch_change.description }}
 ${{ previous_step.modified_files }}
 ${{ previous_step.added_files }}
 ${{ previous_step.deleted_files }}
@@ -116,6 +122,8 @@ ${{ step.stderr}}
 `,
 			want: `README.md main.go
 github.com/sourcegraph/src-cli
+test-batch-change
+This batch change is just an experiment
 [go.mod]
 [main.go.swp]
 [.DS_Store]
@@ -242,6 +250,10 @@ func TestRenderChangesetTemplateField(t *testing.T) {
 	}
 
 	tmplCtx := &ChangesetTemplateContext{
+		BatchChangeAttributes: BatchChangeAttributes{
+			Name:        "test-batch-change",
+			Description: "This batch change is just an experiment",
+		},
 		Outputs: map[string]interface{}{
 			"lastLine": "lastLine is this",
 			"project":  parsedYaml,
@@ -275,6 +287,8 @@ func TestRenderChangesetTemplateField(t *testing.T) {
 			tmplCtx: tmplCtx,
 			run: `${{ repository.search_result_paths }}
 ${{ repository.name }}
+${{ batch_change.name }}
+${{ batch_change.description }}
 ${{ outputs.lastLine }}
 ${{ index outputs.project.env 1 }}
 ${{ steps.modified_files }}
@@ -285,6 +299,8 @@ ${{ steps.path }}
 `,
 			want: `README.md main.go
 github.com/sourcegraph/src-cli
+test-batch-change
+This batch change is just an experiment
 lastLine is this
 CGO_ENABLED=0
 [modified-file.txt]


### PR DESCRIPTION
This fixes https://github.com/sourcegraph/src-cli/issues/487 by adding `batch_change.name` and `batch_change.description` to the templating vars.

I didn't want to use `batch` because it's ambigious, but I'm also not 100% sure about `batch_change` since _technically_ the batch change doesn't exist yet. So maybe it should be `batch_spec`? But that's also not 100% clear cut.

**For code reviewers**: note that I introduced a little helper struct. That might seem overblown, but while writing the code I realized that I'm about to pass the whole `BatchSpec` around if I don't add this helper thing. And if I were to pass the `*BatchSpec` to every `*Task` and every `runSteps` then we could get rid of all the intermediate steps, but _then_ everything would need to dig deep into the `*BatchSpec`. If you think that's fine I can change it. I just thought that for now it's easier and safer to simply pass two duplicated strings around.