### PR TITLE
Fix broken link for batch changes docs

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -7,7 +7,7 @@
 - **Search & get results in your terminal**
 - **Search & get JSON** for programmatic consumption
 - Make **GraphQL API requests** with auth easily & get JSON back fast
-- Execute **[batch changes](https://docs.sourcegraph.com/user/batch-changes)**
+- Execute **[batch changes](https://docs.sourcegraph.com/batch_changes)**
 - **Manage & administrate** repositories, users, and more
 - **Easily convert src-CLI commands to equivalent curl commands**, just add --get-curl!
 
@@ -104,7 +104,7 @@ Is your Sourcegraph instance behind a custom auth proxy? See [auth proxy configu
  - `src login` - authenticate to a Sourcegraph instance with your user credentials
  - `src search` - perform searches and get results in your terminal or as JSON
  - `src api` - run Sourcegraph GraphQL API requests
- - `src batch` - execute and manage [batch changes](https://docs.sourcegraph.com/user/batch-changes)
+ - `src batch` - execute and manage [batch changes](https://docs.sourcegraph.com/batch_changes)
  - `src repos` - manage repositories
  - `src users` - manage users
  - `src orgs` - manages organization


### PR DESCRIPTION
## What

Fix broken links for batch changes.

## Why

Better document maintenability.