### PR TITLE
Fix regression by setting CleanArchives flag again

### DIFF
--- a/cmd/src/batch_common.go
+++ b/cmd/src/batch_common.go
@@ -297,13 +297,14 @@ func executeBatchSpec(ctx context.Context, opts executeBatchSpecOpts) error {
 	batchCompletePending(pending, fmt.Sprintf("Found %d workspaces with steps to execute", len(tasks)))
 
 	execOpts := executor.Opts{
-		CacheDir:    opts.flags.cacheDir,
-		ClearCache:  opts.flags.clearCache,
-		Creator:     workspaceCreator,
-		Parallelism: opts.flags.parallelism,
-		Timeout:     opts.flags.timeout,
-		KeepLogs:    opts.flags.keepLogs,
-		TempDir:     opts.flags.tempDir,
+		CacheDir:      opts.flags.cacheDir,
+		ClearCache:    opts.flags.clearCache,
+		CleanArchives: opts.flags.cleanArchives,
+		Creator:       workspaceCreator,
+		Parallelism:   opts.flags.parallelism,
+		Timeout:       opts.flags.timeout,
+		KeepLogs:      opts.flags.keepLogs,
+		TempDir:       opts.flags.tempDir,
 	}
 
 	p := newBatchProgressPrinter(opts.out, *verbose, opts.flags.parallelism)


### PR DESCRIPTION
Apparently I lost this flag when cleaning up the code here. So: too much
cleaning, but due to that not enough cleaning.

In practical terms: before this commit and since the regression repo
archives would've been kept around, by default.