### PR TITLE
Never expand the inline diff when applying a cached step diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ All notable changes to `src-cli` are documented in this file.
 
 ### Fixed
 
+- The step-wise caching for `src batch [apply|preview]` introduced in 3.28.1 could break if a cached diff contained quoted. This fixes the application by disabling any unquoting/expansion.
+
 ### Removed
 
 ## 3.28.1

--- a/internal/batches/workspace/volume_workspace.go
+++ b/internal/batches/workspace/volume_workspace.go
@@ -269,7 +269,7 @@ exec git diff --cached --no-prefix --binary
 func (w *dockerVolumeWorkspace) ApplyDiff(ctx context.Context, diff []byte) error {
 	script := fmt.Sprintf(`#!/bin/sh
 
-cat << EOF | exec git apply -p0 -
+cat <<'EOF' | exec git apply -p0 -
 %s
 EOF
 


### PR DESCRIPTION
See example 19.7 here: https://tldp.org/LDP/abs/html/here-docs.html

TIL that it's possible to turn variable expansion off.