### PR TITLE
Filter out repositories with .batchignore at root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to `src-cli` are documented in this file.
 ### Added
 
 - Extension publishing will now add a `gitHead` property to the extension's manifest. [#500](https://github.com/sourcegraph/src-cli/pull/500)
+- `src batch [apply|preview]` now ignore repositories in which a `.batchignore` file exists. The `-force-override-ignore` flag can be used to turn that behaviour off. [#509](https://github.com/sourcegraph/src-cli/pull/509)
 
 ### Changed
 

--- a/cmd/src/batch_apply.go
+++ b/cmd/src/batch_apply.go
@@ -69,6 +69,7 @@ Examples:
 
 		svc := batches.NewService(&batches.ServiceOpts{
 			AllowUnsupported: flags.allowUnsupported,
+			AllowIgnored:     flags.allowIgnored,
 			Client:           cfg.apiClient(flags.api, flagSet.Output()),
 			Workspace:        flags.workspace,
 		})

--- a/cmd/src/batch_common.go
+++ b/cmd/src/batch_common.go
@@ -31,6 +31,7 @@ var (
 
 type batchApplyFlags struct {
 	allowUnsupported bool
+	allowIgnored     bool
 	api              *api.Flags
 	apply            bool
 	cacheDir         string
@@ -54,6 +55,10 @@ func newBatchApplyFlags(flagSet *flag.FlagSet, cacheDir, tempDir string) *batchA
 	flagSet.BoolVar(
 		&caf.allowUnsupported, "allow-unsupported", false,
 		"Allow unsupported code hosts.",
+	)
+	flagSet.BoolVar(
+		&caf.allowIgnored, "no-ignore", false,
+		"Do not ignore repositories that have a .batchignore file.",
 	)
 	flagSet.BoolVar(
 		&caf.apply, "apply", false,
@@ -234,6 +239,14 @@ func batchExecute(ctx context.Context, out *output.Output, svc *batches.Service,
 			batchCompletePending(pending, "Resolved repositories")
 
 			block := out.Block(output.Line(" ", output.StyleWarning, "Some repositories are hosted on unsupported code hosts and will be skipped. Use the -allow-unsupported flag to avoid skipping them."))
+			for repo := range repoSet {
+				block.Write(repo.Name)
+			}
+			block.Close()
+		} else if repoSet, ok := err.(batches.IgnoredRepoSet); ok {
+			batchCompletePending(pending, "Resolved repositories")
+
+			block := out.Block(output.Line(" ", output.StyleWarning, "Some repositories contain .batchignore files and will be skipped. Use the -no-ignore flag to avoid skipping them."))
 			for repo := range repoSet {
 				block.Write(repo.Name)
 			}

--- a/cmd/src/batch_common.go
+++ b/cmd/src/batch_common.go
@@ -246,7 +246,7 @@ func batchExecute(ctx context.Context, out *output.Output, svc *batches.Service,
 		} else if repoSet, ok := err.(batches.IgnoredRepoSet); ok {
 			batchCompletePending(pending, "Resolved repositories")
 
-			block := out.Block(output.Line(" ", output.StyleWarning, "Some repositories contain .batchignore files and will be skipped. Use the -no-ignore flag to avoid skipping them."))
+			block := out.Block(output.Line(" ", output.StyleWarning, "The repositories listed below contain .batchignore files and will be skipped. Use the -no-ignore flag to avoid skipping them."))
 			for repo := range repoSet {
 				block.Write(repo.Name)
 			}

--- a/cmd/src/batch_common.go
+++ b/cmd/src/batch_common.go
@@ -57,7 +57,7 @@ func newBatchApplyFlags(flagSet *flag.FlagSet, cacheDir, tempDir string) *batchA
 		"Allow unsupported code hosts.",
 	)
 	flagSet.BoolVar(
-		&caf.allowIgnored, "no-ignore", false,
+		&caf.allowIgnored, "force-override-ignore", false,
 		"Do not ignore repositories that have a .batchignore file.",
 	)
 	flagSet.BoolVar(
@@ -246,7 +246,7 @@ func batchExecute(ctx context.Context, out *output.Output, svc *batches.Service,
 		} else if repoSet, ok := err.(batches.IgnoredRepoSet); ok {
 			batchCompletePending(pending, "Resolved repositories")
 
-			block := out.Block(output.Line(" ", output.StyleWarning, "The repositories listed below contain .batchignore files and will be skipped. Use the -no-ignore flag to avoid skipping them."))
+			block := out.Block(output.Line(" ", output.StyleWarning, "The repositories listed below contain .batchignore files and will be skipped. Use the -force-override-ignore flag to avoid skipping them."))
 			for repo := range repoSet {
 				block.Write(repo.Name)
 			}

--- a/cmd/src/batch_preview.go
+++ b/cmd/src/batch_preview.go
@@ -44,6 +44,7 @@ Examples:
 
 		svc := batches.NewService(&batches.ServiceOpts{
 			AllowUnsupported: flags.allowUnsupported,
+			AllowIgnored:     flags.allowIgnored,
 			Client:           cfg.apiClient(flags.api, flagSet.Output()),
 			Workspace:        flags.workspace,
 		})

--- a/internal/batches/errors.go
+++ b/internal/batches/errors.go
@@ -44,3 +44,33 @@ func (e UnsupportedRepoSet) appendRepo(repo *graphql.Repository) {
 func (e UnsupportedRepoSet) hasUnsupported() bool {
 	return len(e) > 0
 }
+
+// IgnoredRepoSet provides a set to manage repositories that are on
+// unsupported code hosts. This type implements error to allow it to be
+// returned directly as an error value if needed.
+type IgnoredRepoSet map[*graphql.Repository]struct{}
+
+func (e IgnoredRepoSet) includes(r *graphql.Repository) bool {
+	_, ok := e[r]
+	return ok
+}
+
+func (e IgnoredRepoSet) Error() string {
+	repos := []string{}
+	for repo := range e {
+		repos = append(repos, repo.Name)
+	}
+
+	return fmt.Sprintf(
+		"found repositories containing .batchignore files:\n\t%s",
+		strings.Join(repos, "\n\t"),
+	)
+}
+
+func (e IgnoredRepoSet) appendRepo(repo *graphql.Repository) {
+	e[repo] = struct{}{}
+}
+
+func (e IgnoredRepoSet) hasIgnored() bool {
+	return len(e) > 0
+}

--- a/internal/batches/graphql/repository.go
+++ b/internal/batches/graphql/repository.go
@@ -42,8 +42,6 @@ type Repository struct {
 	URL                string
 	ExternalRepository struct{ ServiceType string }
 
-	BatchIgnoreLocations []string
-
 	DefaultBranch *Branch
 
 	Commit Target
@@ -52,10 +50,6 @@ type Repository struct {
 	Branch Branch
 
 	FileMatches map[string]bool
-}
-
-func (r *Repository) HasBatchIgnoreFile() bool {
-	return len(r.BatchIgnoreLocations) != 0
 }
 
 func (r *Repository) HasBranch() bool {

--- a/internal/batches/graphql/repository.go
+++ b/internal/batches/graphql/repository.go
@@ -42,6 +42,8 @@ type Repository struct {
 	URL                string
 	ExternalRepository struct{ ServiceType string }
 
+	BatchIgnoreLocations []string
+
 	DefaultBranch *Branch
 
 	Commit Target
@@ -50,6 +52,10 @@ type Repository struct {
 	Branch Branch
 
 	FileMatches map[string]bool
+}
+
+func (r *Repository) HasBatchIgnoreFile() bool {
+	return len(r.BatchIgnoreLocations) != 0
 }
 
 func (r *Repository) HasBranch() bool {

--- a/internal/batches/service.go
+++ b/internal/batches/service.go
@@ -678,8 +678,11 @@ func (svc *Service) resolveRepositorySearch(ctx context.Context, query string) (
 			}
 		}
 	}
+
+	q := setBatchignoreFilter(setDefaultQueryCount(query))
+
 	if ok, err := svc.client.NewRequest(repositorySearchQuery, map[string]interface{}{
-		"query":       setDefaultQueryCount(query),
+		"query":       q,
 		"queryCommit": false,
 		"rev":         "",
 	}).Do(ctx, &result); err != nil || !ok {
@@ -832,6 +835,18 @@ func setDefaultQueryCount(query string) string {
 	}
 
 	return query + hardCodedCount
+}
+
+const batchignoreFilter = " -repohasfile:^.batchignore$"
+
+func setBatchignoreFilter(query string) string {
+	// If the user already defined something related to .batchignore, we don't
+	// mess with the query
+	if strings.Contains(query, ".batchignore") {
+		return query
+	}
+
+	return query + batchignoreFilter
 }
 
 type searchResult struct {


### PR DESCRIPTION
This implements https://github.com/sourcegraph/sourcegraph/issues/18330 by querying the locations of `.batchignore` files in each repository yielded by the `on` attribute in a batch spec. If locations were found, the repository is ignored.

This can be overwritten by using the `-force-override-ignore` flag.

Example: given my instance has the following repositories:

- `github.com/sourcegraph-testing/zap`
- `github.com/sourcegraph-testing/titan`
- `github.com/sourcegraph-testing/tidb`
- `github.com/sourcegraph-testing/etcd`
- `github.com/sourcegraph-testing/batch-changes-testing-ignore`

And I use the following batch spec:

```yaml
on:
  - repositoriesMatchingQuery: repohasfile:README.md repo:sourcegraph-testing

steps:
  - run: echo "a horse says 'hello'" >> README.md
    container: alpine:3
```

with this change the `batch-changes-testing-ignore` repository will be ignored:

- no archive will be downloaded
- no steps executed

A message is printed that says it's ignored.

