### PR TITLE
Make checking of cache explicit in TUI

### DIFF
--- a/cmd/src/batch_common.go
+++ b/cmd/src/batch_common.go
@@ -298,7 +298,7 @@ func executeBatchSpec(ctx context.Context, opts executeBatchSpecOpts) error {
 	// EXECUTION OF TASKS
 
 	svc.InitCache(opts.flags.cacheDir)
-	svc.InitExecutor(ctx, executor.Opts{
+	svc.InitExecutor(ctx, executor.NewExecutorOpts{
 		CacheDir:      opts.flags.cacheDir,
 		CleanArchives: opts.flags.cleanArchives,
 		Creator:       workspaceCreator,

--- a/cmd/src/batch_common.go
+++ b/cmd/src/batch_common.go
@@ -299,7 +299,6 @@ func executeBatchSpec(ctx context.Context, opts executeBatchSpecOpts) error {
 
 	svc.InitExecutor(ctx, executor.Opts{
 		CacheDir:      opts.flags.cacheDir,
-		ClearCache:    opts.flags.clearCache,
 		CleanArchives: opts.flags.cleanArchives,
 		Creator:       workspaceCreator,
 		Parallelism:   opts.flags.parallelism,
@@ -309,7 +308,7 @@ func executeBatchSpec(ctx context.Context, opts executeBatchSpecOpts) error {
 	})
 
 	pending = batchCreatePending(opts.out, "Checking cache for changeset specs")
-	uncachedTasks, cachedSpecs, err := svc.CheckCache(ctx, tasks)
+	uncachedTasks, cachedSpecs, err := svc.CheckCache(ctx, tasks, opts.flags.clearCache)
 	if err != nil {
 		return err
 	}

--- a/cmd/src/batch_common.go
+++ b/cmd/src/batch_common.go
@@ -297,6 +297,7 @@ func executeBatchSpec(ctx context.Context, opts executeBatchSpecOpts) error {
 
 	// EXECUTION OF TASKS
 
+	svc.InitCache(opts.flags.cacheDir)
 	svc.InitExecutor(ctx, executor.Opts{
 		CacheDir:      opts.flags.cacheDir,
 		CleanArchives: opts.flags.cleanArchives,

--- a/cmd/src/batch_common.go
+++ b/cmd/src/batch_common.go
@@ -313,10 +313,19 @@ func executeBatchSpec(ctx context.Context, opts executeBatchSpecOpts) error {
 	if err != nil {
 		return err
 	}
-	if len(uncachedTasks) > 0 {
-		batchCompletePending(pending, fmt.Sprintf("Found %d cached changeset specs. %d tasks need to be executed", len(cachedSpecs), len(uncachedTasks)))
+	var specsFoundMessage string
+	if len(cachedSpecs) == 1 {
+		specsFoundMessage = "Found 1 cached changeset spec"
 	} else {
-		batchCompletePending(pending, fmt.Sprintf("Found %d cached changeset specs. No tasks need to be executed", len(cachedSpecs)))
+		specsFoundMessage = fmt.Sprintf("Found %d cached changeset specs", len(cachedSpecs))
+	}
+	switch len(uncachedTasks) {
+	case 0:
+		batchCompletePending(pending, fmt.Sprintf("%s; no tasks need to be executed", specsFoundMessage))
+	case 1:
+		batchCompletePending(pending, fmt.Sprintf("%s; %d task needs to be executed", specsFoundMessage, len(uncachedTasks)))
+	default:
+		batchCompletePending(pending, fmt.Sprintf("%s; %d tasks need to be executed", specsFoundMessage, len(uncachedTasks)))
 	}
 
 	p := newBatchProgressPrinter(opts.out, *verbose, opts.flags.parallelism)

--- a/internal/batches/executor/changeset_specs.go
+++ b/internal/batches/executor/changeset_specs.go
@@ -1,0 +1,215 @@
+package executor
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/sourcegraph/go-diff/diff"
+	"github.com/sourcegraph/src-cli/internal/batches"
+)
+
+func createChangesetSpecs(task *Task, result executionResult, features batches.FeatureFlags) ([]*batches.ChangesetSpec, error) {
+	repo := task.Repository.Name
+
+	tmplCtx := &ChangesetTemplateContext{
+		BatchChangeAttributes: *task.BatchChangeAttributes,
+		Steps: StepsContext{
+			Changes: result.ChangedFiles,
+			Path:    result.Path,
+		},
+		Outputs:    result.Outputs,
+		Repository: *task.Repository,
+	}
+
+	var authorName string
+	var authorEmail string
+
+	if task.Template.Commit.Author == nil {
+		if features.IncludeAutoAuthorDetails {
+			// user did not provide author info, so use defaults
+			authorName = "Sourcegraph"
+			authorEmail = "batch-changes@sourcegraph.com"
+		}
+	} else {
+		var err error
+		authorName, err = renderChangesetTemplateField("authorName", task.Template.Commit.Author.Name, tmplCtx)
+		if err != nil {
+			return nil, err
+		}
+		authorEmail, err = renderChangesetTemplateField("authorEmail", task.Template.Commit.Author.Email, tmplCtx)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	title, err := renderChangesetTemplateField("title", task.Template.Title, tmplCtx)
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := renderChangesetTemplateField("body", task.Template.Body, tmplCtx)
+	if err != nil {
+		return nil, err
+	}
+
+	message, err := renderChangesetTemplateField("message", task.Template.Commit.Message, tmplCtx)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: As a next step, we should extend the ChangesetTemplateContext to also include
+	// TransformChanges.Group and then change validateGroups and groupFileDiffs to, for each group,
+	// render the branch name *before* grouping the diffs.
+	defaultBranch, err := renderChangesetTemplateField("branch", task.Template.Branch, tmplCtx)
+	if err != nil {
+		return nil, err
+	}
+
+	newSpec := func(branch, diff string) *batches.ChangesetSpec {
+		return &batches.ChangesetSpec{
+			BaseRepository: task.Repository.ID,
+			CreatedChangeset: &batches.CreatedChangeset{
+				BaseRef:        task.Repository.BaseRef(),
+				BaseRev:        task.Repository.Rev(),
+				HeadRepository: task.Repository.ID,
+				HeadRef:        "refs/heads/" + branch,
+				Title:          title,
+				Body:           body,
+				Commits: []batches.GitCommitDescription{
+					{
+						Message:     message,
+						AuthorName:  authorName,
+						AuthorEmail: authorEmail,
+						Diff:        diff,
+					},
+				},
+				Published: task.Template.Published.ValueWithSuffix(repo, branch),
+			},
+		}
+	}
+
+	var specs []*batches.ChangesetSpec
+
+	groups := groupsForRepository(task.Repository.Name, task.TransformChanges)
+	if len(groups) != 0 {
+		err := validateGroups(task.Repository.Name, task.Template.Branch, groups)
+		if err != nil {
+			return specs, err
+		}
+
+		// TODO: Regarding 'defaultBranch', see comment above
+		diffsByBranch, err := groupFileDiffs(result.Diff, defaultBranch, groups)
+		if err != nil {
+			return specs, errors.Wrap(err, "grouping diffs failed")
+		}
+
+		for branch, diff := range diffsByBranch {
+			specs = append(specs, newSpec(branch, diff))
+		}
+	} else {
+		specs = append(specs, newSpec(defaultBranch, result.Diff))
+	}
+
+	return specs, nil
+}
+
+func groupsForRepository(repo string, transform *batches.TransformChanges) []batches.Group {
+	var groups []batches.Group
+
+	if transform == nil {
+		return groups
+	}
+
+	for _, g := range transform.Group {
+		if g.Repository != "" {
+			if g.Repository == repo {
+				groups = append(groups, g)
+			}
+		} else {
+			groups = append(groups, g)
+		}
+	}
+
+	return groups
+}
+
+func validateGroups(repo, defaultBranch string, groups []batches.Group) error {
+	uniqueBranches := make(map[string]struct{}, len(groups))
+
+	for _, g := range groups {
+		if _, ok := uniqueBranches[g.Branch]; ok {
+			return fmt.Errorf("transformChanges would lead to multiple changesets in repository %s to have the same branch %q", repo, g.Branch)
+		} else {
+			uniqueBranches[g.Branch] = struct{}{}
+		}
+
+		if g.Branch == defaultBranch {
+			return fmt.Errorf("transformChanges group branch for repository %s is the same as branch %q in changesetTemplate", repo, defaultBranch)
+		}
+	}
+
+	return nil
+}
+
+func groupFileDiffs(completeDiff, defaultBranch string, groups []batches.Group) (map[string]string, error) {
+	fileDiffs, err := diff.ParseMultiFileDiff([]byte(completeDiff))
+	if err != nil {
+		return nil, err
+	}
+
+	// Housekeeping: we setup these two datastructures so we can
+	// - access the group.Branch by the directory for which they should be used
+	// - check against the given directories, in order.
+	branchesByDirectory := make(map[string]string, len(groups))
+	dirs := make([]string, len(branchesByDirectory))
+	for _, g := range groups {
+		branchesByDirectory[g.Directory] = g.Branch
+		dirs = append(dirs, g.Directory)
+	}
+
+	byBranch := make(map[string][]*diff.FileDiff, len(groups))
+	byBranch[defaultBranch] = []*diff.FileDiff{}
+
+	// For each file diff...
+	for _, f := range fileDiffs {
+		name := f.NewName
+		if name == "/dev/null" {
+			name = f.OrigName
+		}
+
+		// .. we check whether it matches one of the given directories in the
+		// group transformations, with the last match winning:
+		var matchingDir string
+		for _, d := range dirs {
+			if strings.Contains(name, d) {
+				matchingDir = d
+			}
+		}
+
+		// If the diff didn't match a rule, it goes into the default branch and
+		// the default changeset.
+		if matchingDir == "" {
+			byBranch[defaultBranch] = append(byBranch[defaultBranch], f)
+			continue
+		}
+
+		// If it *did* match a directory, we look up which branch we should use:
+		branch, ok := branchesByDirectory[matchingDir]
+		if !ok {
+			panic("this should not happen: " + matchingDir)
+		}
+
+		byBranch[branch] = append(byBranch[branch], f)
+	}
+
+	finalDiffsByBranch := make(map[string]string, len(byBranch))
+	for branch, diffs := range byBranch {
+		printed, err := diff.PrintMultiFileDiff(diffs)
+		if err != nil {
+			return nil, errors.Wrap(err, "printing multi file diff failed")
+		}
+		finalDiffsByBranch[branch] = string(printed)
+	}
+	return finalDiffsByBranch, nil
+}

--- a/internal/batches/executor/check_cache.go
+++ b/internal/batches/executor/check_cache.go
@@ -1,0 +1,45 @@
+package executor
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"github.com/sourcegraph/src-cli/internal/batches"
+)
+
+func CheckCache(ctx context.Context, cache ExecutionCache, clearCache bool, features batches.FeatureFlags, task *Task) (specs []*batches.ChangesetSpec, found bool, err error) {
+	// Check if the task is cached.
+	cacheKey := task.cacheKey()
+	if clearCache {
+		if err = cache.Clear(ctx, cacheKey); err != nil {
+			return specs, false, errors.Wrapf(err, "clearing cache for %q", task.Repository.Name)
+		}
+
+		return specs, false, nil
+	}
+
+	var result executionResult
+	result, found, err = cache.Get(ctx, cacheKey)
+	if err != nil {
+		return specs, false, errors.Wrapf(err, "checking cache for %q", task.Repository.Name)
+	}
+
+	if !found {
+		return specs, false, nil
+	}
+
+	// If the cached result resulted in an empty diff, we don't need to
+	// add it to the list of specs that are displayed to the user and
+	// send to the server. Instead, we can just report that the task is
+	// complete and move on.
+	if result.Diff == "" {
+		return specs, true, nil
+	}
+
+	specs, err = createChangesetSpecs(task, result, features)
+	if err != nil {
+		return specs, false, err
+	}
+
+	return specs, true, nil
+}

--- a/internal/batches/executor/executor.go
+++ b/internal/batches/executor/executor.go
@@ -228,7 +228,6 @@ func New(opts Opts, client api.Client, features batches.FeatureFlags) *executor 
 }
 
 func (x *executor) AddTask(task *Task) {
-	task.Archive = x.fetcher.Checkout(task.Repository, task.ArchivePathToFetch())
 	x.tasks = append(x.tasks, task)
 
 	x.statusesMu.Lock()
@@ -376,6 +375,9 @@ func (x *executor) do(ctx context.Context, task *Task) (err error) {
 		}
 		log.Close()
 	}()
+
+	// Now checkout the archive
+	task.Archive = x.fetcher.Checkout(task.Repository, task.ArchivePathToFetch())
 
 	// Set up our timeout.
 	runCtx, cancel := context.WithTimeout(ctx, x.timeout)

--- a/internal/batches/executor/executor.go
+++ b/internal/batches/executor/executor.go
@@ -4,13 +4,11 @@ import (
 	"context"
 	"fmt"
 	"os/exec"
-	"strings"
 	"sync"
 	"time"
 
 	"github.com/neelance/parallel"
 	"github.com/pkg/errors"
-	"github.com/sourcegraph/go-diff/diff"
 	"github.com/sourcegraph/src-cli/internal/api"
 	"github.com/sourcegraph/src-cli/internal/batches"
 	"github.com/sourcegraph/src-cli/internal/batches/log"
@@ -56,7 +54,7 @@ type Executor interface {
 	LockedTaskStatuses(func([]*TaskStatus))
 }
 
-type Opts struct {
+type NewExecutorOpts struct {
 	Cache    ExecutionCache
 	Client   api.Client
 	Features batches.FeatureFlags
@@ -97,7 +95,7 @@ type executor struct {
 	specsMu sync.Mutex
 }
 
-func New(opts Opts) *executor {
+func New(opts NewExecutorOpts) *executor {
 	return &executor{
 		cache:    opts.Cache,
 		client:   opts.Client,
@@ -321,209 +319,4 @@ func reachedTimeout(cmdCtx context.Context, err error) bool {
 	}
 
 	return errors.Is(errors.Cause(err), context.DeadlineExceeded)
-}
-
-func createChangesetSpecs(task *Task, result executionResult, features batches.FeatureFlags) ([]*batches.ChangesetSpec, error) {
-	repo := task.Repository.Name
-
-	tmplCtx := &ChangesetTemplateContext{
-		BatchChangeAttributes: *task.BatchChangeAttributes,
-		Steps: StepsContext{
-			Changes: result.ChangedFiles,
-			Path:    result.Path,
-		},
-		Outputs:    result.Outputs,
-		Repository: *task.Repository,
-	}
-
-	var authorName string
-	var authorEmail string
-
-	if task.Template.Commit.Author == nil {
-		if features.IncludeAutoAuthorDetails {
-			// user did not provide author info, so use defaults
-			authorName = "Sourcegraph"
-			authorEmail = "batch-changes@sourcegraph.com"
-		}
-	} else {
-		var err error
-		authorName, err = renderChangesetTemplateField("authorName", task.Template.Commit.Author.Name, tmplCtx)
-		if err != nil {
-			return nil, err
-		}
-		authorEmail, err = renderChangesetTemplateField("authorEmail", task.Template.Commit.Author.Email, tmplCtx)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	title, err := renderChangesetTemplateField("title", task.Template.Title, tmplCtx)
-	if err != nil {
-		return nil, err
-	}
-
-	body, err := renderChangesetTemplateField("body", task.Template.Body, tmplCtx)
-	if err != nil {
-		return nil, err
-	}
-
-	message, err := renderChangesetTemplateField("message", task.Template.Commit.Message, tmplCtx)
-	if err != nil {
-		return nil, err
-	}
-
-	// TODO: As a next step, we should extend the ChangesetTemplateContext to also include
-	// TransformChanges.Group and then change validateGroups and groupFileDiffs to, for each group,
-	// render the branch name *before* grouping the diffs.
-	defaultBranch, err := renderChangesetTemplateField("branch", task.Template.Branch, tmplCtx)
-	if err != nil {
-		return nil, err
-	}
-
-	newSpec := func(branch, diff string) *batches.ChangesetSpec {
-		return &batches.ChangesetSpec{
-			BaseRepository: task.Repository.ID,
-			CreatedChangeset: &batches.CreatedChangeset{
-				BaseRef:        task.Repository.BaseRef(),
-				BaseRev:        task.Repository.Rev(),
-				HeadRepository: task.Repository.ID,
-				HeadRef:        "refs/heads/" + branch,
-				Title:          title,
-				Body:           body,
-				Commits: []batches.GitCommitDescription{
-					{
-						Message:     message,
-						AuthorName:  authorName,
-						AuthorEmail: authorEmail,
-						Diff:        diff,
-					},
-				},
-				Published: task.Template.Published.ValueWithSuffix(repo, branch),
-			},
-		}
-	}
-
-	var specs []*batches.ChangesetSpec
-
-	groups := groupsForRepository(task.Repository.Name, task.TransformChanges)
-	if len(groups) != 0 {
-		err := validateGroups(task.Repository.Name, task.Template.Branch, groups)
-		if err != nil {
-			return specs, err
-		}
-
-		// TODO: Regarding 'defaultBranch', see comment above
-		diffsByBranch, err := groupFileDiffs(result.Diff, defaultBranch, groups)
-		if err != nil {
-			return specs, errors.Wrap(err, "grouping diffs failed")
-		}
-
-		for branch, diff := range diffsByBranch {
-			specs = append(specs, newSpec(branch, diff))
-		}
-	} else {
-		specs = append(specs, newSpec(defaultBranch, result.Diff))
-	}
-
-	return specs, nil
-}
-
-func groupsForRepository(repo string, transform *batches.TransformChanges) []batches.Group {
-	var groups []batches.Group
-
-	if transform == nil {
-		return groups
-	}
-
-	for _, g := range transform.Group {
-		if g.Repository != "" {
-			if g.Repository == repo {
-				groups = append(groups, g)
-			}
-		} else {
-			groups = append(groups, g)
-		}
-	}
-
-	return groups
-}
-
-func validateGroups(repo, defaultBranch string, groups []batches.Group) error {
-	uniqueBranches := make(map[string]struct{}, len(groups))
-
-	for _, g := range groups {
-		if _, ok := uniqueBranches[g.Branch]; ok {
-			return fmt.Errorf("transformChanges would lead to multiple changesets in repository %s to have the same branch %q", repo, g.Branch)
-		} else {
-			uniqueBranches[g.Branch] = struct{}{}
-		}
-
-		if g.Branch == defaultBranch {
-			return fmt.Errorf("transformChanges group branch for repository %s is the same as branch %q in changesetTemplate", repo, defaultBranch)
-		}
-	}
-
-	return nil
-}
-
-func groupFileDiffs(completeDiff, defaultBranch string, groups []batches.Group) (map[string]string, error) {
-	fileDiffs, err := diff.ParseMultiFileDiff([]byte(completeDiff))
-	if err != nil {
-		return nil, err
-	}
-
-	// Housekeeping: we setup these two datastructures so we can
-	// - access the group.Branch by the directory for which they should be used
-	// - check against the given directories, in order.
-	branchesByDirectory := make(map[string]string, len(groups))
-	dirs := make([]string, len(branchesByDirectory))
-	for _, g := range groups {
-		branchesByDirectory[g.Directory] = g.Branch
-		dirs = append(dirs, g.Directory)
-	}
-
-	byBranch := make(map[string][]*diff.FileDiff, len(groups))
-	byBranch[defaultBranch] = []*diff.FileDiff{}
-
-	// For each file diff...
-	for _, f := range fileDiffs {
-		name := f.NewName
-		if name == "/dev/null" {
-			name = f.OrigName
-		}
-
-		// .. we check whether it matches one of the given directories in the
-		// group transformations, with the last match winning:
-		var matchingDir string
-		for _, d := range dirs {
-			if strings.Contains(name, d) {
-				matchingDir = d
-			}
-		}
-
-		// If the diff didn't match a rule, it goes into the default branch and
-		// the default changeset.
-		if matchingDir == "" {
-			byBranch[defaultBranch] = append(byBranch[defaultBranch], f)
-			continue
-		}
-
-		// If it *did* match a directory, we look up which branch we should use:
-		branch, ok := branchesByDirectory[matchingDir]
-		if !ok {
-			panic("this should not happen: " + matchingDir)
-		}
-
-		byBranch[branch] = append(byBranch[branch], f)
-	}
-
-	finalDiffsByBranch := make(map[string]string, len(byBranch))
-	for branch, diffs := range byBranch {
-		printed, err := diff.PrintMultiFileDiff(diffs)
-		if err != nil {
-			return nil, errors.Wrap(err, "printing multi file diff failed")
-		}
-		finalDiffsByBranch[branch] = string(printed)
-	}
-	return finalDiffsByBranch, nil
 }

--- a/internal/batches/executor/executor.go
+++ b/internal/batches/executor/executor.go
@@ -202,14 +202,15 @@ func (ts *TaskStatus) FileDiffs() ([]*diff.FileDiff, bool, error) {
 }
 
 type Opts struct {
+	Cache    ExecutionCache
+	Client   api.Client
+	Features batches.FeatureFlags
+	Creator  workspace.Creator
+
 	CleanArchives bool
 
 	CacheDir string
 
-	// TODO: shoudl be builder
-	Cache ExecutionCache
-
-	Creator     workspace.Creator
 	Parallelism int
 	Timeout     time.Duration
 
@@ -241,18 +242,16 @@ type executor struct {
 	specsMu sync.Mutex
 }
 
-// TODO(mrnugget): Why are client and features not part of Opts?
-func New(opts Opts, client api.Client, features batches.FeatureFlags) *executor {
+func New(opts Opts) *executor {
 	return &executor{
-		cache: opts.Cache,
+		cache:    opts.Cache,
+		client:   opts.Client,
+		features: opts.Features,
+		creator:  opts.Creator,
 
-		logger:  log.NewManager(opts.TempDir, opts.KeepLogs),
-		creator: opts.Creator,
+		logger: log.NewManager(opts.TempDir, opts.KeepLogs),
 
-		fetcher: batches.NewRepoFetcher(client, opts.CacheDir, opts.CleanArchives),
-
-		client:   client,
-		features: features,
+		fetcher: batches.NewRepoFetcher(opts.Client, opts.CacheDir, opts.CleanArchives),
 
 		tempDir: opts.TempDir,
 		timeout: opts.Timeout,

--- a/internal/batches/executor/executor_test.go
+++ b/internal/batches/executor/executor_test.go
@@ -436,7 +436,10 @@ output4=integration-test-batch-change`,
 			cache := newInMemoryExecutionCache()
 			creator := workspace.NewCreator(context.Background(), "bind", testTempDir, testTempDir, []batches.Step{})
 			opts := Opts{
+				Cache:       cache,
 				Creator:     creator,
+				Client:      client,
+				Features:    featuresAllEnabled(),
 				TempDir:     testTempDir,
 				Parallelism: runtime.GOMAXPROCS(0),
 				Timeout:     tc.executorTimeout,
@@ -452,8 +455,7 @@ output4=integration-test-batch-change`,
 			// executor. We'll run this multiple times to cover both the cache
 			// and non-cache code paths.
 			execute := func(t *testing.T) {
-				executor := New(opts, client, featuresAllEnabled())
-				executor.cache = cache
+				executor := New(opts)
 				executor.fetcher = repoFetcher
 
 				for i := range tc.steps {

--- a/internal/batches/executor/executor_test.go
+++ b/internal/batches/executor/executor_test.go
@@ -435,7 +435,7 @@ output4=integration-test-batch-change`,
 
 			cache := newInMemoryExecutionCache()
 			creator := workspace.NewCreator(context.Background(), "bind", testTempDir, testTempDir, []batches.Step{})
-			opts := Opts{
+			opts := NewExecutorOpts{
 				Cache:       cache,
 				Creator:     creator,
 				Client:      client,

--- a/internal/batches/executor/task.go
+++ b/internal/batches/executor/task.go
@@ -1,0 +1,40 @@
+package executor
+
+import (
+	"github.com/sourcegraph/src-cli/internal/batches"
+	"github.com/sourcegraph/src-cli/internal/batches/graphql"
+)
+
+type Task struct {
+	Repository *graphql.Repository
+
+	// Path is the folder relative to the repository's root in which the steps
+	// should be executed.
+	Path string
+	// OnlyFetchWorkspace determines whether the repository archive contains
+	// the complete repository or just the files in Path (and additional files,
+	// see RepoFetcher).
+	// If Path is "" then this setting has no effect.
+	OnlyFetchWorkspace bool
+
+	Steps []batches.Step
+
+	// TODO(mrnugget): this should just be a single BatchSpec field instead, if
+	// we can make it work with caching
+	BatchChangeAttributes *BatchChangeAttributes     `json:"-"`
+	Template              *batches.ChangesetTemplate `json:"-"`
+	TransformChanges      *batches.TransformChanges  `json:"-"`
+
+	Archive batches.RepoZip `json:"-"`
+}
+
+func (t *Task) ArchivePathToFetch() string {
+	if t.OnlyFetchWorkspace {
+		return t.Path
+	}
+	return ""
+}
+
+func (t *Task) cacheKey() ExecutionCacheKey {
+	return ExecutionCacheKey{t}
+}

--- a/internal/batches/executor/task_status.go
+++ b/internal/batches/executor/task_status.go
@@ -1,0 +1,82 @@
+package executor
+
+import (
+	"sync"
+	"time"
+
+	"github.com/sourcegraph/go-diff/diff"
+	"github.com/sourcegraph/src-cli/internal/batches"
+)
+
+type TaskStatus struct {
+	RepoName string
+	Path     string
+
+	Cached bool
+
+	LogFile    string
+	EnqueuedAt time.Time
+	StartedAt  time.Time
+	FinishedAt time.Time
+
+	// TODO: add current step and progress fields.
+	CurrentlyExecuting string
+
+	// ChangesetSpecs are the specs produced by executing the Task in a
+	// repository. With the introduction of `transformChanges` to the batch
+	// spec, one Task can produce multiple ChangesetSpecs.
+	ChangesetSpecs []*batches.ChangesetSpec
+	// Err is set if executing the Task lead to an error.
+	Err error
+
+	fileDiffs     []*diff.FileDiff
+	fileDiffsErr  error
+	fileDiffsOnce sync.Once
+}
+
+func (ts *TaskStatus) DisplayName() string {
+	if ts.Path != "" {
+		return ts.RepoName + ":" + ts.Path
+	}
+	return ts.RepoName
+}
+
+func (ts *TaskStatus) IsRunning() bool {
+	return !ts.StartedAt.IsZero() && ts.FinishedAt.IsZero()
+}
+
+func (ts *TaskStatus) IsCompleted() bool {
+	return !ts.StartedAt.IsZero() && !ts.FinishedAt.IsZero()
+}
+
+func (ts *TaskStatus) ExecutionTime() time.Duration {
+	return ts.FinishedAt.Sub(ts.StartedAt).Truncate(time.Millisecond)
+}
+
+// FileDiffs returns the file diffs produced by the Task in the given
+// repository.
+// If no file diffs were produced, the task resulted in an error, or the task
+// hasn't finished execution yet, the second return value is false.
+func (ts *TaskStatus) FileDiffs() ([]*diff.FileDiff, bool, error) {
+	if !ts.IsCompleted() || len(ts.ChangesetSpecs) == 0 || ts.Err != nil {
+		return nil, false, nil
+	}
+
+	ts.fileDiffsOnce.Do(func() {
+		var all []*diff.FileDiff
+
+		for _, spec := range ts.ChangesetSpecs {
+			fd, err := diff.ParseMultiFileDiff([]byte(spec.Commits[0].Diff))
+			if err != nil {
+				ts.fileDiffsErr = err
+				return
+			}
+
+			all = append(all, fd...)
+		}
+
+		ts.fileDiffs = all
+	})
+
+	return ts.fileDiffs, len(ts.fileDiffs) != 0, ts.fileDiffsErr
+}

--- a/internal/batches/repo_fetcher.go
+++ b/internal/batches/repo_fetcher.go
@@ -184,6 +184,7 @@ func (rz *repoZip) Close() error {
 	defer rz.mu.Unlock()
 
 	rz.uses -= 1
+
 	if rz.uses == 0 && rz.checkouts == 0 && rz.deleteOnClose {
 		for _, addFile := range rz.additionalFiles {
 			if addFile.fetched {

--- a/internal/batches/service/service.go
+++ b/internal/batches/service/service.go
@@ -28,6 +28,9 @@ type Service struct {
 	client           api.Client
 	features         batches.FeatureFlags
 	imageCache       *docker.ImageCache
+
+	// TODO(mrnugget): I don't like this state here, ugh.
+	exec executor.Executor
 }
 
 type Opts struct {
@@ -192,16 +195,37 @@ func (svc *Service) BuildTasks(ctx context.Context, repos []*graphql.Repository,
 	return builder.BuildAll(ctx, repos)
 }
 
-func (svc *Service) RunExecutor(ctx context.Context, opts executor.Opts, tasks []*executor.Task, spec *batches.BatchSpec, progress func([]*executor.TaskStatus), skipErrors bool) ([]*batches.ChangesetSpec, []string, error) {
-	x := executor.New(opts, svc.client, svc.features)
+func (svc *Service) InitExecutor(ctx context.Context, opts executor.Opts) {
+	svc.exec = executor.New(opts, svc.client, svc.features)
+}
+
+func (svc *Service) CheckCache(ctx context.Context, tasks []*executor.Task) (uncached []*executor.Task, specs []*batches.ChangesetSpec, err error) {
 	for _, t := range tasks {
-		x.AddTask(t)
+		cachedSpecs, found, err := svc.exec.CheckCache(ctx, t)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		if !found {
+			uncached = append(uncached, t)
+			continue
+		}
+
+		specs = append(specs, cachedSpecs...)
+	}
+
+	return uncached, specs, nil
+}
+
+func (svc *Service) RunExecutor(ctx context.Context, tasks []*executor.Task, spec *batches.BatchSpec, progress func([]*executor.TaskStatus), skipErrors bool) ([]*batches.ChangesetSpec, []string, error) {
+	for _, t := range tasks {
+		svc.exec.AddTask(t)
 	}
 
 	done := make(chan struct{})
 	if progress != nil {
 		go func() {
-			x.LockedTaskStatuses(progress)
+			svc.exec.LockedTaskStatuses(progress)
 
 			ticker := time.NewTicker(1 * time.Second)
 			defer ticker.Stop()
@@ -209,7 +233,7 @@ func (svc *Service) RunExecutor(ctx context.Context, opts executor.Opts, tasks [
 			for {
 				select {
 				case <-ticker.C:
-					x.LockedTaskStatuses(progress)
+					svc.exec.LockedTaskStatuses(progress)
 
 				case <-done:
 					return
@@ -220,10 +244,10 @@ func (svc *Service) RunExecutor(ctx context.Context, opts executor.Opts, tasks [
 
 	var errs *multierror.Error
 
-	x.Start(ctx)
-	specs, err := x.Wait(ctx)
+	svc.exec.Start(ctx)
+	specs, err := svc.exec.Wait(ctx)
 	if progress != nil {
-		x.LockedTaskStatuses(progress)
+		svc.exec.LockedTaskStatuses(progress)
 		done <- struct{}{}
 	}
 	if err != nil {
@@ -272,7 +296,7 @@ func (svc *Service) RunExecutor(ctx context.Context, opts executor.Opts, tasks [
 		}
 	}
 
-	return specs, x.LogFiles(), errs.ErrorOrNil()
+	return specs, svc.exec.LogFiles(), errs.ErrorOrNil()
 }
 
 func (svc *Service) ValidateChangesetSpecs(repos []*graphql.Repository, specs []*batches.ChangesetSpec) error {

--- a/internal/batches/service/service.go
+++ b/internal/batches/service/service.go
@@ -203,7 +203,7 @@ func (svc *Service) InitCache(cacheDir string) {
 
 // TODO(mrnugget): This is not good. Ideally the executor wouldn't have to know
 // anything about the cache.
-func (svc *Service) InitExecutor(ctx context.Context, opts executor.Opts) {
+func (svc *Service) InitExecutor(ctx context.Context, opts executor.NewExecutorOpts) {
 	opts.Cache = svc.cache
 	opts.Client = svc.client
 	opts.Features = svc.features


### PR DESCRIPTION
This is based on @eseliger's idea, which was confirmed independently by @courier-new as something worthwhile.

In short: before this change we wouldn't tell users whether we have cached results _and_ we'd only check the check once we start executing a task. The problem with that is that if you have 500 tasks to execute, 480 of which are cached, the UI would tell you "executing 4/500 tasks" and then only speed up once it gets to the cached values.

This PR here pulls the cache-checking out of the task execution and makes it a separate step in the batch spec execution and in the UI:

![image](https://user-images.githubusercontent.com/1185253/117985188-c6378580-b338-11eb-8409-ef1c4080fd8d.png)

---

**Note to reviewers:** there is also a lot of other clean-up/refactoring/move-around stuff in here that I either (a) had to do to make this easier or (b) wanted to do after digging more into this and realizing that we could probably decouple the executor from this whole process of caching/building-changeset-specs.

I'm not done yet, but I decided to open this PR before things get unreviewable.

Take a look at 3e8475dd7951e3430d35afd76e873b047415517c to see the gist of this change. The other commits mostly move things in separate files, rename stuff, clean up dependency chains.

I'm going to create a new branch off of this one for more cleanups/refactorings.