### PR TITLE
Remove use of ioutil package

### DIFF
--- a/cmd/src/api.go
+++ b/cmd/src/api.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -67,7 +66,7 @@ Examples:
 			if isatty.IsTerminal(os.Stdin.Fd()) {
 				return &usageError{errors.New("expected query to be piped into 'src api' or -query flag to be specified")}
 			}
-			data, err := ioutil.ReadAll(os.Stdin)
+			data, err := io.ReadAll(os.Stdin)
 			if err != nil {
 				return err
 			}

--- a/cmd/src/config_edit.go
+++ b/cmd/src/config_edit.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 
 	"github.com/sourcegraph/src-cli/internal/api"
 )
@@ -71,7 +70,7 @@ Examples:
 		if *valueFlag != "" {
 			value = *valueFlag
 		} else if *valueFileFlag != "" {
-			data, err := ioutil.ReadFile(*valueFileFlag)
+			data, err := os.ReadFile(*valueFileFlag)
 			if err != nil {
 				return err
 			}

--- a/cmd/src/extensions_copy.go
+++ b/cmd/src/extensions_copy.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"strings"
 
@@ -106,7 +105,7 @@ Copy an extension from Sourcegraph.com to your private registry.
 			return err
 		}
 		defer response.Body.Close()
-		bundle, err := ioutil.ReadAll(response.Body)
+		bundle, err := io.ReadAll(response.Body)
 		if err != nil {
 			return err
 		}

--- a/cmd/src/extensions_publish.go
+++ b/cmd/src/extensions_publish.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -66,7 +65,7 @@ Notes:
 		}
 		manifestDir := filepath.Dir(manifestPath)
 
-		manifest, err := ioutil.ReadFile(manifestPath)
+		manifest, err := os.ReadFile(manifestPath)
 		if err != nil {
 			return fmt.Errorf("%s\n\nRun this command in a directory with a %s file for an extension.\n\nSee 'src extensions %s -h' for help", err, *manifestFlag, flagSet.Name())
 		}
