### PR TITLE
Support -insecure-skip-verify flag for LSIF upload

### DIFF
--- a/cmd/src/lsif_upload.go
+++ b/cmd/src/lsif_upload.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"io"
 	"net/url"
 	"os"
 	"strings"
@@ -66,6 +67,7 @@ func handleLSIFUpload(args []string) error {
 	}
 
 	client := api.NewClient(api.ClientOpts{
+		Out:   io.Discard,
 		Flags: lsifUploadFlags.apiFlags,
 	})
 

--- a/cmd/src/lsif_upload.go
+++ b/cmd/src/lsif_upload.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/lib/codeintel/upload"
 	"github.com/sourcegraph/sourcegraph/lib/output"
+	"github.com/sourcegraph/src-cli/internal/api"
 )
 
 func init() {
@@ -64,7 +65,11 @@ func handleLSIFUpload(args []string) error {
 		return handleLSIFUploadError(nil, err)
 	}
 
-	uploadID, err := upload.UploadIndex(lsifUploadFlags.file, lsifUploadOptions(out))
+	client := api.NewClient(api.ClientOpts{
+		Flags: lsifUploadFlags.apiFlags,
+	})
+
+	uploadID, err := upload.UploadIndex(lsifUploadFlags.file, client, lsifUploadOptions(out))
 	if err != nil {
 		return handleLSIFUploadError(out, err)
 	}
@@ -163,7 +168,7 @@ func lsifUploadOptions(out *output.Output) upload.UploadOptions {
 	}
 }
 
-//printInferredArguments prints a block showing the effective values of flags that are
+// printInferredArguments prints a block showing the effective values of flags that are
 // inferrably defined. This function is called on all paths except for -json uploads. This
 // function no-ops if the given output object is nil.
 func printInferredArguments(out *output.Output) {

--- a/cmd/src/lsif_upload_flags.go
+++ b/cmd/src/lsif_upload_flags.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/sourcegraph/sourcegraph/lib/codeintel/upload"
+	"github.com/sourcegraph/src-cli/internal/api"
 	"github.com/sourcegraph/src-cli/internal/codeintel"
 )
 
@@ -32,9 +33,16 @@ var lsifUploadFlags struct {
 	verbosity            int
 	json                 bool
 	open                 bool
+	apiFlags             *api.Flags
 }
 
