### PR TITLE
batches: update troubleshooting link URL

### DIFF
--- a/cmd/src/batch_common.go
+++ b/cmd/src/batch_common.go
@@ -497,7 +497,7 @@ func printExecutionError(out *output.Output, err error) {
 	out.Write("")
 
 	block := out.Block(output.Line(output.EmojiLightbulb, output.StyleSuggestion, "The troubleshooting documentation can help to narrow down the cause of the errors:"))
-	block.WriteLine(output.Line("", output.StyleSuggestion, "https://docs.sourcegraph.com/batch-changes/references/troubleshooting"))
+	block.WriteLine(output.Line("", output.StyleSuggestion, "https://docs.sourcegraph.com/batch_changes/references/troubleshooting"))
 	block.Close()
 }
 


### PR DESCRIPTION
Closes [#20470](https://github.com/sourcegraph/sourcegraph/issues/20470).

[Separate PR](https://github.com/sourcegraph/sourcegraph/pull/21317) on sourcegraph/sourcegraph adds a redirect for the old URL.