### PR TITLE
docker: remove description updates when publishing a release

### DIFF
--- a/docker/batch-change-volume-workspace/README.md
+++ b/docker/batch-change-volume-workspace/README.md
@@ -5,3 +5,9 @@ Sourcegraph `src` executes batch changes using either a bind or volume workspace
 This image is based on Alpine, and adds the tools we need: curl, git, and unzip.
 
 For more information, please refer to the [`src-cli` repository](https://github.com/sourcegraph/src-cli/tree/main/docker/batch-change-volume-workspace).
+
+<!--
+If you update this description, you _must_ also update the description at
+https://hub.docker.com/r/sourcegraph/src-batch-change-volume-workspace — this
+does not happen automatically!
+-->


### PR DESCRIPTION
We used to update the Docker Hub description for
https://hub.docker.com/r/sourcegraph/src-batch-change-volume-workspace
on release, but doing so reliably has proven to be difficult, as Docker
Hub doesn't provide a reliable API to do this. When it fails, the entire
release shows up as red, which is obviously not ideal!

Since this description rarely changes, and the pushes themselves are
reliable, this removes the description update and makes it a manual
process.