-var lsifUploadFlagSet = flag.NewFlagSet("upload", flag.ExitOnError)
+var (
+	lsifUploadFlagSet = flag.NewFlagSet("upload", flag.ExitOnError)
+	apiClientFlagSet  = flag.NewFlagSet("upload client", flag.ExitOnError)
+	// Used to include the insecure-skip-verify flag in the help output, as we don't use any of the
+	// other api.Client methods, so only the insecureSkipVerify flag is relevant here.
+	dummyflag bool
+)
 
 func init() {
 	lsifUploadFlagSet.StringVar(&lsifUploadFlags.file, "file", "./dump.lsif", `The path to the LSIF dump file.`)
@@ -57,6 +65,7 @@ func init() {
 	lsifUploadFlagSet.IntVar(&lsifUploadFlags.verbosity, "trace", 0, "-trace=0 shows no logs; -trace=1 shows requests and response metadata; -trace=2 shows headers, -trace=3 shows response body")
 	lsifUploadFlagSet.BoolVar(&lsifUploadFlags.json, "json", false, `Output relevant state in JSON on success.`)
 	lsifUploadFlagSet.BoolVar(&lsifUploadFlags.open, "open", false, `Open the LSIF upload page in your browser.`)
+	lsifUploadFlagSet.BoolVar(&dummyflag, "insecure-skip-verify", false, "Skip validation of TLS certificates against trusted chains")
 }
 
 // parseAndValidateLSIFUploadFlags calls lsifUploadFlagSet.Parse, then infers values for
@@ -69,6 +78,22 @@ func parseAndValidateLSIFUploadFlags(args []string) error {
 	if err := lsifUploadFlagSet.Parse(args); err != nil {
 		return err
 	}
+
+	// extract only the -insecure-skip-verify flag so we dont get 'flag provided but not defined'
+	var insecureSkipVerifyFlag []string
+	for _, s := range args {
+		if strings.HasPrefix(s, "-insecure-skip-verify") {
+			insecureSkipVerifyFlag = append(insecureSkipVerifyFlag, s)
+		}
+	}
+
+	// parse the api client flags separately and then populate the lsifUploadFlags struct with the result
+	if err := apiClientFlagSet.Parse(insecureSkipVerifyFlag); err != nil {
+		return err
+	}
+	// we could just use insecureSkipVerify but I'm including everything here because it costs nothing
+	// and maybe we'll use some in the future
+	lsifUploadFlags.apiFlags = api.NewFlags(apiClientFlagSet)
 
 	if inferenceErrors := inferMissingLSIFUploadFlags(); len(inferenceErrors) > 0 {
 		return errorWithHint{

--- a/cmd/src/lsif_upload_flags.go
+++ b/cmd/src/lsif_upload_flags.go
@@ -88,12 +88,12 @@ func parseAndValidateLSIFUploadFlags(args []string) error {
 	}
 
 	// parse the api client flags separately and then populate the lsifUploadFlags struct with the result
-	if err := apiClientFlagSet.Parse(insecureSkipVerifyFlag); err != nil {
-		return err
-	}
 	// we could just use insecureSkipVerify but I'm including everything here because it costs nothing
 	// and maybe we'll use some in the future
 	lsifUploadFlags.apiFlags = api.NewFlags(apiClientFlagSet)
+	if err := apiClientFlagSet.Parse(insecureSkipVerifyFlag); err != nil {
+		return err
+	}
 
 	if inferenceErrors := inferMissingLSIFUploadFlags(); len(inferenceErrors) > 0 {
 		return errorWithHint{

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/sourcegraph/batch-change-utils v0.0.0-20210309183117-206c057cc03e
 	github.com/sourcegraph/go-diff v0.6.1
 	github.com/sourcegraph/jsonx v0.0.0-20200629203448-1a936bd500cf
-	github.com/sourcegraph/sourcegraph/lib v0.0.0-20210622093026-6470ff817296
+	github.com/sourcegraph/sourcegraph/lib v0.0.0-20210625192803-788d15faf64b
 	github.com/ssor/bom v0.0.0-20170718123548-6386211fdfcf // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	golang.org/x/net v0.0.0-20210614182718-04defd469f4e

--- a/go.sum
+++ b/go.sum
@@ -242,6 +242,8 @@ github.com/sourcegraph/jsonx v0.0.0-20200629203448-1a936bd500cf h1:oAdWFqhStsWii
 github.com/sourcegraph/jsonx v0.0.0-20200629203448-1a936bd500cf/go.mod h1:ppFaPm6kpcHnZGqQTFhUIAQRIEhdQDWP1PCv4/ON354=
 github.com/sourcegraph/sourcegraph/lib v0.0.0-20210622093026-6470ff817296 h1:eP0i1yqCusx6d2jmy0X2z+dGfxKD4xI0CP9ox7UC7BA=
 github.com/sourcegraph/sourcegraph/lib v0.0.0-20210622093026-6470ff817296/go.mod h1:0Df1LLzPHhuxInVdcV/eIR7BVl1+R0rch5fSIK8+w5Y=
+github.com/sourcegraph/sourcegraph/lib v0.0.0-20210625192803-788d15faf64b h1:ybhugcgdMAlDSM/73NKFw+NY2YsEX2plpvAyH9cr96M=
+github.com/sourcegraph/sourcegraph/lib v0.0.0-20210625192803-788d15faf64b/go.mod h1:0Df1LLzPHhuxInVdcV/eIR7BVl1+R0rch5fSIK8+w5Y=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=


### PR DESCRIPTION
As we previously used a different API client as was provided in the src-cli codebase, we did not take into account the `-skip-insecure-verify` flag. This affected a customer as they used self-signed certs.

This PR passes the src-cli configured API client that honours the flag to the LSIF upload function that resides in sg/sg/lib. The only part of the API client that is consumed is the direct pass-through method, [Do(...)](https://sourcegraph.com/github.com/sourcegraph/src-cli@main/-/blob/internal/api/api.go?L147)

Related to https://github.com/sourcegraph/sourcegraph/pull/22399 and will require bumping go.mod here when it is merged.


cc @efritz for :eyes: after PTO