### PR TITLE
Fix skip errors flag

### DIFF
--- a/internal/batches/executor/executor.go
+++ b/internal/batches/executor/executor.go
@@ -171,7 +171,7 @@ func (x *executor) Wait(ctx context.Context) ([]*batches.ChangesetSpec, error) {
 	case err := <-result:
 		close(result)
 		if err != nil {
-			return nil, err
+			return x.specs, err
 		}
 	}
 


### PR DESCRIPTION
We didn't return the specs in case of an error, so we would ignore the error, but still have no changeset specs uploaded, which resulted in the generated batch spec in the preview being empty.