### PR TITLE
Implement step-wise caching for batch spec execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ All notable changes to `src-cli` are documented in this file.
 
 ### Changed
 
+- `src batch [apply|preview]` now cache the results of each step when executing a batch spec. That can make re-execution a lot faster when only a subset of the steps has been changed. [#540](https://github.com/sourcegraph/src-cli/pull/540)
+
 ### Fixed
 
 ### Removed

--- a/internal/batches/executor/changeset_specs_test.go
+++ b/internal/batches/executor/changeset_specs_test.go
@@ -8,22 +8,15 @@ import (
 	"github.com/sourcegraph/batch-change-utils/overridable"
 	"github.com/sourcegraph/src-cli/internal/batches"
 	"github.com/sourcegraph/src-cli/internal/batches/git"
-	"github.com/sourcegraph/src-cli/internal/batches/graphql"
 )
 
 func TestCreateChangesetSpecs(t *testing.T) {
-	srcCLI := &graphql.Repository{
-		ID:            "src-cli",
-		Name:          "github.com/sourcegraph/src-cli",
-		DefaultBranch: &graphql.Branch{Name: "main", Target: graphql.Target{OID: "d34db33f"}},
-	}
-
 	defaultChangesetSpec := &batches.ChangesetSpec{
-		BaseRepository: srcCLI.ID,
+		BaseRepository: testRepo1.ID,
 		CreatedChangeset: &batches.CreatedChangeset{
-			BaseRef:        srcCLI.DefaultBranch.Name,
-			BaseRev:        srcCLI.DefaultBranch.Target.OID,
-			HeadRepository: srcCLI.ID,
+			BaseRef:        testRepo1.DefaultBranch.Name,
+			BaseRev:        testRepo1.DefaultBranch.Target.OID,
+			HeadRepository: testRepo1.ID,
 			HeadRef:        "refs/heads/my-branch",
 			Title:          "The title",
 			Body:           "The body",
@@ -58,7 +51,7 @@ func TestCreateChangesetSpecs(t *testing.T) {
 			},
 			Published: parsePublishedFieldString(t, "false"),
 		},
-		Repository: srcCLI,
+		Repository: testRepo1,
 	}
 
 	taskWith := func(t *Task, f func(t *Task)) *Task {

--- a/internal/batches/executor/coordinator.go
+++ b/internal/batches/executor/coordinator.go
@@ -28,7 +28,7 @@ type Coordinator struct {
 
 	cache      ExecutionCache
 	exec       taskExecutor
-	logManager *log.Manager
+	logManager log.LogManager
 }
 
 type repoNameResolver func(ctx context.Context, name string) (*graphql.Repository, error)
@@ -217,8 +217,9 @@ func (c *Coordinator) Execute(ctx context.Context, tasks []*Task, spec *batches.
 	if stepCache, ok := c.cache.(StepWiseExecutionCache); ok {
 		for _, t := range tasks {
 			// We start at the back, because the steps depend on each other
-			for i := len(t.Steps) - 1; i > 0; i-- {
+			for i := len(t.Steps) - 1; i > -1; i-- {
 				key := StepsCacheKey{Task: t, StepIndex: i}
+
 				result, found, err := stepCache.GetStepResult(ctx, key)
 				if err != nil {
 					return nil, nil, errors.Wrapf(err, "checking for cached diff for step %d", i)

--- a/internal/batches/executor/coordinator.go
+++ b/internal/batches/executor/coordinator.go
@@ -150,7 +150,7 @@ func (c *Coordinator) cacheAndBuildSpec(ctx context.Context, taskResult taskResu
 	for _, stepResult := range taskResult.stepResults {
 		key := StepsCacheKey{Task: taskResult.task, StepIndex: stepResult.Step}
 		if err := c.cache.SetStepResult(ctx, key, stepResult); err != nil {
-			return nil, errors.Wrapf(err, "caching result for %q", taskResult.task.Repository.Name)
+			return nil, errors.Wrapf(err, "caching result for step %d in %q", stepResult.Step, taskResult.task.Repository.Name)
 		}
 	}
 
@@ -213,7 +213,8 @@ func (c *Coordinator) Execute(ctx context.Context, tasks []*Task, spec *batches.
 	// If we are here, that means we didn't find anything in the cache for the
 	// complete task. So, what if we have cached results for the steps?
 	for _, t := range tasks {
-		// We start at the back, because the steps depend on each other
+		// We start at the back so that we can find the _last_ cached step,
+		// then restart execution on the following step.
 		for i := len(t.Steps) - 1; i > -1; i-- {
 			key := StepsCacheKey{Task: t, StepIndex: i}
 

--- a/internal/batches/executor/coordinator.go
+++ b/internal/batches/executor/coordinator.go
@@ -146,9 +146,7 @@ func (c *Coordinator) cacheAndBuildSpec(ctx context.Context, taskResult taskResu
 		return nil, errors.Wrapf(err, "caching result for %q", taskResult.task.Repository.Name)
 	}
 
-	// ----------------------------------------------------------------------------
-	// EXPERIMENT STARTS HERE
-	// vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
+	// Save the per-step results
 	if stepCache, ok := c.cache.(StepWiseExecutionCache); ok {
 		for _, stepResult := range taskResult.stepResults {
 			key := taskResult.task.cacheKeyForSteps(stepResult.Step)
@@ -158,9 +156,6 @@ func (c *Coordinator) cacheAndBuildSpec(ctx context.Context, taskResult taskResu
 			}
 		}
 	}
-	// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-	// EXPERIMENT ENDS HERE
-	// ----------------------------------------------------------------------------
 
 	// If the steps didn't result in any diff, we don't need to create a
 	// changeset spec that's displayed to the user and send to the server.

--- a/internal/batches/executor/coordinator.go
+++ b/internal/batches/executor/coordinator.go
@@ -148,9 +148,9 @@ func (c *Coordinator) cacheAndBuildSpec(ctx context.Context, taskResult taskResu
 
 	// Save the per-step results
 	for _, stepResult := range taskResult.stepResults {
-		key := StepsCacheKey{Task: taskResult.task, StepIndex: stepResult.Step}
+		key := StepsCacheKey{Task: taskResult.task, StepIndex: stepResult.StepIndex}
 		if err := c.cache.SetStepResult(ctx, key, stepResult); err != nil {
-			return nil, errors.Wrapf(err, "caching result for step %d in %q", stepResult.Step, taskResult.task.Repository.Name)
+			return nil, errors.Wrapf(err, "caching result for step %d in %q", stepResult.StepIndex, taskResult.task.Repository.Name)
 		}
 	}
 

--- a/internal/batches/executor/coordinator.go
+++ b/internal/batches/executor/coordinator.go
@@ -6,8 +6,6 @@ import (
 	"strconv"
 	"time"
 
-	logger "log"
-
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/src-cli/internal/api"
@@ -155,8 +153,6 @@ func (c *Coordinator) cacheAndBuildSpec(ctx context.Context, taskResult taskResu
 		for _, stepResult := range taskResult.stepResults {
 			key := taskResult.task.cacheKeyForSteps(stepResult.Step)
 
-			logger.Printf("caching diff. step=%d, len(diff)=%d, len(outputs)=%d\n", stepResult.Step, len(stepResult.Diff), len(stepResult.Outputs))
-
 			if err := stepCache.SetStepResult(ctx, key, stepResult); err != nil {
 				return nil, errors.Wrapf(err, "caching result for %q", taskResult.task.Repository.Name)
 			}
@@ -194,7 +190,6 @@ type executionProgressPrinter func([]*TaskStatus)
 // given spec. It regularly calls the executionProgressPrinter with the
 // current TaskStatuses.
 func (c *Coordinator) Execute(ctx context.Context, tasks []*Task, spec *batches.BatchSpec, printer executionProgressPrinter) ([]*batches.ChangesetSpec, []string, error) {
-	logger.Printf("------- executing batch spec ------------")
 	var (
 		specs []*batches.ChangesetSpec
 		errs  *multierror.Error
@@ -228,9 +223,6 @@ func (c *Coordinator) Execute(ctx context.Context, tasks []*Task, spec *batches.
 	// If we are here, that means we didn't find anything in the cache for the
 	// complete task. So, what if we have cached results for the steps?
 	if stepCache, ok := c.cache.(StepWiseExecutionCache); ok {
-		if len(tasks) > 0 {
-			logger.Printf("need to execute %d tasks. checking cache for per-step caches", len(tasks))
-		}
 		for _, t := range tasks {
 			// We start at the back, because the steps depend on each other
 			for i := len(t.Steps) - 1; i > 0; i-- {
@@ -242,8 +234,6 @@ func (c *Coordinator) Execute(ctx context.Context, tasks []*Task, spec *batches.
 				}
 
 				if found {
-					logger.Printf("found a cached diff we can start from. step=%d, len(result.diff)=%d, len(result.outputs)=%d", i, len(result.Diff), len(result.Outputs))
-
 					t.CachedResultFound = true
 					t.CachedResult = result
 					break

--- a/internal/batches/executor/coordinator_test.go
+++ b/internal/batches/executor/coordinator_test.go
@@ -411,7 +411,7 @@ func (c *inMemoryExecutionCache) size() int {
 	return len(c.cache)
 }
 
-func (c *inMemoryExecutionCache) Get(ctx context.Context, key ExecutionCacheKey) (executionResult, bool, error) {
+func (c *inMemoryExecutionCache) Get(ctx context.Context, key CacheKeyer) (executionResult, bool, error) {
 	k, err := key.Key()
 	if err != nil {
 		return executionResult{}, false, err
@@ -426,7 +426,7 @@ func (c *inMemoryExecutionCache) Get(ctx context.Context, key ExecutionCacheKey)
 	return executionResult{}, false, nil
 }
 
-func (c *inMemoryExecutionCache) Set(ctx context.Context, key ExecutionCacheKey, result executionResult) error {
+func (c *inMemoryExecutionCache) Set(ctx context.Context, key CacheKeyer, result executionResult) error {
 	k, err := key.Key()
 	if err != nil {
 		return err
@@ -439,7 +439,7 @@ func (c *inMemoryExecutionCache) Set(ctx context.Context, key ExecutionCacheKey,
 	return nil
 }
 
-func (c *inMemoryExecutionCache) Clear(ctx context.Context, key ExecutionCacheKey) error {
+func (c *inMemoryExecutionCache) Clear(ctx context.Context, key CacheKeyer) error {
 	k, err := key.Key()
 	if err != nil {
 		return err

--- a/internal/batches/executor/coordinator_test.go
+++ b/internal/batches/executor/coordinator_test.go
@@ -340,6 +340,7 @@ func TestCoordinator_Execute(t *testing.T) {
 		})
 	}
 }
+
 func TestCoordinator_Execute_StepCaching(t *testing.T) {
 	cache := newInMemoryExecutionCache()
 
@@ -354,7 +355,6 @@ func TestCoordinator_Execute_StepCaching(t *testing.T) {
 	}
 
 	executor := &dummyExecutor{}
-
 	executor.results = []taskResult{{
 		task: task,
 		result: executionResult{

--- a/internal/batches/executor/coordinator_test.go
+++ b/internal/batches/executor/coordinator_test.go
@@ -422,7 +422,7 @@ func execAndEnsure(t *testing.T, cache ExecutionCache, exec *dummyExecutor, task
 		t.Fatalf("execution of task failed: %s", err)
 	}
 
-	// Sanity check, because we're not interesting in the specs
+	// Sanity check, because we're not interested in the specs
 	if have, want := len(specs), 1; have != want {
 		t.Fatalf("Wrong number of specs. want=%d, have=%d", want, have)
 	}

--- a/internal/batches/executor/coordinator_test.go
+++ b/internal/batches/executor/coordinator_test.go
@@ -265,7 +265,7 @@ func TestCoordinator_Execute(t *testing.T) {
 				}
 			}
 
-			logManager := mock.NoopLogManager{}
+			logManager := mock.LogNoOpManager{}
 
 			cache := newInMemoryExecutionCache()
 			noopPrinter := func([]*TaskStatus) {}
@@ -364,9 +364,9 @@ func TestCoordinator_Execute_StepCaching(t *testing.T) {
 			Path:         "",
 		},
 		stepResults: []stepExecutionResult{
-			{Step: 0, Diff: []byte(`step-0-diff`)},
-			{Step: 1, Diff: []byte(`step-1-diff`)},
-			{Step: 2, Diff: []byte(`step-2-diff`)},
+			{StepIndex: 0, Diff: []byte(`step-0-diff`)},
+			{StepIndex: 1, Diff: []byte(`step-1-diff`)},
+			{StepIndex: 2, Diff: []byte(`step-2-diff`)},
 		},
 	}}
 
@@ -404,7 +404,7 @@ func execAndEnsure(t *testing.T, cache ExecutionCache, exec *dummyExecutor, task
 
 	// Setup dependencies
 	batchSpec := &batches.BatchSpec{ChangesetTemplate: testChangesetTemplate}
-	logManager := mock.NoopLogManager{}
+	logManager := mock.LogNoOpManager{}
 	noopPrinter := func([]*TaskStatus) {}
 
 	// Build Coordinator
@@ -455,7 +455,7 @@ func assertCachedResultForStep(t *testing.T, step int) func(context.Context, []*
 			t.Fatalf("CachedResultFound not set")
 		}
 
-		if have, want := task.CachedResult.Step, step; have != want {
+		if have, want := task.CachedResult.StepIndex, step; have != want {
 			t.Fatalf("CachedResult.Step wrong. have=%d, want=%d", have, want)
 		}
 	}

--- a/internal/batches/executor/execution_cache.go
+++ b/internal/batches/executor/execution_cache.go
@@ -195,8 +195,8 @@ type StepWiseExecutionCache interface {
 	ExecutionCache
 
 	// TODO: This should only take a key
-	GetStepResult(ctx context.Context, key ExecutionCacheKey, stepidx int) (result cachedStepResult, found bool, err error)
-	SetStepResult(ctx context.Context, key ExecutionCacheKey, result cachedStepResult) error
+	GetStepResult(ctx context.Context, key ExecutionCacheKey, stepidx int) (result stepExecutionResult, found bool, err error)
+	SetStepResult(ctx context.Context, key ExecutionCacheKey, result stepExecutionResult) error
 }
 
 var _ StepWiseExecutionCache = ExecutionDiskCache{}
@@ -210,8 +210,8 @@ func (c ExecutionDiskCache) cachedStepResultFilePath(key ExecutionCacheKey, step
 	return filepath.Join(c.Dir, key.RepoSlug(), fmt.Sprintf("step-%d-%s.json", stepidx, keyString)), nil
 }
 
-func (c ExecutionDiskCache) GetStepResult(ctx context.Context, key ExecutionCacheKey, stepidx int) (cachedStepResult, bool, error) {
-	var result cachedStepResult
+func (c ExecutionDiskCache) GetStepResult(ctx context.Context, key ExecutionCacheKey, stepidx int) (stepExecutionResult, bool, error) {
+	var result stepExecutionResult
 	path, err := c.cachedStepResultFilePath(key, stepidx)
 	if err != nil {
 		return result, false, err
@@ -237,7 +237,7 @@ func (c ExecutionDiskCache) GetStepResult(ctx context.Context, key ExecutionCach
 	return result, true, nil
 }
 
-func (c ExecutionDiskCache) SetStepResult(ctx context.Context, key ExecutionCacheKey, result cachedStepResult) error {
+func (c ExecutionDiskCache) SetStepResult(ctx context.Context, key ExecutionCacheKey, result stepExecutionResult) error {
 	path, err := c.cachedStepResultFilePath(key, result.Step)
 	if err != nil {
 		return err

--- a/internal/batches/executor/execution_cache.go
+++ b/internal/batches/executor/execution_cache.go
@@ -63,7 +63,7 @@ func marshalHash(t *Task, envs []map[string]string) (string, error) {
 	return base64.RawURLEncoding.EncodeToString(hash[:16]), nil
 }
 
-// StepsCachekey implements the CacheKeyer interface for a Task and a *subset*
+// StepsCacheKey implements the CacheKeyer interface for a Task and a *subset*
 // of its Steps, up to and including the step with index StepIndex in
 // Task.Steps.
 type StepsCacheKey struct {

--- a/internal/batches/executor/execution_cache.go
+++ b/internal/batches/executor/execution_cache.go
@@ -236,7 +236,28 @@ func (c ExecutionDiskCache) Clear(ctx context.Context, key CacheKeyer) error {
 	return os.Remove(path)
 }
 
-// ExecutionNoOpCache is an implementation of actionExecutionCache that does not store or
+func (c ExecutionDiskCache) GetStepResult(ctx context.Context, key CacheKeyer) (stepExecutionResult, bool, error) {
+	var result stepExecutionResult
+	path, err := c.cacheFilePath(key)
+	if err != nil {
+		return result, false, err
+	}
+
+	found, err := c.readCacheFile(path, &result)
+
+	return result, found, nil
+}
+
+func (c ExecutionDiskCache) SetStepResult(ctx context.Context, key CacheKeyer, result stepExecutionResult) error {
+	path, err := c.cacheFilePath(key)
+	if err != nil {
+		return err
+	}
+
+	return c.writeCacheFile(path, &result)
+}
+
+// ExecutionNoOpCache is an implementation of ExecutionCache that does not store or
 // retrieve cache entries.
 type ExecutionNoOpCache struct{}
 
@@ -258,35 +279,4 @@ func (ExecutionNoOpCache) SetStepResult(ctx context.Context, key CacheKeyer, res
 
 func (ExecutionNoOpCache) GetStepResult(ctx context.Context, key CacheKeyer) (stepExecutionResult, bool, error) {
 	return stepExecutionResult{}, false, nil
-}
-
-// ----------------------------------------------------------------------------
-// EXPERIMENT STARTS HERE
-// ----------------------------------------------------------------------------
-
-type StepWiseExecutionCache interface {
-	ExecutionCache
-}
-
-var _ StepWiseExecutionCache = ExecutionDiskCache{}
-
-func (c ExecutionDiskCache) GetStepResult(ctx context.Context, key CacheKeyer) (stepExecutionResult, bool, error) {
-	var result stepExecutionResult
-	path, err := c.cacheFilePath(key)
-	if err != nil {
-		return result, false, err
-	}
-
-	found, err := c.readCacheFile(path, &result)
-
-	return result, found, nil
-}
-
-func (c ExecutionDiskCache) SetStepResult(ctx context.Context, key CacheKeyer, result stepExecutionResult) error {
-	path, err := c.cacheFilePath(key)
-	if err != nil {
-		return err
-	}
-
-	return c.writeCacheFile(path, &result)
 }

--- a/internal/batches/executor/execution_cache_test.go
+++ b/internal/batches/executor/execution_cache_test.go
@@ -35,7 +35,16 @@ func TestExecutionCacheKey(t *testing.T) {
 	}
 
 	// And now we can set up a key to work with.
-	key := ExecutionCacheKey{&Task{Steps: steps}}
+	key := ExecutionCacheKey{&Task{
+		Repository: &graphql.Repository{
+			ID:   "repo-1",
+			Name: "github.com/sourcegraph/src-cli",
+			DefaultBranch: &graphql.Branch{
+				Target: graphql.Target{OID: "d34db33f"},
+			},
+		},
+		Steps: steps,
+	}}
 
 	// All righty. Let's get ourselves a baseline cache key here.
 	initial, err := key.Key()
@@ -120,14 +129,26 @@ func TestExecutionDiskCache(t *testing.T) {
 	}
 
 	cacheKey1 := ExecutionCacheKey{Task: &Task{
-		Repository: &graphql.Repository{Name: "src-cli"},
+		Repository: &graphql.Repository{
+			ID:   "repo-1",
+			Name: "github.com/sourcegraph/src-cli",
+			DefaultBranch: &graphql.Branch{
+				Target: graphql.Target{OID: "d34db33f"},
+			},
+		},
 		Steps: []batches.Step{
 			{Run: "echo 'Hello World'", Container: "alpine:3"},
 		},
 	}}
 
 	cacheKey2 := ExecutionCacheKey{Task: &Task{
-		Repository: &graphql.Repository{Name: "documentation"},
+		Repository: &graphql.Repository{
+			ID:   "repo-2",
+			Name: "github.com/sourcegraph/docs",
+			DefaultBranch: &graphql.Branch{
+				Target: graphql.Target{OID: "d34db33f"},
+			},
+		},
 		Steps: []batches.Step{
 			{Run: "echo 'Hello World'", Container: "alpine:3"},
 		},

--- a/internal/batches/executor/execution_cache_test.go
+++ b/internal/batches/executor/execution_cache_test.go
@@ -188,37 +188,6 @@ func TestExecutionDiskCache(t *testing.T) {
 	})
 }
 
-func TestSortCacheFiles(t *testing.T) {
-	tests := []struct {
-		paths []string
-		want  []string
-	}{
-		{
-			paths: []string{"file.v3.json", "file.diff", "file.json"},
-			want:  []string{"file.v3.json", "file.diff", "file.json"},
-		},
-		{
-			paths: []string{"file.json", "file.diff", "file.v3.json"},
-			want:  []string{"file.v3.json", "file.json", "file.diff"},
-		},
-		{
-			paths: []string{"file.diff", "file.v3.json"},
-			want:  []string{"file.v3.json", "file.diff"},
-		},
-		{
-			paths: []string{"file1.v3.json", "file2.v3.json"},
-			want:  []string{"file1.v3.json", "file2.v3.json"},
-		},
-	}
-
-	for _, tt := range tests {
-		sortCacheFiles(tt.paths)
-		if diff := cmp.Diff(tt.paths, tt.want); diff != "" {
-			t.Errorf("wrong cached result (-have +want):\n\n%s", diff)
-		}
-	}
-}
-
 func assertFileDeleted(t *testing.T, path string) {
 	t.Helper()
 	if _, err := os.Stat(path); err == nil {

--- a/internal/batches/executor/executor.go
+++ b/internal/batches/executor/executor.go
@@ -51,7 +51,7 @@ type newExecutorOpts struct {
 	// Dependencies
 	Creator workspace.Creator
 	Fetcher batches.RepoFetcher
-	Logger  *log.Manager
+	Logger  log.LogManager
 
 	// Config
 	AutoAuthorDetails bool

--- a/internal/batches/executor/executor.go
+++ b/internal/batches/executor/executor.go
@@ -44,7 +44,7 @@ func (e TaskExecutionErr) StatusText() string {
 type taskResult struct {
 	task        *Task
 	result      executionResult
-	stepResults []cachedStepResult
+	stepResults []stepExecutionResult
 }
 
 type newExecutorOpts struct {
@@ -208,7 +208,7 @@ func (x *executor) do(ctx context.Context, task *Task, status taskStatusHandler)
 	return nil
 }
 
-func (x *executor) addResult(task *Task, result executionResult, stepResults []cachedStepResult) {
+func (x *executor) addResult(task *Task, result executionResult, stepResults []stepExecutionResult) {
 	x.resultsMu.Lock()
 	defer x.resultsMu.Unlock()
 

--- a/internal/batches/executor/executor_test.go
+++ b/internal/batches/executor/executor_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/sourcegraph/go-diff/diff"
 	"github.com/sourcegraph/src-cli/internal/api"
 	"github.com/sourcegraph/src-cli/internal/batches"
-	"github.com/sourcegraph/src-cli/internal/batches/graphql"
 	"github.com/sourcegraph/src-cli/internal/batches/log"
 	"github.com/sourcegraph/src-cli/internal/batches/mock"
 	"github.com/sourcegraph/src-cli/internal/batches/workspace"
@@ -29,21 +28,6 @@ func TestExecutor_Integration(t *testing.T) {
 	}
 
 	addToPath(t, "testdata/dummydocker")
-
-	srcCLIRepo := &graphql.Repository{
-		ID:            "src-cli",
-		Name:          "github.com/sourcegraph/src-cli",
-		DefaultBranch: &graphql.Branch{Name: "main", Target: graphql.Target{OID: "d34db33f"}},
-	}
-
-	sourcegraphRepo := &graphql.Repository{
-		ID:   "sourcegraph",
-		Name: "github.com/sourcegraph/sourcegraph",
-		DefaultBranch: &graphql.Branch{
-			Name:   "main",
-			Target: graphql.Target{OID: "f00b4r3r"},
-		},
-	}
 
 	defaultBatchChangeAttributes := &BatchChangeAttributes{
 		Name:        "integration-test-batch-change",
@@ -78,11 +62,11 @@ func TestExecutor_Integration(t *testing.T) {
 		{
 			name: "success",
 			archives: []mock.RepoArchive{
-				{Repo: srcCLIRepo, Files: map[string]string{
+				{Repo: testRepo1, Files: map[string]string{
 					"README.md": "# Welcome to the README\n",
 					"main.go":   "package main\n\nfunc main() {\n\tfmt.Println(     \"Hello World\")\n}\n",
 				}},
-				{Repo: sourcegraphRepo, Files: map[string]string{
+				{Repo: testRepo2, Files: map[string]string{
 					"README.md": "# Sourcegraph README\n",
 				}},
 			},
@@ -91,14 +75,14 @@ func TestExecutor_Integration(t *testing.T) {
 				{Run: `[[ -f "main.go" ]] && go fmt main.go || exit 0`},
 			},
 			tasks: []*Task{
-				{Repository: srcCLIRepo},
-				{Repository: sourcegraphRepo},
+				{Repository: testRepo1},
+				{Repository: testRepo2},
 			},
 			wantFilesChanged: filesByRepository{
-				srcCLIRepo.ID: filesByPath{
+				testRepo1.ID: filesByPath{
 					rootPath: []string{"README.md", "main.go"},
 				},
-				sourcegraphRepo.ID: {
+				testRepo2.ID: {
 					rootPath: []string{"README.md"},
 				},
 			},
@@ -106,7 +90,7 @@ func TestExecutor_Integration(t *testing.T) {
 		{
 			name: "empty",
 			archives: []mock.RepoArchive{
-				{Repo: srcCLIRepo, Files: map[string]string{
+				{Repo: testRepo1, Files: map[string]string{
 					"README.md": "# Welcome to the README\n",
 					"main.go":   "package main\n\nfunc main() {\n\tfmt.Println(     \"Hello World\")\n}\n",
 				}},
@@ -116,11 +100,11 @@ func TestExecutor_Integration(t *testing.T) {
 			},
 
 			tasks: []*Task{
-				{Repository: srcCLIRepo},
+				{Repository: testRepo1},
 			},
 			// No diff should be generated.
 			wantFilesChanged: filesByRepository{
-				srcCLIRepo.ID: filesByPath{
+				testRepo1.ID: filesByPath{
 					rootPath: []string{},
 				},
 			},
@@ -128,7 +112,7 @@ func TestExecutor_Integration(t *testing.T) {
 		{
 			name: "timeout",
 			archives: []mock.RepoArchive{
-				{Repo: srcCLIRepo, Files: map[string]string{"README.md": "line 1"}},
+				{Repo: testRepo1, Files: map[string]string{"README.md": "line 1"}},
 			},
 			steps: []batches.Step{
 				// This needs to be a loop, because when a process goes to sleep
@@ -139,7 +123,7 @@ func TestExecutor_Integration(t *testing.T) {
 				{Run: `while true; do echo "zZzzZ" && sleep 0.05; done`},
 			},
 			tasks: []*Task{
-				{Repository: srcCLIRepo},
+				{Repository: testRepo1},
 			},
 			executorTimeout: 100 * time.Millisecond,
 			wantErrInclude:  "execution in github.com/sourcegraph/src-cli failed: Timeout reached. Execution took longer than 100ms.",
@@ -147,7 +131,7 @@ func TestExecutor_Integration(t *testing.T) {
 		{
 			name: "templated steps",
 			archives: []mock.RepoArchive{
-				{Repo: srcCLIRepo, Files: map[string]string{
+				{Repo: testRepo1, Files: map[string]string{
 					"README.md": "# Welcome to the README\n",
 					"main.go":   "package main\n\nfunc main() {\n\tfmt.Println(     \"Hello World\")\n}\n",
 				}},
@@ -168,10 +152,10 @@ func TestExecutor_Integration(t *testing.T) {
 			},
 
 			tasks: []*Task{
-				{Repository: srcCLIRepo},
+				{Repository: testRepo1},
 			},
 			wantFilesChanged: filesByRepository{
-				srcCLIRepo.ID: filesByPath{
+				testRepo1.ID: filesByPath{
 					rootPath: []string{
 						"main.go",
 						"modified-main.go.md",
@@ -184,24 +168,24 @@ func TestExecutor_Integration(t *testing.T) {
 		{
 			name: "workspaces",
 			archives: []mock.RepoArchive{
-				{Repo: srcCLIRepo, Path: "", Files: map[string]string{
+				{Repo: testRepo1, Path: "", Files: map[string]string{
 					".gitignore":      "node_modules",
 					"message.txt":     "root-dir",
 					"a/message.txt":   "a-dir",
 					"a/.gitignore":    "node_modules-in-a",
 					"a/b/message.txt": "b-dir",
 				}},
-				{Repo: srcCLIRepo, Path: "a", Files: map[string]string{
+				{Repo: testRepo1, Path: "a", Files: map[string]string{
 					"a/message.txt":   "a-dir",
 					"a/.gitignore":    "node_modules-in-a",
 					"a/b/message.txt": "b-dir",
 				}},
-				{Repo: srcCLIRepo, Path: "a/b", Files: map[string]string{
+				{Repo: testRepo1, Path: "a/b", Files: map[string]string{
 					"a/b/message.txt": "b-dir",
 				}},
 			},
 			additionalFiles: []mock.MockRepoAdditionalFiles{
-				{Repo: srcCLIRepo, AdditionalFiles: map[string]string{
+				{Repo: testRepo1, AdditionalFiles: map[string]string{
 					".gitignore":   "node_modules",
 					"a/.gitignore": "node_modules-in-a",
 				}},
@@ -222,13 +206,13 @@ func TestExecutor_Integration(t *testing.T) {
 				{Run: `if [[ $(basename $(pwd)) == "b" && -f "../.gitignore" ]]; then echo "yes" >> gitignore-exists-in-a; fi`},
 			},
 			tasks: []*Task{
-				{Repository: srcCLIRepo, Path: ""},
-				{Repository: srcCLIRepo, Path: "a"},
-				{Repository: srcCLIRepo, Path: "a/b"},
+				{Repository: testRepo1, Path: ""},
+				{Repository: testRepo1, Path: "a"},
+				{Repository: testRepo1, Path: "a/b"},
 			},
 
 			wantFilesChanged: filesByRepository{
-				srcCLIRepo.ID: filesByPath{
+				testRepo1.ID: filesByPath{
 					rootPath: []string{"hello.txt", "gitignore-exists"},
 					"a":      []string{"a/hello.txt", "a/gitignore-exists"},
 					"a/b":    []string{"a/b/hello.txt", "a/b/gitignore-exists", "a/b/gitignore-exists-in-a"},
@@ -238,10 +222,10 @@ func TestExecutor_Integration(t *testing.T) {
 		{
 			name: "step condition",
 			archives: []mock.RepoArchive{
-				{Repo: srcCLIRepo, Files: map[string]string{
+				{Repo: testRepo1, Files: map[string]string{
 					"README.md": "# Welcome to the README\n",
 				}},
-				{Repo: sourcegraphRepo, Files: map[string]string{
+				{Repo: testRepo2, Files: map[string]string{
 					"README.md": "# Sourcegraph README\n",
 				}},
 			},
@@ -257,14 +241,14 @@ func TestExecutor_Integration(t *testing.T) {
 				},
 			},
 			tasks: []*Task{
-				{Repository: srcCLIRepo},
-				{Repository: sourcegraphRepo, Path: "sub/directory/of/repo"},
+				{Repository: testRepo1},
+				{Repository: testRepo2, Path: "sub/directory/of/repo"},
 			},
 			wantFilesChanged: filesByRepository{
-				srcCLIRepo.ID: filesByPath{
+				testRepo1.ID: filesByPath{
 					rootPath: []string{"README.md"},
 				},
-				sourcegraphRepo.ID: {
+				testRepo2.ID: {
 					"sub/directory/of/repo": []string{"README.md", "hello.txt", "in-path.txt"},
 				},
 			},
@@ -272,10 +256,10 @@ func TestExecutor_Integration(t *testing.T) {
 		{
 			name: "skips errors",
 			archives: []mock.RepoArchive{
-				{Repo: srcCLIRepo, Files: map[string]string{
+				{Repo: testRepo1, Files: map[string]string{
 					"README.md": "# Welcome to the README\n",
 				}},
-				{Repo: sourcegraphRepo, Files: map[string]string{
+				{Repo: testRepo2, Files: map[string]string{
 					"README.md": "# Sourcegraph README\n",
 				}},
 			},
@@ -283,18 +267,18 @@ func TestExecutor_Integration(t *testing.T) {
 				{Run: `echo -e "foobar\n" >> README.md`},
 				{
 					Run: `exit 1`,
-					If:  fmt.Sprintf(`${{ eq repository.name %q }}`, sourcegraphRepo.Name),
+					If:  fmt.Sprintf(`${{ eq repository.name %q }}`, testRepo2.Name),
 				},
 			},
 			tasks: []*Task{
-				{Repository: srcCLIRepo},
-				{Repository: sourcegraphRepo},
+				{Repository: testRepo1},
+				{Repository: testRepo2},
 			},
 			wantFilesChanged: filesByRepository{
-				srcCLIRepo.ID: filesByPath{
+				testRepo1.ID: filesByPath{
 					rootPath: []string{"README.md"},
 				},
-				sourcegraphRepo.ID: {},
+				testRepo2.ID: {},
 			},
 			wantErrInclude: "execution in github.com/sourcegraph/sourcegraph failed: run: exit 1",
 		},

--- a/internal/batches/executor/executor_test.go
+++ b/internal/batches/executor/executor_test.go
@@ -327,7 +327,7 @@ func TestExecutor_Integration(t *testing.T) {
 			opts := newExecutorOpts{
 				Creator: workspace.NewCreator(context.Background(), "bind", testTempDir, testTempDir, []batches.Step{}),
 				Fetcher: batches.NewRepoFetcher(client, testTempDir, false),
-				Logger:  mock.NoopLogManager{},
+				Logger:  mock.LogNoOpManager{},
 
 				TempDir:     testTempDir,
 				Parallelism: runtime.GOMAXPROCS(0),

--- a/internal/batches/executor/executor_test.go
+++ b/internal/batches/executor/executor_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/sourcegraph/go-diff/diff"
 	"github.com/sourcegraph/src-cli/internal/api"
 	"github.com/sourcegraph/src-cli/internal/batches"
-	"github.com/sourcegraph/src-cli/internal/batches/log"
 	"github.com/sourcegraph/src-cli/internal/batches/mock"
 	"github.com/sourcegraph/src-cli/internal/batches/workspace"
 )
@@ -328,7 +327,7 @@ func TestExecutor_Integration(t *testing.T) {
 			opts := newExecutorOpts{
 				Creator: workspace.NewCreator(context.Background(), "bind", testTempDir, testTempDir, []batches.Step{}),
 				Fetcher: batches.NewRepoFetcher(client, testTempDir, false),
-				Logger:  log.NewManager(testTempDir, false),
+				Logger:  mock.NoopLogManager{},
 
 				TempDir:     testTempDir,
 				Parallelism: runtime.GOMAXPROCS(0),

--- a/internal/batches/executor/main_test.go
+++ b/internal/batches/executor/main_test.go
@@ -1,0 +1,40 @@
+package executor
+
+import (
+	"github.com/sourcegraph/batch-change-utils/overridable"
+	"github.com/sourcegraph/src-cli/internal/batches"
+	"github.com/sourcegraph/src-cli/internal/batches/graphql"
+)
+
+var testRepo1 = &graphql.Repository{
+	ID:            "src-cli",
+	Name:          "github.com/sourcegraph/src-cli",
+	DefaultBranch: &graphql.Branch{Name: "main", Target: graphql.Target{OID: "d34db33f"}},
+	FileMatches: map[string]bool{
+		"README.md": true,
+		"main.go":   true,
+	},
+}
+
+var testRepo2 = &graphql.Repository{
+	ID:   "sourcegraph",
+	Name: "github.com/sourcegraph/sourcegraph",
+	DefaultBranch: &graphql.Branch{
+		Name:   "main",
+		Target: graphql.Target{OID: "f00b4r3r"},
+	},
+}
+
+var testChangesetTemplate = &batches.ChangesetTemplate{
+	Title:  "commit title",
+	Body:   "commit body",
+	Branch: "commit-branch",
+	Commit: batches.ExpandedGitCommitDescription{
+		Message: "commit msg",
+		Author: &batches.GitCommitAuthor{
+			Name:  "Tester",
+			Email: "tester@example.com",
+		},
+	},
+	Published: overridable.FromBoolOrString(false),
+}

--- a/internal/batches/executor/run_steps.go
+++ b/internal/batches/executor/run_steps.go
@@ -25,11 +25,9 @@ import (
 
 // stepExecutionResult is the executionResult after executing the step with the
 // given index in task.Steps.
-// TODO: The naming here kinda clashes with StepResult, which is used for
-// templating.
 type stepExecutionResult struct {
-	// Step is the index of the step in task.Steps
-	Step int `json:"step"`
+	// StepIndex is the index of the step in task.Steps
+	StepIndex int `json:"stepIndex"`
 	// Diff is the cumulative `git diff` after executing the Step.
 	Diff []byte `json:"diff"`
 	// Outputs is a copy of the Outputs after executing the Step.
@@ -102,7 +100,7 @@ func runSteps(ctx context.Context, opts *executionOpts) (result executionResult,
 		// Set the Outputs to the cached outputs
 		execResult.Outputs = opts.cachedResult.Outputs
 
-		startStep = opts.cachedResult.Step + 1
+		startStep = opts.cachedResult.StepIndex + 1
 
 		switch startStep {
 		case 1:
@@ -347,7 +345,7 @@ func runSteps(ctx context.Context, opts *executionOpts) (result executionResult,
 			return execResult, nil, errors.Wrap(err, "getting diff produced by step")
 		}
 		stepResult := stepExecutionResult{
-			Step:               i,
+			StepIndex:          i,
 			Diff:               stepDiff,
 			Outputs:            make(map[string]interface{}),
 			PreviousStepResult: stepContext.PreviousStep,

--- a/internal/batches/executor/run_steps.go
+++ b/internal/batches/executor/run_steps.go
@@ -67,7 +67,7 @@ type executionOpts struct {
 
 	tempDir string
 
-	logger         *log.TaskLogger
+	logger         log.TaskLogger
 	reportProgress func(string)
 
 	// cachedResultFound determines whether all steps are executed or only

--- a/internal/batches/executor/task.go
+++ b/internal/batches/executor/task.go
@@ -26,6 +26,12 @@ type Task struct {
 	TransformChanges      *batches.TransformChanges  `json:"-"`
 
 	Archive batches.RepoZip `json:"-"`
+
+	// ----------------------------------------------------------------------------
+	// EXPERIMENT STARTS HERE
+	// vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
+	CachedResultFound bool             `json:"-"`
+	CachedResult      cachedStepResult `json:"-"`
 }
 
 func (t *Task) ArchivePathToFetch() string {
@@ -37,4 +43,21 @@ func (t *Task) ArchivePathToFetch() string {
 
 func (t *Task) cacheKey() ExecutionCacheKey {
 	return ExecutionCacheKey{t}
+}
+
+// TODO: This is hacky, because we only do this to get an ExecutionCacheKey
+func (t *Task) cacheKeyForSteps(i int) ExecutionCacheKey {
+	taskCopy := &Task{
+		Repository:            t.Repository,
+		Path:                  t.Path,
+		OnlyFetchWorkspace:    t.OnlyFetchWorkspace,
+		BatchChangeAttributes: t.BatchChangeAttributes,
+		Template:              t.Template,
+		TransformChanges:      t.TransformChanges,
+		Archive:               t.Archive,
+	}
+
+	taskCopy.Steps = t.Steps[0 : i+1]
+
+	return ExecutionCacheKey{taskCopy}
 }

--- a/internal/batches/executor/task.go
+++ b/internal/batches/executor/task.go
@@ -30,8 +30,8 @@ type Task struct {
 	// ----------------------------------------------------------------------------
 	// EXPERIMENT STARTS HERE
 	// vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
-	CachedResultFound bool             `json:"-"`
-	CachedResult      cachedStepResult `json:"-"`
+	CachedResultFound bool                `json:"-"`
+	CachedResult      stepExecutionResult `json:"-"`
 }
 
 func (t *Task) ArchivePathToFetch() string {

--- a/internal/batches/executor/task.go
+++ b/internal/batches/executor/task.go
@@ -27,9 +27,6 @@ type Task struct {
 
 	Archive batches.RepoZip `json:"-"`
 
-	// ----------------------------------------------------------------------------
-	// EXPERIMENT STARTS HERE
-	// vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
 	CachedResultFound bool                `json:"-"`
 	CachedResult      stepExecutionResult `json:"-"`
 }

--- a/internal/batches/executor/task.go
+++ b/internal/batches/executor/task.go
@@ -41,23 +41,6 @@ func (t *Task) ArchivePathToFetch() string {
 	return ""
 }
 
-func (t *Task) cacheKey() ExecutionCacheKey {
-	return ExecutionCacheKey{t}
-}
-
-// TODO: This is hacky, because we only do this to get an ExecutionCacheKey
-func (t *Task) cacheKeyForSteps(i int) ExecutionCacheKey {
-	taskCopy := &Task{
-		Repository:            t.Repository,
-		Path:                  t.Path,
-		OnlyFetchWorkspace:    t.OnlyFetchWorkspace,
-		BatchChangeAttributes: t.BatchChangeAttributes,
-		Template:              t.Template,
-		TransformChanges:      t.TransformChanges,
-		Archive:               t.Archive,
-	}
-
-	taskCopy.Steps = t.Steps[0 : i+1]
-
-	return ExecutionCacheKey{taskCopy}
+func (t *Task) cacheKey() TaskCacheKey {
+	return TaskCacheKey{t}
 }

--- a/internal/batches/executor/task_builder_test.go
+++ b/internal/batches/executor/task_builder_test.go
@@ -12,8 +12,6 @@ import (
 )
 
 func TestTaskBuilder_BuildTask_IfConditions(t *testing.T) {
-	repo := &graphql.Repository{Name: "github.com/sourcegraph/automation-testing"}
-
 	tests := map[string]struct {
 		spec *batches.BatchSpec
 
@@ -82,11 +80,11 @@ func TestTaskBuilder_BuildTask_IfConditions(t *testing.T) {
 		"if expression that can be partially evaluated to true": {
 			spec: &batches.BatchSpec{
 				Steps: []batches.Step{
-					{Run: "echo 1", If: `${{ matches repository.name "github.com/sourcegraph/automation*" }}`},
+					{Run: "echo 1", If: `${{ matches repository.name "github.com/sourcegraph/src*" }}`},
 				},
 			},
 			wantSteps: []batches.Step{
-				{Run: "echo 1", If: `${{ matches repository.name "github.com/sourcegraph/automation*" }}`},
+				{Run: "echo 1", If: `${{ matches repository.name "github.com/sourcegraph/src*" }}`},
 			},
 		},
 
@@ -126,7 +124,7 @@ func TestTaskBuilder_BuildTask_IfConditions(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			task, ok, err := builder.buildTask(repo, "", false)
+			task, ok, err := builder.buildTask(testRepo1, "", false)
 			if err != nil {
 				t.Fatalf("unexpected err: %s", err)
 			}

--- a/internal/batches/executor/templating_test.go
+++ b/internal/batches/executor/templating_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/sourcegraph/src-cli/internal/batches/git"
-	"github.com/sourcegraph/src-cli/internal/batches/graphql"
 	"gopkg.in/yaml.v3"
 )
 
@@ -34,13 +33,7 @@ func TestEvalStepCondition(t *testing.T) {
 		},
 		Outputs: map[string]interface{}{},
 		// Step is not set when evalStepCondition is called
-		Repository: graphql.Repository{
-			Name: "github.com/sourcegraph/src-cli",
-			FileMatches: map[string]bool{
-				"README.md": true,
-				"main.go":   true,
-			},
-		},
+		Repository: *testRepo1,
 	}
 
 	tests := []struct {
@@ -108,14 +101,8 @@ func TestRenderStepTemplate(t *testing.T) {
 			Stdout: bytes.NewBufferString("this is current step's stdout"),
 			Stderr: bytes.NewBufferString("this is current step's stderr"),
 		},
-		Steps: StepsContext{Changes: testChanges, Path: "sub/directory/of/repo"},
-		Repository: graphql.Repository{
-			Name: "github.com/sourcegraph/src-cli",
-			FileMatches: map[string]bool{
-				"README.md": true,
-				"main.go":   true,
-			},
-		},
+		Steps:      StepsContext{Changes: testChanges, Path: "sub/directory/of/repo"},
+		Repository: *testRepo1,
 	}
 
 	tests := []struct {
@@ -249,14 +236,8 @@ func TestRenderStepMap(t *testing.T) {
 			Stdout: bytes.NewBufferString("this is previous step's stdout"),
 			Stderr: bytes.NewBufferString("this is previous step's stderr"),
 		},
-		Outputs: map[string]interface{}{},
-		Repository: graphql.Repository{
-			Name: "github.com/sourcegraph/src-cli",
-			FileMatches: map[string]bool{
-				"README.md": true,
-				"main.go":   true,
-			},
-		},
+		Outputs:    map[string]interface{}{},
+		Repository: *testRepo1,
 	}
 
 	input := map[string]string{
@@ -299,13 +280,7 @@ func TestRenderChangesetTemplateField(t *testing.T) {
 			"lastLine": "lastLine is this",
 			"project":  parsedYaml,
 		},
-		Repository: graphql.Repository{
-			Name: "github.com/sourcegraph/src-cli",
-			FileMatches: map[string]bool{
-				"README.md": true,
-				"main.go":   true,
-			},
-		},
+		Repository: *testRepo1,
 		Steps: StepsContext{
 			Changes: &git.Changes{
 				Modified: []string{"modified-file.txt"},

--- a/internal/batches/mock/logger.go
+++ b/internal/batches/mock/logger.go
@@ -7,28 +7,28 @@ import (
 	"github.com/sourcegraph/src-cli/internal/batches/log"
 )
 
-var _ log.TaskLogger = NoopTaskLogger{}
+var _ log.TaskLogger = TaskNoOpLogger{}
 
-type NoopTaskLogger struct{}
+type TaskNoOpLogger struct{}
 
-func (tl NoopTaskLogger) Close() error                         { return nil }
-func (tl NoopTaskLogger) Log(string)                           {}
-func (tl NoopTaskLogger) Logf(string, ...interface{})          {}
-func (tl NoopTaskLogger) MarkErrored()                         {}
-func (tl NoopTaskLogger) Path() string                         { return "" }
-func (tl NoopTaskLogger) PrefixWriter(prefix string) io.Writer { return &bytes.Buffer{} }
+func (tl TaskNoOpLogger) Close() error                         { return nil }
+func (tl TaskNoOpLogger) Log(string)                           {}
+func (tl TaskNoOpLogger) Logf(string, ...interface{})          {}
+func (tl TaskNoOpLogger) MarkErrored()                         {}
+func (tl TaskNoOpLogger) Path() string                         { return "" }
+func (tl TaskNoOpLogger) PrefixWriter(prefix string) io.Writer { return &bytes.Buffer{} }
 
-var _ log.LogManager = NoopLogManager{}
+var _ log.LogManager = LogNoOpManager{}
 
-type NoopLogManager struct{}
+type LogNoOpManager struct{}
 
-func (lm NoopLogManager) AddTask(string) (log.TaskLogger, error) {
-	return NoopTaskLogger{}, nil
+func (lm LogNoOpManager) AddTask(string) (log.TaskLogger, error) {
+	return TaskNoOpLogger{}, nil
 }
 
-func (lm NoopLogManager) Close() error {
+func (lm LogNoOpManager) Close() error {
 	return nil
 }
-func (lm NoopLogManager) LogFiles() []string {
+func (lm LogNoOpManager) LogFiles() []string {
 	return []string{"noop"}
 }

--- a/internal/batches/mock/logger.go
+++ b/internal/batches/mock/logger.go
@@ -1,0 +1,34 @@
+package mock
+
+import (
+	"bytes"
+	"io"
+
+	"github.com/sourcegraph/src-cli/internal/batches/log"
+)
+
+var _ log.TaskLogger = NoopTaskLogger{}
+
+type NoopTaskLogger struct{}
+
+func (tl NoopTaskLogger) Close() error                         { return nil }
+func (tl NoopTaskLogger) Log(string)                           {}
+func (tl NoopTaskLogger) Logf(string, ...interface{})          {}
+func (tl NoopTaskLogger) MarkErrored()                         {}
+func (tl NoopTaskLogger) Path() string                         { return "" }
+func (tl NoopTaskLogger) PrefixWriter(prefix string) io.Writer { return &bytes.Buffer{} }
+
+var _ log.LogManager = NoopLogManager{}
+
+type NoopLogManager struct{}
+
+func (lm NoopLogManager) AddTask(string) (log.TaskLogger, error) {
+	return NoopTaskLogger{}, nil
+}
+
+func (lm NoopLogManager) Close() error {
+	return nil
+}
+func (lm NoopLogManager) LogFiles() []string {
+	return []string{"noop"}
+}

--- a/internal/batches/workspace/bind_workspace.go
+++ b/internal/batches/workspace/bind_workspace.go
@@ -62,7 +62,7 @@ func (wc *dockerBindWorkspaceCreator) unzipToWorkspace(ctx context.Context, repo
 		return nil, errors.Wrap(err, "unzipping the ZIP archive")
 	}
 
-	return &dockerBindWorkspace{dir: workspace}, nil
+	return &dockerBindWorkspace{tempDir: wc.Dir, dir: workspace}, nil
 }
 
 func (wc *dockerBindWorkspaceCreator) copyToWorkspace(ctx context.Context, w *dockerBindWorkspace, files map[string]string) error {
@@ -104,6 +104,8 @@ func (wc *dockerBindWorkspaceCreator) copyToWorkspace(ctx context.Context, w *do
 }
 
 type dockerBindWorkspace struct {
+	tempDir string
+
 	dir string
 }
 
@@ -147,11 +149,35 @@ func (w *dockerBindWorkspace) Diff(ctx context.Context) ([]byte, error) {
 	//
 	// Also, we need to add --binary so binary file changes are inlined in the patch.
 	//
+	// ATTENTION: When you change the options here, be sure to also update the
+	// ApplyDiff method accordingly.
 	return runGitCmd(ctx, w.dir, "diff", "--cached", "--no-prefix", "--binary")
 }
 
 func (w *dockerBindWorkspace) ApplyDiff(ctx context.Context, diff []byte) error {
-	return fmt.Errorf("TODO")
+	// Write the diff to a temp file so we can pass it to `git apply`
+	tmp, err := ioutil.TempFile(w.tempDir, "bind-workspace-test-*")
+	if err != nil {
+		return errors.Wrap(err, "saving cached diff to temporary file")
+	}
+	defer os.Remove(tmp.Name())
+
+	if _, err := tmp.Write(diff); err != nil {
+		return errors.Wrap(err, "writing to temporary file")
+	}
+
+	if err := tmp.Close(); err != nil {
+		return errors.Wrap(err, "closing temporary file")
+	}
+
+	// Apply diff
+	if _, err = runGitCmd(ctx, w.dir, "apply", "-p0", tmp.Name()); err != nil {
+		return errors.Wrap(err, "applying cached diff")
+	}
+
+	// Add all files to index
+	_, err = runGitCmd(ctx, w.dir, "add", "--all")
+	return err
 }
 
 func fileExists(path string) (bool, error) {

--- a/internal/batches/workspace/bind_workspace.go
+++ b/internal/batches/workspace/bind_workspace.go
@@ -150,6 +150,10 @@ func (w *dockerBindWorkspace) Diff(ctx context.Context) ([]byte, error) {
 	return runGitCmd(ctx, w.dir, "diff", "--cached", "--no-prefix", "--binary")
 }
 
+func (w *dockerBindWorkspace) ApplyDiff(ctx context.Context, diff []byte) error {
+	return fmt.Errorf("TODO")
+}
+
 func fileExists(path string) (bool, error) {
 	_, err := os.Stat(path)
 	if err != nil {

--- a/internal/batches/workspace/bind_workspace_test.go
+++ b/internal/batches/workspace/bind_workspace_test.go
@@ -14,31 +14,14 @@ import (
 	"github.com/sourcegraph/src-cli/internal/batches/graphql"
 )
 
-func TestDockerBindWorkspaceCreator_Create(t *testing.T) {
-	workspaceTmpDir := func(t *testing.T) string {
-		testTempDir, err := ioutil.TempDir("", "executor-integration-test-*")
-		if err != nil {
-			t.Fatal(err)
-		}
-		t.Cleanup(func() { os.Remove(testTempDir) })
+var repo = &graphql.Repository{
+	ID:            "src-cli",
+	Name:          "github.com/sourcegraph/src-cli",
+	DefaultBranch: &graphql.Branch{Name: "main", Target: graphql.Target{OID: "d34db33f"}},
+}
 
-		return testTempDir
-	}
-
-	repo := &graphql.Repository{
-		ID:            "src-cli",
-		Name:          "github.com/sourcegraph/src-cli",
-		DefaultBranch: &graphql.Branch{Name: "main", Target: graphql.Target{OID: "d34db33f"}},
-	}
-
-	filesInZip := map[string]string{
-		"README.md": "# Welcome to the README\n",
-	}
-
-	fakeFilesTmpDir := workspaceTmpDir(t)
-
-	// Create a zip file for all the other tests to use.
-	f, err := ioutil.TempFile(fakeFilesTmpDir, "repo-zip-*")
+func zipUpFiles(t *testing.T, dir string, files map[string]string) string {
+	f, err := ioutil.TempFile(dir, "repo-zip-*")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -46,7 +29,7 @@ func TestDockerBindWorkspaceCreator_Create(t *testing.T) {
 	t.Cleanup(func() { os.Remove(archivePath) })
 
 	zw := zip.NewWriter(f)
-	for name, body := range filesInZip {
+	for name, body := range files {
 		f, err := zw.Create(name)
 		if err != nil {
 			t.Fatal(err)
@@ -57,6 +40,27 @@ func TestDockerBindWorkspaceCreator_Create(t *testing.T) {
 	}
 	zw.Close()
 	f.Close()
+
+	return archivePath
+}
+
+func workspaceTmpDir(t *testing.T) string {
+	testTempDir, err := ioutil.TempDir("", "bind-workspace-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Remove(testTempDir) })
+
+	return testTempDir
+}
+
+func TestDockerBindWorkspaceCreator_Create(t *testing.T) {
+	// Create a zip file for all the other tests to use.
+	fakeFilesTmpDir := workspaceTmpDir(t)
+	filesInZip := map[string]string{
+		"README.md": "# Welcome to the README\n",
+	}
+	archivePath := zipUpFiles(t, fakeFilesTmpDir, filesInZip)
 
 	// Create "additional files" for the tests to use
 	additionalFiles := map[string]string{
@@ -148,6 +152,80 @@ func TestDockerBindWorkspaceCreator_Create(t *testing.T) {
 		}
 		if !cmp.Equal(wantFiles, haveUnzippedFiles) {
 			t.Fatalf("wrong files in workspace:\n%s", cmp.Diff(wantFiles, haveUnzippedFiles))
+		}
+	})
+}
+
+func TestDockerBindWorkspace_ApplyDiff(t *testing.T) {
+	// Create a zip file for all the other tests to use.
+	fakeFilesTmpDir := workspaceTmpDir(t)
+	filesInZip := map[string]string{
+		"README.md": "# Welcome to the README\n",
+	}
+	archivePath := zipUpFiles(t, fakeFilesTmpDir, filesInZip)
+
+	t.Run("success", func(t *testing.T) {
+		diff := `diff --git README.md README.md
+index 02a19af..a84667f 100644
+--- README.md
++++ README.md
+@@ -1 +1,3 @@
+ # Welcome to the README
++
++This is a new line
+diff --git new-file.txt new-file.txt
+new file mode 100644
+index 0000000..7bb2542
+--- /dev/null
++++ new-file.txt
+@@ -0,0 +1,2 @@
++check this out. this is a new file.
++written on a computer. what a blast.
+`
+
+		wantFiles := map[string]string{
+			"README.md":    "# Welcome to the README\n\nThis is a new line\n",
+			"new-file.txt": "check this out. this is a new file.\nwritten on a computer. what a blast.\n",
+		}
+		testTempDir := workspaceTmpDir(t)
+
+		archive := &fakeRepoArchive{mockPath: archivePath}
+		creator := &dockerBindWorkspaceCreator{Dir: testTempDir}
+		workspace, err := creator.Create(context.Background(), repo, nil, archive)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+
+		err = workspace.ApplyDiff(context.Background(), []byte(diff))
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+
+		haveFiles, err := readWorkspaceFiles(workspace)
+		if err != nil {
+			t.Fatalf("error walking workspace: %s", err)
+		}
+
+		if !cmp.Equal(wantFiles, haveFiles) {
+			t.Fatalf("wrong files in workspace:\n%s", cmp.Diff(wantFiles, haveFiles))
+		}
+	})
+
+	t.Run("failure", func(t *testing.T) {
+		diff := `lol this is not a diff but the computer doesn't know it yet, watch`
+
+		testTempDir := workspaceTmpDir(t)
+
+		archive := &fakeRepoArchive{mockPath: archivePath}
+		creator := &dockerBindWorkspaceCreator{Dir: testTempDir}
+		workspace, err := creator.Create(context.Background(), repo, nil, archive)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+
+		err = workspace.ApplyDiff(context.Background(), []byte(diff))
+		if err == nil {
+			t.Fatalf("error is nil")
 		}
 	})
 }

--- a/internal/batches/workspace/volume_workspace.go
+++ b/internal/batches/workspace/volume_workspace.go
@@ -263,6 +263,24 @@ exec git diff --cached --no-prefix --binary
 	return out, nil
 }
 
+func (w *dockerVolumeWorkspace) ApplyDiff(ctx context.Context, diff []byte) error {
+	script := fmt.Sprintf(`#!/bin/sh
+
+cat << EOF | exec git apply -p0 -
+%s
+EOF
+
+git add --all > /dev/null
+`, string(diff))
+
+	out, err := w.runScript(ctx, "/work", script)
+	if err != nil {
+		return errors.Wrapf(err, "git apply diff:\n\n%s", string(out))
+	}
+
+	return nil
+}
+
 // DockerVolumeWorkspaceImage is the Docker image we'll run our unzip and git
 // commands in. This needs to match the name defined in
 // .github/workflows/docker.yml.

--- a/internal/batches/workspace/volume_workspace.go
+++ b/internal/batches/workspace/volume_workspace.go
@@ -250,6 +250,9 @@ func (w *dockerVolumeWorkspace) Diff(ctx context.Context) ([]byte, error) {
 	// See: https://github.com/sourcegraph/sourcegraph/blob/82d5e7e1562fef6be5c0b17f18631040fd330835/enterprise/internal/campaigns/service.go#L324-L329
 	//
 	// Also, we need to add --binary so binary file changes are inlined in the patch.
+	//
+	// ATTENTION: When you change the options here, be sure to also update the
+	// ApplyDiff method accordingly.
 	script := `#!/bin/sh
 	
 exec git diff --cached --no-prefix --binary

--- a/internal/batches/workspace/volume_workspace_test.go
+++ b/internal/batches/workspace/volume_workspace_test.go
@@ -572,6 +572,29 @@ index 06471f4..5f9d3fa 100644
 	})
 }
 
+func TestVolumeWorkspace_ApplyDiff(t *testing.T) {
+	ctx := context.Background()
+	w := &dockerVolumeWorkspace{volume: volumeID}
+
+	expect.Commands(
+		t,
+		expect.NewGlob(
+			expect.Behaviour{ExitCode: 0},
+			"docker", "run", "--rm", "--init", "--workdir", "/work",
+			"--mount", "type=bind,source=*,target=/run.sh,ro",
+			"--user", "0:0",
+			"--mount", "type=volume,source="+volumeID+",target=/work",
+			DockerVolumeWorkspaceImage,
+			"sh", "/run.sh",
+		),
+	)
+
+	err := w.ApplyDiff(ctx, []byte(`dummydiff`))
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
 func TestVolumeWorkspace_runScript(t *testing.T) {
 	// Since the above tests have thoroughly tested our error handling, this
 	// test just fills in the one logical gap we have in our test coverage: is

--- a/internal/batches/workspace/workspace.go
+++ b/internal/batches/workspace/workspace.go
@@ -45,6 +45,9 @@ type Workspace interface {
 	// Diff should return the total diff for the workspace. This may be called
 	// multiple times in the life of a workspace.
 	Diff(ctx context.Context) ([]byte, error)
+
+	// ApplyDiff applies the given diff
+	ApplyDiff(ctx context.Context, diff []byte) error
 }
 
 type CreatorType int


### PR DESCRIPTION
This adds step-wise caching for the execution of batch specs.

In short, given a batch spec that contains the following

```yaml
on:
  - repository: github.com/sourcegraph/automation-testing
  - repository: github.com/sourcegraph-testing/mkcert

steps:
  - run: echo "this is step 1" >> caching.txt
    container: alpine:3
  - run: echo "this is step 2" >> README.md
    container: alpine:3
  - run: echo "this is step 3" >> README.md
    container: alpine:3
    outputs:
      myOutput:
        value: "what is up"
  - run: echo "this is step 4" >> caching.txt
    if: ${{ eq repository.name "github.com/sourcegraph/automation-testing" }}
    container: alpine:3
```

this PR would cause `src` to cache the results _per step and per repository.

In practice, this means that if we would change the batch spec from the above so it would look like this

```yaml
steps:
  - run: echo "this is step 0" >> caching.txt
    container: alpine:3
  - run: echo "this is step 1" >> README.md
    container: alpine:3
    #                         vvvv LOOK HERE vvv
  - run: echo "this is step 2 WITH A CHANGE" >> README.md
    container: alpine:3
    outputs:
      myOutput:
        value: "what is up"
  - run: echo "this is step 3" >> caching.txt
    if: ${{ eq repository.name "github.com/sourcegraph/automation-testing" }}
    container: alpine:3
```

and we'd then re-execute the batch spec, **the steps 0 and 1 would not need to be re-executed**. Only step 2 would need to be re-executed for both repositories and step 3 would only need to be re-executed for both repositories.