### PR TITLE
Clean up the `src version` output

### DIFF
--- a/cmd/src/version.go
+++ b/cmd/src/version.go
@@ -33,11 +33,11 @@ Examples:
 			return err
 		}
 		if recommendedVersion == "" {
-			fmt.Println("Recommended Version: <unknown>")
+			fmt.Println("Recommended version: <unknown>")
 			fmt.Println("This Sourcegraph instance does not support this feature.")
 			return nil
 		}
-		fmt.Printf("Recommended Version: %s\n", recommendedVersion)
+		fmt.Printf("Recommended version: %s or later\n", recommendedVersion)
 		return nil
 	}
 


### PR DESCRIPTION
The output of `src version` uses inconsistent capitalization of
"version", and the recommended version can sometimes be a downgrade
compared to what is actually installed. The changes in this PR are to:

- standardize on lower-case `v` in "version"
- add `or later` to output of recommended version

Fixes sourcegraph/sourcegraph#16850
