### PR TITLE
batches/executor: fix TestCreateChangesetSpecs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/json-iterator/go v1.1.11
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/mattn/go-isatty v0.0.12
+	github.com/mitchellh/copystructure v1.2.0
 	github.com/neelance/parallel v0.0.0-20160708114440-4de9ce63d14c
 	github.com/nsf/termbox-go v1.0.0 // indirect
 	github.com/olekukonko/tablewriter v0.0.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -67,7 +67,11 @@ github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m
 github.com/mattn/go-runewidth v0.0.12 h1:Y41i/hVW3Pgwr8gV+J23B9YEY0zxjptBuCWEaxmAOow=
 github.com/mattn/go-runewidth v0.0.12/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
+github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
+github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
 github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
+github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
+github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421 h1:ZqeYNhU3OHLH3mGKHDcjJRFFRrJa6eAM5H+CtDdOsPc=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742 h1:Esafd1046DLDQ0W1YjYsBW+p8U2u7vzgW2SQVmlNazg=

--- a/internal/batches/executor/changeset_specs_test.go
+++ b/internal/batches/executor/changeset_specs_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/mitchellh/copystructure"
 	"github.com/sourcegraph/batch-change-utils/overridable"
 	"github.com/sourcegraph/src-cli/internal/batches"
 	"github.com/sourcegraph/src-cli/internal/batches/git"
@@ -33,6 +34,12 @@ func TestCreateChangesetSpecs(t *testing.T) {
 	}
 
 	specWith := func(s *batches.ChangesetSpec, f func(s *batches.ChangesetSpec)) *batches.ChangesetSpec {
+		copy, err := copystructure.Copy(s)
+		if err != nil {
+			t.Fatalf("deep copying spec: %+v", err)
+		}
+
+		s = copy.(*batches.ChangesetSpec)
 		f(s)
 		return s
 	}
@@ -54,9 +61,15 @@ func TestCreateChangesetSpecs(t *testing.T) {
 		Repository: testRepo1,
 	}
 
-	taskWith := func(t *Task, f func(t *Task)) *Task {
-		f(t)
-		return t
+	taskWith := func(task *Task, f func(task *Task)) *Task {
+		copy, err := copystructure.Copy(task)
+		if err != nil {
+			t.Fatalf("deep copying task: %+v", err)
+		}
+
+		task = copy.(*Task)
+		f(task)
+		return task
 	}
 
 	defaultResult := executionResult{


### PR DESCRIPTION
The `specWith()` and `taskWith()` helpers inadvertently mutate `defaultChangesetSpec` and `defaultTask` fields, rather than isolating their changes to just the returned spec and task, respectively. Practically speaking, this means that all tests have the same spec and task based on the last element in the `tests` slice, which means that all the test cases end up testing the same, identical thing.

Instead, we must deep copy the spec and task before invoking the mutator function. I've chosen to pull in a third party package (specifically, [copystructure](https://github.com/mitchellh/copystructure)) for this: naïvely using JSON to marshal and unmarshal doesn't work because most of the interesting task fields are excluded when marshalled to JSON.