### PR TITLE
batches: fix batch apply on old Sourcegraph versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ All notable changes to `src-cli` are documented in this file.
 
 ### Fixed
 
+- Directly applying a batch change with `src batch apply` against Sourcegraph 3.25 or older would fail in 3.26.0. This has been fixed. [#495](https://github.com/sourcegraph/src-cli/issues/495)
+
 ### Removed
 
 ## 3.26.0

--- a/internal/batches/graphql/campaigns.go
+++ b/internal/batches/graphql/campaigns.go
@@ -30,7 +30,7 @@ func (cb *campaignsBackend) ApplyBatchChange(ctx context.Context, batchSpecID Ba
 	var result struct {
 		BatchChange *BatchChange `json:"applyCampaign"`
 	}
-	if ok, err := cb.newRequest(applyBatchChangeMutation, map[string]interface{}{
+	if ok, err := cb.newRequest(applyCampaignMutation, map[string]interface{}{
 		"campaignSpec": batchSpecID,
 	}).Do(ctx, &result); err != nil || !ok {
 		return nil, err


### PR DESCRIPTION
Well, that was embarrassing. I guess I get a dunce hat instead of a propeller hat for this version.

Fixes #495.