### PR TITLE
More user-friendly error message if batch change name is invalid

### DIFF
--- a/internal/batches/batch_spec_test.go
+++ b/internal/batches/batch_spec_test.go
@@ -52,4 +52,39 @@ steps:
 			t.Fatalf("wrong error. want=%q, have=%q", wantErr, haveErr)
 		}
 	})
+
+	t.Run("invalid batch change name", func(t *testing.T) {
+		const spec = `
+name: this name is invalid cause it contains whitespace
+description: Add Hello World to READMEs
+on:
+  - repositoriesMatchingQuery: file:README.md
+steps:
+  - run: echo Hello World | tee -a $(find -name README.md)
+    container: alpine:3
+changesetTemplate:
+  title: Hello World
+  body: My first batch change!
+  branch: hello-world
+  commit:
+    message: Append Hello World to all README.md files
+  published: false
+`
+
+		_, err := ParseBatchSpec([]byte(spec), featureFlags{})
+		if err == nil {
+			t.Fatal("no error returned")
+		}
+
+		// We expect this error to be user-friendly, which is why we test for
+		// it specifically here.
+		wantErr := `1 error occurred:
+	* The batch change name can only contain word characters, dots and dashes. No whitespace or newlines allowed.
+
+`
+		haveErr := err.Error()
+		if haveErr != wantErr {
+			t.Fatalf("wrong error. want=%q, have=%q", wantErr, haveErr)
+		}
+	})
 }


### PR DESCRIPTION
This fixes https://github.com/sourcegraph/sourcegraph/issues/16955.

Preview:

![user-friendly-message](https://user-images.githubusercontent.com/1185253/112153828-fe95cf80-8be3-11eb-8eb4-4caf895b2365.png)
