### PR TITLE
Use select:repo to speed up repository resolution

### DIFF
--- a/cmd/src/batch_common.go
+++ b/cmd/src/batch_common.go
@@ -272,7 +272,7 @@ func batchExecute(ctx context.Context, out *output.Output, svc *batches.Service,
 		Parallelism: flags.parallelism,
 		FetchFileMatches: func(repo *graphql.Repository) (map[string]bool, error) {
 			fileResults := make(map[string]bool)
-			for _, onQuery := range repo.IncludedInSearchQueries {
+			for onQuery := range repo.IncludedInSearchQueries {
 				r, err := svc.FetchFileResultsForRepo(ctx, repo, onQuery)
 				if err != nil {
 					return nil, err

--- a/cmd/src/batch_common.go
+++ b/cmd/src/batch_common.go
@@ -270,6 +270,19 @@ func batchExecute(ctx context.Context, out *output.Output, svc *batches.Service,
 		Timeout:     flags.timeout,
 		TempDir:     flags.tempDir,
 		Parallelism: flags.parallelism,
+		FetchFileMatches: func(repo *graphql.Repository) (map[string]bool, error) {
+			fileResults := make(map[string]bool)
+			for _, onQuery := range repo.IncludedInSearchQueries {
+				r, err := svc.FetchFileResultsForRepo(ctx, repo, onQuery)
+				if err != nil {
+					return nil, err
+				}
+				for k := range r {
+					fileResults[k] = true
+				}
+			}
+			return fileResults, nil
+		},
 	}
 
 	p := newBatchProgressPrinter(out, *verbose, flags.parallelism)

--- a/internal/batches/executor.go
+++ b/internal/batches/executor.go
@@ -362,9 +362,15 @@ func (x *executor) do(ctx context.Context, task *Task) (err error) {
 		x.updateTaskStatus(task, func(status *TaskStatus) {
 			status.CurrentlyExecuting = "Resolving file matches..."
 		})
-		task.Repository.FileMatches, err = x.FetchFileMatches(task.Repository)
+		req, err := requiresSearchResultPaths(task)
 		if err != nil {
 			return err
+		}
+		if req {
+			task.Repository.FileMatches, err = x.FetchFileMatches(task.Repository)
+			if err != nil {
+				return err
+			}
 		}
 		x.updateTaskStatus(task, func(status *TaskStatus) {
 			status.CurrentlyExecuting = "Executing steps..."

--- a/internal/batches/executor.go
+++ b/internal/batches/executor.go
@@ -362,7 +362,6 @@ func (x *executor) do(ctx context.Context, task *Task) (err error) {
 		x.updateTaskStatus(task, func(status *TaskStatus) {
 			status.CurrentlyExecuting = "Resolving file matches..."
 		})
-		time.Sleep(10 * time.Second)
 		task.Repository.FileMatches, err = x.FetchFileMatches(task.Repository)
 		if err != nil {
 			return err

--- a/internal/batches/features.go
+++ b/internal/batches/features.go
@@ -14,6 +14,7 @@ type featureFlags struct {
 	allowtransformChanges    bool
 	allowWorkspaces          bool
 	batchChanges             bool
+	selectSearchOperator     bool
 }
 
 func (ff *featureFlags) setFromVersion(version string) error {
@@ -28,6 +29,7 @@ func (ff *featureFlags) setFromVersion(version string) error {
 		{&ff.allowtransformChanges, ">= 3.23.0", "2020-12-11"},
 		{&ff.allowWorkspaces, ">= 3.25.0", "2021-01-29"},
 		{&ff.batchChanges, ">= 3.26.0", "2021-03-07"},
+		{&ff.selectSearchOperator, ">= 3.26.0", "2021-03-17"},
 	} {
 		value, err := api.CheckSourcegraphVersion(version, feature.constraint, feature.minDate)
 		if err != nil {

--- a/internal/batches/features.go
+++ b/internal/batches/features.go
@@ -29,7 +29,7 @@ func (ff *featureFlags) setFromVersion(version string) error {
 		{&ff.allowtransformChanges, ">= 3.23.0", "2020-12-11"},
 		{&ff.allowWorkspaces, ">= 3.25.0", "2021-01-29"},
 		{&ff.batchChanges, ">= 3.26.0", "2021-03-07"},
-		{&ff.selectSearchOperator, ">= 3.26.0", "2021-03-17"},
+		{&ff.selectSearchOperator, ">= 3.26.0", "2021-03-16"},
 	} {
 		value, err := api.CheckSourcegraphVersion(version, feature.constraint, feature.minDate)
 		if err != nil {

--- a/internal/batches/graphql/repository.go
+++ b/internal/batches/graphql/repository.go
@@ -49,7 +49,8 @@ type Repository struct {
 	// branch's name and the contents of the Commit property.
 	Branch Branch
 
-	FileMatches map[string]bool
+	FileMatches             map[string]bool
+	IncludedInSearchQueries []string
 }
 
 func (r *Repository) HasBranch() bool {

--- a/internal/batches/graphql/repository.go
+++ b/internal/batches/graphql/repository.go
@@ -53,6 +53,23 @@ type Repository struct {
 	IncludedInSearchQueries map[string]bool
 }
 
+func (r *Repository) Clone() *Repository {
+	c := *r
+	if r.DefaultBranch != nil {
+		db := *r.DefaultBranch
+		c.DefaultBranch = &db
+	}
+	c.FileMatches = make(map[string]bool)
+	for k, v := range r.FileMatches {
+		c.FileMatches[k] = v
+	}
+	c.IncludedInSearchQueries = make(map[string]bool)
+	for k, v := range r.IncludedInSearchQueries {
+		c.IncludedInSearchQueries[k] = v
+	}
+	return &c
+}
+
 func (r *Repository) HasBranch() bool {
 	return r.DefaultBranch != nil || (r.Commit.OID != "" && r.Branch.Name != "")
 }

--- a/internal/batches/graphql/repository.go
+++ b/internal/batches/graphql/repository.go
@@ -50,7 +50,7 @@ type Repository struct {
 	Branch Branch
 
 	FileMatches             map[string]bool
-	IncludedInSearchQueries []string
+	IncludedInSearchQueries map[string]bool
 }
 
 func (r *Repository) HasBranch() bool {

--- a/internal/batches/service.go
+++ b/internal/batches/service.go
@@ -278,7 +278,7 @@ func (svc *Service) BuildTasks(ctx context.Context, repos []*graphql.Repository,
 				}
 
 				tasks = append(tasks, &Task{
-					Repository:            repo,
+					Repository:            repo.Clone(),
 					Path:                  d,
 					Steps:                 spec.Steps,
 					TransformChanges:      spec.TransformChanges,
@@ -292,7 +292,7 @@ func (svc *Service) BuildTasks(ctx context.Context, repos []*graphql.Repository,
 
 	for r := range rootWorkspace {
 		tasks = append(tasks, &Task{
-			Repository:            r,
+			Repository:            r.Clone(),
 			Path:                  "",
 			Steps:                 spec.Steps,
 			TransformChanges:      spec.TransformChanges,

--- a/internal/batches/service.go
+++ b/internal/batches/service.go
@@ -886,7 +886,7 @@ func (svc *Service) FetchFileResultsForRepo(ctx context.Context, repo *graphql.R
 	if len(result.Search.Results.Results) == 1 {
 		return result.Search.Results.Results[0].FileMatches, nil
 	}
-	return nil, errors.New("what the heck")
+	return nil, fmt.Errorf("got invalid result count, expected to get exactly one result for the queried repository, but got %d", len(result.Search.Results.Results))
 }
 
 var defaultQueryCountRegex = regexp.MustCompile(`\bcount:\d+\b`)

--- a/internal/batches/service.go
+++ b/internal/batches/service.go
@@ -553,6 +553,14 @@ func (svc *Service) ResolveRepositories(ctx context.Context, spec *BatchSpec) ([
 					}
 				}
 			} else {
+				for filename := range repo.FileMatches {
+					other.FileMatches[filename] = true
+				}
+
+				for searchq := range repo.IncludedInSearchQueries {
+					other.IncludedInSearchQueries[searchq] = true
+				}
+
 				// If we've already seen this repository, we overwrite the
 				// Commit/Branch fields with the latest value we have
 				other.Commit = repo.Commit
@@ -699,7 +707,10 @@ func (svc *Service) resolveRepositorySearch(ctx context.Context, query string) (
 	if svc.features.selectSearchOperator {
 		repos = make([]*graphql.Repository, 0, len(result.Search.Results.Results))
 		for _, r := range result.Search.Results.Results {
-			r.Repository.IncludedInSearchQueries = append(r.Repository.IncludedInSearchQueries, queryWithDefaultCount)
+			if r.Repository.IncludedInSearchQueries == nil {
+				r.Repository.IncludedInSearchQueries = make(map[string]bool)
+			}
+			r.Repository.IncludedInSearchQueries[queryWithDefaultCount] = true
 			repos = append(repos, &r.Repository)
 		}
 	} else {

--- a/internal/batches/service.go
+++ b/internal/batches/service.go
@@ -696,6 +696,7 @@ func (svc *Service) resolveRepositorySearch(ctx context.Context, query string) (
 
 	var repos []*graphql.Repository
 	if svc.features.selectSearchOperator {
+		repos = make([]*graphql.Repository, 0, len(result.Search.Results.Results))
 		for _, r := range result.Search.Results.Results {
 			repos = append(repos, &r.Repository)
 		}

--- a/internal/batches/templating_test.go
+++ b/internal/batches/templating_test.go
@@ -343,3 +343,30 @@ ${{ steps.renamed_files }}
 		})
 	}
 }
+
+func TestUsesTemplating(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{name: "no templating", input: "foobar", want: false},
+		{name: "only templating", input: "${{ .CoolVar }}", want: false},
+		{name: "text and templating", input: "foobar and ${{ .CoolVar }}", want: false},
+		{name: "uses repository.search_result_paths", input: "foobar and ${{ repository.search_result_paths }}", want: true},
+		{name: "uses repository.search_result_paths", input: `foobar and ${{ join repository.search_result_paths "," }}`, want: true},
+		{name: "repository.search_result_paths outside of template expression", input: "repository.search_result_paths", want: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			have, err := usesTemplating(tc.input)
+			if err != nil {
+				t.Error(err)
+			}
+			if have != tc.want {
+				t.Errorf("wrong result. want=%t, have=%t", tc.want, have)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adopts select:repo to speed up initial resolution of matching repositories in batch changes, if the Sourcegraph instance supports it. To fetch file matches per repository, we each out to the server again to get the file results, per repo. This is significantly faster than waiting for all results for all repos to be retrieved.

Co-authored-by: Rijnard van Tonder <rvantonder@gmail.com>
