### PR TITLE
Only checkout repo archive if steps will be executed

### DIFF
--- a/internal/batches/executor/executor.go
+++ b/internal/batches/executor/executor.go
@@ -228,7 +228,6 @@ func New(opts Opts, client api.Client, features batches.FeatureFlags) *executor 
 }
 
 func (x *executor) AddTask(task *Task) {
-	task.Archive = x.fetcher.Checkout(task.Repository, task.ArchivePathToFetch())
 	x.tasks = append(x.tasks, task)
 
 	x.statusesMu.Lock()
@@ -376,6 +375,9 @@ func (x *executor) do(ctx context.Context, task *Task) (err error) {
 		}
 		log.Close()
 	}()
+
+	// Now checkout the archive
+	task.Archive = x.fetcher.Checkout(task.Repository, task.ArchivePathToFetch())
 
 	// Set up our timeout.
 	runCtx, cancel := context.WithTimeout(ctx, x.timeout)


### PR DESCRIPTION
Since we use a "reference counting" mechanism when checking out archives
we shouldn't bump the ref count if we never execute steps.

Because only after executing the steps do we decrease the ref count and
thus "free" the archive to be cleaned up.

The problem is that if a `Task` has a cache hit then the ref will never
be decreased and the archive never cleaned up.

Edit, just to clarify: it's hard to hit this, since it requires `workspaces` to be defined and `if:` conditions structured in a way that would bust the cache for _one_ of N workspaces that use the same archive.