### PR TITLE
goreleaser: correctly structure the docker section

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -43,7 +43,7 @@ brews:
       bin.install "src"
 dockers:
   - dockerfile: Dockerfile.release
-  - image_templates:
+    image_templates:
     - "sourcegraph/src-cli:{{ .Tag }}"
     - "sourcegraph/src-cli:{{ .Major }}"
     - "sourcegraph/src-cli:{{ .Major }}.{{ .Minor }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ All notable changes to `src-cli` are documented in this file.
 
 ### Removed
 
+## 3.26.2
+
+### Fixed
+
+- Publishing of Docker images for `src` was broken after release 3.24.3. This has been fixed, and [`sourcegraph/src-cli` images](https://hub.docker.com/r/sourcegraph/src-cli) are available once again. [#501](https://github.com/sourcegraph/src-cli/issues/501)
+
 ## 3.26.1
 
 ### Fixed


### PR DESCRIPTION
Annoyingly, this passes GoReleaser's check action, but then does nothing silently.

Fixes #501.