@@ -255,7 +254,7 @@ func addReadmeToManifest(manifest []byte, dir string) ([]byte, error) {
 	var readme string
 	filenames := []string{"README.md", "README.txt", "README", "readme.md", "readme.txt", "readme", "Readme.md", "Readme.txt", "Readme"}
 	for _, f := range filenames {
-		data, err := ioutil.ReadFile(filepath.Join(dir, f))
+		data, err := os.ReadFile(filepath.Join(dir, f))
 		if err != nil {
 			continue
 		}
@@ -291,7 +290,7 @@ func readExtensionArtifacts(manifest []byte, dir string) (bundle, sourceMap *str
 
 	mainPath := filepath.Join(dir, o.Main)
 
-	data, err := ioutil.ReadFile(mainPath)
+	data, err := os.ReadFile(mainPath)
 	if err != nil {
 		return nil, nil, fmt.Errorf(`extension manifest "main" bundle file: %s`, err)
 	}
@@ -302,7 +301,7 @@ func readExtensionArtifacts(manifest []byte, dir string) (bundle, sourceMap *str
 
 	// Guess that source map is the main file with a ".map" extension.
 	sourceMapPath := strings.TrimSuffix(mainPath, filepath.Ext(mainPath)) + ".map"
-	data, err = ioutil.ReadFile(sourceMapPath)
+	data, err = os.ReadFile(sourceMapPath)
 	if err == nil {
 		tmp := string(data)
 		sourceMap = &tmp

--- a/cmd/src/extsvc_edit.go
+++ b/cmd/src/extsvc_edit.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -70,14 +69,14 @@ Examples:
 		// Determine if we are updating the JSON configuration or not.
 		var updateJSON []byte
 		if len(flagSet.Args()) == 1 {
-			updateJSON, err = ioutil.ReadFile(flagSet.Arg(0))
+			updateJSON, err = os.ReadFile(flagSet.Arg(0))
 			if err != nil {
 				return err
 			}
 		}
 		if !isatty.IsTerminal(os.Stdin.Fd()) {
 			// stdin is a pipe not a terminal
-			updateJSON, err = ioutil.ReadAll(os.Stdin)
+			updateJSON, err = io.ReadAll(os.Stdin)
 			if err != nil {
 				return err
 			}

--- a/cmd/src/login.go
+++ b/cmd/src/login.go
@@ -6,7 +6,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -53,7 +52,7 @@ Examples:
 			return &usageError{errors.New("expected exactly one argument: the Sourcegraph URL, or SRC_ENDPOINT to be set")}
 		}
 
-		client := cfg.apiClient(apiFlags, ioutil.Discard)
+		client := cfg.apiClient(apiFlags, io.Discard)
 
 		return loginCmd(context.Background(), cfg, client, endpoint, os.Stdout)
 	}

--- a/cmd/src/login_test.go
+++ b/cmd/src/login_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -16,7 +15,7 @@ func TestLogin(t *testing.T) {
 		t.Helper()
 
 		var out bytes.Buffer
-		err = loginCmd(context.Background(), cfg, cfg.apiClient(nil, ioutil.Discard), endpointArg, &out)
+		err = loginCmd(context.Background(), cfg, cfg.apiClient(nil, io.Discard), endpointArg, &out)
 		return strings.TrimSpace(out.String()), err
 	}
 

--- a/cmd/src/lsif_upload.go
+++ b/cmd/src/lsif_upload.go
@@ -15,7 +15,6 @@ import (
 	"github.com/efritz/pentimento"
 	"github.com/pkg/browser"
 	"github.com/pkg/errors"
-	"github.com/sourcegraph/sourcegraph/lib/codeintel/utils"
 	"github.com/sourcegraph/src-cli/internal/codeintel"
 )
 

--- a/cmd/src/main.go
+++ b/cmd/src/main.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"flag"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/user"
@@ -113,7 +112,7 @@ func readConfig() (*config, error) {
 	} else if strings.HasPrefix(cfgPath, "~/") {
 		cfgPath = filepath.Join(homeDir, cfgPath[2:])
 	}
-	data, err := ioutil.ReadFile(os.ExpandEnv(cfgPath))
+	data, err := os.ReadFile(os.ExpandEnv(cfgPath))
 	if err != nil && (!os.IsNotExist(err) || userSpecified) {
 		return nil, err
 	}

--- a/cmd/src/main_test.go
+++ b/cmd/src/main_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -154,7 +153,7 @@ func TestReadConfig(t *testing.T) {
 			setEnv("SRC_ACCESS_TOKEN", test.envToken)
 			setEnv("SRC_ENDPOINT", test.envEndpoint)
 
-			tmpDir, err := ioutil.TempDir("", "")
+			tmpDir, err := os.MkdirTemp("", "")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -176,7 +175,7 @@ func TestReadConfig(t *testing.T) {
 					t.Fatal(err)
 				}
 				filePath := filepath.Join(tmpDir, "config.json")
-				err = ioutil.WriteFile(filePath, data, 0600)
+				err = os.WriteFile(filePath, data, 0600)
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/cmd/src/search_stream_test.go
+++ b/cmd/src/search_stream_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"flag"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -147,11 +146,11 @@ func TestSearchStream(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			got, err := ioutil.ReadAll(r)
+			got, err := io.ReadAll(r)
 			if err != nil {
 				t.Fatal(err)
 			}
-			want, err := ioutil.ReadFile(c.want)
+			want, err := os.ReadFile(c.want)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/cmd/src/search_test.go
+++ b/cmd/src/search_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -29,7 +28,7 @@ func TestSearchOutput(t *testing.T) {
 	tests := map[string]*testT{}
 
 	dataDir := "testdata/search_formatting"
-	infos, err := ioutil.ReadDir(dataDir)
+	infos, err := os.ReadDir(dataDir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -50,7 +49,7 @@ func TestSearchOutput(t *testing.T) {
 			tests[testName] = &testT{}
 		}
 
-		data, err := ioutil.ReadFile(path)
+		data, err := os.ReadFile(path)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -74,7 +73,7 @@ func TestSearchOutput(t *testing.T) {
 		if tst.want == nil {
 			// Create the initial (empty) .want.txt file.
 			wantFile := filepath.Join(dataDir, testName+".want.txt")
-			if err := ioutil.WriteFile(wantFile, nil, 0600); err != nil {
+			if err := os.WriteFile(wantFile, nil, 0600); err != nil {
 				t.Fatal(err)
 			}
 			tmp := ""
@@ -100,7 +99,7 @@ func TestSearchOutput(t *testing.T) {
 				gotFile := filepath.Join(dataDir, testName+".got.txt")
 				wantFile := filepath.Join(dataDir, testName+".want.txt")
 
-				err := ioutil.WriteFile(gotFile, []byte(got), 0600)
+				err := os.WriteFile(gotFile, []byte(got), 0600)
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/cmd/src/servegit.go
+++ b/cmd/src/servegit.go
@@ -3,7 +3,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 
@@ -53,7 +52,7 @@ Documentation at https://docs.sourcegraph.com/admin/external_service/src_serve_g
 			return &usageError{errors.New("requires zero or one arguments")}
 		}
 
-		dbug := log.New(ioutil.Discard, "", log.LstdFlags)
+		dbug := log.New(io.Discard, "", log.LstdFlags)
 		if *verbose {
 			dbug = log.New(os.Stderr, "DBUG serve-git: ", log.LstdFlags)
 		}

--- a/cmd/src/validate.go
+++ b/cmd/src/validate.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"strings"
@@ -89,7 +88,7 @@ Please visit https://docs.sourcegraph.com/admin/validation for documentation of 
 		var err error
 		if len(flagSet.Args()) == 1 {
 			filename := flagSet.Arg(0)
-			script, err = ioutil.ReadFile(filename)
+			script, err = os.ReadFile(filename)
 			if err != nil {
 				return err
 			}
@@ -99,7 +98,7 @@ Please visit https://docs.sourcegraph.com/admin/validation for documentation of 
 		}
 		if !isatty.IsTerminal(os.Stdin.Fd()) {
 			// stdin is a pipe not a terminal
-			script, err = ioutil.ReadAll(os.Stdin)
+			script, err = io.ReadAll(os.Stdin)
 			if err != nil {
 				return err
 			}
@@ -144,7 +143,7 @@ func (vd *validator) parseKVPairs(val string, pairSep string) map[string]string 
 }
 
 func (vd *validator) readSecrets(path string) (map[string]string, error) {
-	bs, err := ioutil.ReadFile(path)
+	bs, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
@@ -494,7 +493,7 @@ func (vd *validator) newClient(baseURL string) (*vdClient, error) {
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	p, err := ioutil.ReadAll(resp.Body)
+	p, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -545,7 +544,7 @@ func (c *vdClient) authenticate(path string, body interface{}) error {
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		p, err := ioutil.ReadAll(resp.Body)
+		p, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return err
 		}
@@ -651,7 +650,7 @@ func (c *vdClient) graphQL(token, query string, variables map[string]interface{}
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		p, err := ioutil.ReadAll(resp.Body)
+		p, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return err
 		}

--- a/cmd/src/version.go
+++ b/cmd/src/version.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 
 	"github.com/sourcegraph/src-cli/internal/api"
@@ -66,7 +65,7 @@ func getRecommendedVersion(ctx context.Context, client api.Client) (string, erro
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
 	}

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"strings"
@@ -16,7 +15,6 @@ import (
 	ioaux "github.com/jig/teereadcloser"
 	"github.com/kballard/go-shellquote"
 	"github.com/mattn/go-isatty"
-	"github.com/sourcegraph/sourcegraph/lib/codeintel/utils"
 )
 
 // Client instances provide methods to create API requests.
@@ -249,7 +247,7 @@ func (r *request) do(ctx context.Context, result interface{}) (bool, error) {
 			fmt.Println("See https://github.com/sourcegraph/src-cli#readme")
 			fmt.Println("")
 		}
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return false, err
 		}

--- a/internal/batches/bind_workspace.go
+++ b/internal/batches/bind_workspace.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -158,7 +157,7 @@ func fileExists(path string) (bool, error) {
 }
 
 func unzipToTempDir(ctx context.Context, zipFile, tempDir, tempFilePrefix string) (string, error) {
-	volumeDir, err := ioutil.TempDir(tempDir, tempFilePrefix)
+	volumeDir, err := os.MkdirTemp(tempDir, tempFilePrefix)
 	if err != nil {
 		return "", err
 	}

--- a/internal/batches/bind_workspace_test.go
+++ b/internal/batches/bind_workspace_test.go
@@ -3,7 +3,6 @@ package batches
 import (
 	"archive/zip"
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -15,7 +14,7 @@ import (
 
 func TestDockerBindWorkspaceCreator_Create(t *testing.T) {
 	workspaceTmpDir := func(t *testing.T) string {
-		testTempDir, err := ioutil.TempDir("", "executor-integration-test-*")
+		testTempDir, err := os.MkdirTemp("", "executor-integration-test-*")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -37,7 +36,7 @@ func TestDockerBindWorkspaceCreator_Create(t *testing.T) {
 	fakeFilesTmpDir := workspaceTmpDir(t)
 
 	// Create a zip file for all the other tests to use.
-	f, err := ioutil.TempFile(fakeFilesTmpDir, "repo-zip-*")
+	f, err := os.CreateTemp(fakeFilesTmpDir, "repo-zip-*")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -64,7 +63,7 @@ func TestDockerBindWorkspaceCreator_Create(t *testing.T) {
 	}
 	additionalFilePaths := map[string]string{}
 	for name, content := range additionalFiles {
-		f, err := ioutil.TempFile(fakeFilesTmpDir, name+"-*")
+		f, err := os.CreateTemp(fakeFilesTmpDir, name+"-*")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -103,7 +102,7 @@ func TestDockerBindWorkspaceCreator_Create(t *testing.T) {
 		testTempDir := workspaceTmpDir(t)
 
 		// Create an empty file (which is therefore a bad zip file).
-		badZip, err := ioutil.TempFile(testTempDir, "bad-zip-*")
+		badZip, err := os.CreateTemp(testTempDir, "bad-zip-*")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -247,7 +246,7 @@ func TestEnsureAll(t *testing.T) {
 }
 
 func mustCreateWorkspace(t *testing.T) string {
-	base, err := ioutil.TempDir("", "")
+	base, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -295,7 +294,7 @@ func readWorkspaceFiles(workspace Workspace) (map[string]string, error) {
 			return nil
 		}
 
-		content, err := ioutil.ReadFile(path)
+		content, err := os.ReadFile(path)
 		if err != nil {
 			return err
 		}
@@ -317,7 +316,7 @@ func readWorkspaceFiles(workspace Workspace) (map[string]string, error) {
 }
 
 func dirContains(dir, filename string) (bool, error) {
-	files, err := ioutil.ReadDir(dir)
+	files, err := os.ReadDir(dir)
 	if err != nil {
 		return false, err
 	}

--- a/internal/batches/execution_cache.go
+++ b/internal/batches/execution_cache.go
@@ -5,7 +5,6 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -112,7 +111,7 @@ func sortCacheFiles(paths []string) {
 func isOldCacheFile(path string) bool { return !strings.HasSuffix(path, cacheFileExt) }
 
 func (c ExecutionDiskCache) readCacheFile(path string, result *executionResult) error {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return err
 	}
@@ -142,7 +141,7 @@ func (c ExecutionDiskCache) Set(ctx context.Context, key ExecutionCacheKey, resu
 		return err
 	}
 
-	return ioutil.WriteFile(path, raw, 0600)
+	return os.WriteFile(path, raw, 0600)
 }
 
 func (c ExecutionDiskCache) Clear(ctx context.Context, key ExecutionCacheKey) error {

--- a/internal/batches/execution_cache_test.go
+++ b/internal/batches/execution_cache_test.go
@@ -3,7 +3,6 @@ package batches
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -108,7 +107,7 @@ func TestExecutionDiskCache(t *testing.T) {
 	ctx := context.Background()
 
 	cacheTmpDir := func(t *testing.T) string {
-		testTempDir, err := ioutil.TempDir("", "execution-disk-cache-test-*")
+		testTempDir, err := os.MkdirTemp("", "execution-disk-cache-test-*")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -229,7 +228,7 @@ func writeV1CacheFile(t *testing.T, c ExecutionDiskCache, k ExecutionCacheKey, d
 		t.Fatal(err)
 	}
 
-	if err := ioutil.WriteFile(path, raw, 0600); err != nil {
+	if err := os.WriteFile(path, raw, 0600); err != nil {
 		t.Fatalf("writing the cache file failed: %s", err)
 	}
 
@@ -248,7 +247,7 @@ func writeV2CacheFile(t *testing.T, c ExecutionDiskCache, k ExecutionCacheKey, d
 	path = filepath.Join(c.Dir, hashedKey+".diff")
 
 	// v2 contained only a diff
-	if err := ioutil.WriteFile(path, []byte(diff), 0600); err != nil {
+	if err := os.WriteFile(path, []byte(diff), 0600); err != nil {
 		t.Fatalf("writing the cache file failed: %s", err)
 	}
 

--- a/internal/batches/executor_test.go
+++ b/internal/batches/executor_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"mime"
 	"net/http"
@@ -407,7 +406,7 @@ output4=integration-test-batch-change`,
 			var clientBuffer bytes.Buffer
 			client := api.NewClient(api.ClientOpts{Endpoint: ts.URL, Out: &clientBuffer})
 
-			testTempDir, err := ioutil.TempDir("", "executor-integration-test-*")
+			testTempDir, err := os.MkdirTemp("", "executor-integration-test-*")
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/batches/log.go
+++ b/internal/batches/log.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"sync"
 	"time"
@@ -71,7 +70,7 @@ type TaskLogger struct {
 func newTaskLogger(task *Task, keep bool, dir string) (*TaskLogger, error) {
 	prefix := "changeset-" + task.Repository.Slug()
 
-	f, err := ioutil.TempFile(dir, prefix+".*.log")
+	f, err := os.CreateTemp(dir, prefix+".*.log")
 	if err != nil {
 		return nil, errors.Wrapf(err, "creating temporary file with prefix %q", prefix)
 	}

--- a/internal/batches/repo_fetcher_test.go
+++ b/internal/batches/repo_fetcher_test.go
@@ -3,7 +3,6 @@ package batches
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -21,7 +20,7 @@ import (
 
 func TestRepoFetcher_Fetch(t *testing.T) {
 	workspaceTmpDir := func(t *testing.T) string {
-		testTempDir, err := ioutil.TempDir("", "executor-integration-test-*")
+		testTempDir, err := os.MkdirTemp("", "executor-integration-test-*")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/batches/run_steps.go
+++ b/internal/batches/run_steps.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
@@ -83,7 +82,7 @@ func runSteps(ctx context.Context, opts *executionOpts) (result executionResult,
 		// Find a location that we can use for a cidfile, which will contain the
 		// container ID that is used below. We can then use this to remove the
 		// container on a successful run, rather than leaving it dangling.
-		cidFile, err := ioutil.TempFile(opts.tempDir, opts.repo.Slug()+"-container-id")
+		cidFile, err := os.CreateTemp(opts.tempDir, opts.repo.Slug()+"-container-id")
 		if err != nil {
 			return execResult, errors.Wrap(err, "Creating a CID file failed")
 		}
@@ -99,7 +98,7 @@ func runSteps(ctx context.Context, opts *executionOpts) (result executionResult,
 		// Since we went to all that effort, we can now defer a function that
 		// uses the cidfile to clean up after this function is done.
 		defer func() {
-			cid, err := ioutil.ReadFile(cidFile.Name())
+			cid, err := os.ReadFile(cidFile.Name())
 			_ = os.Remove(cidFile.Name())
 			if err == nil {
 				ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
@@ -122,7 +121,7 @@ func runSteps(ctx context.Context, opts *executionOpts) (result executionResult,
 
 		// Set up a temporary file on the host filesystem to contain the
 		// script.
-		runScriptFile, err := ioutil.TempFile(opts.tempDir, "")
+		runScriptFile, err := os.CreateTemp(opts.tempDir, "")
 		if err != nil {
 			return execResult, errors.Wrap(err, "creating temporary file")
 		}
@@ -163,7 +162,7 @@ func runSteps(ctx context.Context, opts *executionOpts) (result executionResult,
 		// can mount them into the container.
 		filesToMount := make(map[string]*os.File, len(files))
 		for name, content := range files {
-			fp, err := ioutil.TempFile(opts.tempDir, "")
+			fp, err := os.CreateTemp(opts.tempDir, "")
 			if err != nil {
 				return execResult, errors.Wrap(err, "creating temporary file")
 			}

--- a/internal/batches/service.go
+++ b/internal/batches/service.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"path"
 	"reflect"
 	"regexp"
@@ -452,7 +451,7 @@ func (e *duplicateBranchesErr) Error() string {
 }
 
 func (svc *Service) ParseBatchSpec(in io.Reader) (*BatchSpec, string, error) {
-	data, err := ioutil.ReadAll(in)
+	data, err := io.ReadAll(in)
 	if err != nil {
 		return nil, "", errors.Wrap(err, "reading batch spec")
 	}

--- a/internal/batches/volume_workspace.go
+++ b/internal/batches/volume_workspace.go
@@ -6,7 +6,6 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"sort"
 	"strings"
@@ -277,7 +276,7 @@ func init() {
 // container started from the dockerWorkspaceImage, then run it and return the
 // output.
 func (w *dockerVolumeWorkspace) runScript(ctx context.Context, target, script string) ([]byte, error) {
-	f, err := ioutil.TempFile(w.tempDir, "src-run-*")
+	f, err := os.CreateTemp(w.tempDir, "src-run-*")
 	if err != nil {
 		return nil, errors.Wrap(err, "creating run script")
 	}

--- a/internal/batches/volume_workspace_test.go
+++ b/internal/batches/volume_workspace_test.go
@@ -3,7 +3,6 @@ package batches
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -25,7 +24,7 @@ func TestVolumeWorkspaceCreator(t *testing.T) {
 
 	// Create an empty file. It doesn't matter that it's an invalid zip, since
 	// we're mocking the unzip command anyway.
-	f, err := ioutil.TempFile(os.TempDir(), "volume-workspace-*")
+	f, err := os.CreateTemp(os.TempDir(), "volume-workspace-*")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -593,7 +592,7 @@ func TestVolumeWorkspace_runScript(t *testing.T) {
 				// mount options. Let's go get it!
 				values := strings.Split(arg[6], ",")
 				source := strings.SplitN(values[1], "=", 2)
-				have, err := ioutil.ReadFile(source[1])
+				have, err := os.ReadFile(source[1])
 				if err != nil {
 					return errors.Errorf("error reading temporary file %q: %v", source[1], err)
 				}

--- a/internal/codeintel/upload.go
+++ b/internal/codeintel/upload.go
@@ -3,8 +3,6 @@ package codeintel
 import (
 	"encoding/base64"
 	"fmt"
-
-	"github.com/sourcegraph/sourcegraph/lib/codeintel/utils"
 )
 
 type UploadIndexOpts = codeintelutils.UploadIndexOpts

--- a/internal/exec/expect/expect.go
+++ b/internal/exec/expect/expect.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	goexec "os/exec"
 	"testing"
@@ -95,7 +94,7 @@ func Commands(t *testing.T, exp ...*Expectation) {
 		cmd.Args = []string{}
 
 		// Actually create the behaviour file.
-		f, err := ioutil.TempFile(os.TempDir(), "behaviour")
+		f, err := os.CreateTemp(os.TempDir(), "behaviour")
 		if err != nil {
 			t.Fatalf("error creating behaviour file: %v", err)
 		}
@@ -143,7 +142,7 @@ func Handle(m interface{ Run() int }) int {
 		}
 
 		// Load up the expected behaviour of this command.
-		data, err := ioutil.ReadFile(file)
+		data, err := os.ReadFile(file)
 		if err != nil {
 			panicErr(err)
 		}

--- a/internal/servegit/serve_test.go
+++ b/internal/servegit/serve_test.go
@@ -2,7 +2,6 @@ package servegit
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -19,7 +18,7 @@ import (
 
 const testAddress = "test.local:3939"
 
-var discardLogger = log.New(ioutil.Discard, "", log.LstdFlags)
+var discardLogger = log.New(io.Discard, "", log.LstdFlags)
 
 func TestReposHandler(t *testing.T) {
 	cases := []struct {
@@ -87,7 +86,7 @@ func TestReposHandler(t *testing.T) {
 
 			// This is the difference, we create a symlink for root
 			{
-				tmp, err := ioutil.TempDir("", "")
+				tmp, err := os.MkdirTemp("", "")
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -125,7 +124,7 @@ func testReposHandler(t *testing.T, h http.Handler, repos []Repo) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		b, err := ioutil.ReadAll(res.Body)
+		b, err := io.ReadAll(res.Body)
 		res.Body.Close()
 		if err != nil {
 			t.Fatal(err)
@@ -172,7 +171,7 @@ func testReposHandler(t *testing.T, h http.Handler, repos []Repo) {
 }
 
 func gitInitRepos(t *testing.T, names ...string) string {
-	root, err := ioutil.TempDir("", "")
+	root, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -194,7 +193,7 @@ func gitInitRepos(t *testing.T, names ...string) string {
 }
 
 func TestIgnoreGitSubmodules(t *testing.T) {
-	root, err := ioutil.TempDir("", "")
+	root, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -204,7 +203,7 @@ func TestIgnoreGitSubmodules(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := ioutil.WriteFile(filepath.Join(root, "dir", ".git"), []byte("ignore me please"), os.ModePerm); err != nil {
+	if err := os.WriteFile(filepath.Join(root, "dir", ".git"), []byte("ignore me please"), os.ModePerm); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/servegit/service_test.go
+++ b/internal/servegit/service_test.go
@@ -2,7 +2,6 @@ package servegit
 
 import (
 	"bytes"
-	"io/ioutil"
 	"net/http/httptest"
 	"os"
 	"os/exec"
@@ -99,7 +98,7 @@ func runCmd(t *testing.T, dir string, cmd string, arg ...string) string {
 
 func tmpDir(t *testing.T) string {
 	t.Helper()
-	dir, err := ioutil.TempDir("", filepath.Base(t.Name()))
+	dir, err := os.MkdirTemp("", filepath.Base(t.Name()))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/schema/stringdata.go
+++ b/schema/stringdata.go
@@ -5,7 +5,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 )
@@ -25,7 +24,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	data, err := ioutil.ReadFile(*inputFile)
+	data, err := os.ReadFile(*inputFile)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)


### PR DESCRIPTION
Removes usage of the deprecated ioutil package as described [here](https://golang.org/doc/go1.16#ioutil)

[_Created by Sourcegraph batch change `rslade/deprecate-ioutil`._](https://k8s.sgdev.org/users/rslade/batch-changes/deprecate-ioutil)