### PR TITLE
Fix broken UI by setting FinishedAt again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to `src-cli` are documented in this file.
 ### Fixed
 
 - The step-wise caching for `src batch [apply|preview]` introduced in 3.28.1 could break if a cached diff contained quoted. This fixes the application by disabling any unquoting/expansion.
+- A regression was introduced in 3.28.1 that broke the UI for `src batch [apply|preview]` and lead to the execution of steps looking like it got stuck in the first repository.
 
 ### Removed
 

--- a/internal/batches/executor/executor.go
+++ b/internal/batches/executor/executor.go
@@ -140,6 +140,7 @@ func (x *executor) do(ctx context.Context, task *Task, status taskStatusHandler)
 	// Ensure that the status is updated when we're done.
 	defer func() {
 		status.Update(task, func(status *TaskStatus) {
+			status.FinishedAt = time.Now()
 			status.CurrentlyExecuting = ""
 			status.Err = err
 		})

--- a/internal/batches/executor/executor_test.go
+++ b/internal/batches/executor/executor_test.go
@@ -340,7 +340,7 @@ func TestExecutor_Integration(t *testing.T) {
 
 			executor := newExecutor(opts)
 
-			statusHandler := NewTaskStatusCollection([]*Task{})
+			statusHandler := NewTaskStatusCollection(tc.tasks)
 
 			// Run executor
 			executor.Start(context.Background(), tc.tasks, statusHandler)
@@ -426,6 +426,21 @@ func TestExecutor_Integration(t *testing.T) {
 					}
 				}
 			}
+
+			// Make sure that all the TaskStatus have been updated correctly
+			statusHandler.CopyStatuses(func(statuses []*TaskStatus) {
+				for i, status := range statuses {
+					if status.StartedAt.IsZero() {
+						t.Fatalf("status %d: StartedAt is zero", i)
+					}
+					if status.FinishedAt.IsZero() {
+						t.Fatalf("status %d: FinishedAt is zero", i)
+					}
+					if status.CurrentlyExecuting != "" {
+						t.Fatalf("status %d: CurrentlyExecuting not reset", i)
+					}
+				}
+			})
 		})
 	}
 }


### PR DESCRIPTION
This was a left-in "debug removal" that I added in https://github.com/sourcegraph/src-cli/commit/348c49a24dc18e6da5a8a231fea52d840ddcc0a3#diff-e7d4e9760b2767b61760170f3620004882b9fa493251c3619f15d68534891e75L142

It broke the UI. I'll release a new version right after merging this.