### PR TITLE
For internal use only: add a -text-only flag to `src batch [apply|preview]`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to `src-cli` are documented in this file.
 ### Added
 
 - Starting with Sourcegraph 3.30.0, the `published` field is optional in batch specs. If omitted, the publication state will be controlled through the Batch Changes UI. [#538](https://github.com/sourcegraph/src-cli/pull/538)
+- For internal use only: `-text-only` flag added to `src batch [apply|preview]`. [#562](https://github.com/sourcegraph/src-cli/pull/562)
 
 ### Changed
 

--- a/cmd/src/batch_common.go
+++ b/cmd/src/batch_common.go
@@ -59,7 +59,7 @@ func newBatchExecuteFlags(flagSet *flag.FlagSet, cacheDir, tempDir string) *batc
 
 	flagSet.BoolVar(
 		&caf.textOnly, "text-only", false,
-		"No TUI, only print text",
+		"INTERNAL USE ONLY. EXPERIMENTAL. Switches off the TUI to only print JSON lines.",
 	)
 	flagSet.BoolVar(
 		&caf.allowUnsupported, "allow-unsupported", false,

--- a/cmd/src/batch_common.go
+++ b/cmd/src/batch_common.go
@@ -485,21 +485,9 @@ func textOnlyExecuteBatchSpec(ctx context.Context, opts executeBatchSpecOpts) er
 	repos, err := svc.ResolveRepositories(ctx, batchSpec)
 	if err != nil {
 		if repoSet, ok := err.(batches.UnsupportedRepoSet); ok {
-			fmt.Println("Resolved repositories")
-
-			block := opts.out.Block(output.Line(" ", output.StyleWarning, "Some repositories are hosted on unsupported code hosts and will be skipped. Use the -allow-unsupported flag to avoid skipping them."))
-			for repo := range repoSet {
-				block.Write(repo.Name)
-			}
-			block.Close()
+			logOperationSuccess("RESOLVING_REPOSITORIES", fmt.Sprintf("%d unsupported repositories", len(repoSet)))
 		} else if repoSet, ok := err.(batches.IgnoredRepoSet); ok {
-			fmt.Println("Resolved repositories")
-
-			block := opts.out.Block(output.Line(" ", output.StyleWarning, "The repositories listed below contain .batchignore files and will be skipped. Use the -force-override-ignore flag to avoid skipping them."))
-			for repo := range repoSet {
-				block.Write(repo.Name)
-			}
-			block.Close()
+			logOperationSuccess("RESOLVING_REPOSITORIES", fmt.Sprintf("%d ignored repositories", len(repoSet)))
 		} else {
 			return errors.Wrap(err, "resolving repositories")
 		}

--- a/cmd/src/batch_preview.go
+++ b/cmd/src/batch_preview.go
@@ -36,24 +36,36 @@ Examples:
 			return &usageError{errors.New("additional arguments not allowed")}
 		}
 
-		out := output.NewOutput(flagSet.Output(), output.OutputOpts{Verbose: *verbose})
-
 		ctx, cancel := contextCancelOnInterrupt(context.Background())
 		defer cancel()
 
-		err := executeBatchSpec(ctx, executeBatchSpecOpts{
-			flags:  flags,
-			out:    out,
-			client: cfg.apiClient(flags.api, flagSet.Output()),
+		var err error
+		if flags.textOnly {
+			err = textOnlyExecuteBatchSpec(ctx, executeBatchSpecOpts{
+				flags:  flags,
+				client: cfg.apiClient(flags.api, flagSet.Output()),
 
-			// Do not apply the uploaded batch spec
-			applyBatchSpec: false,
-		})
-
-		if err != nil {
-			printExecutionError(out, err)
-			out.Write("")
-			return &exitCodeError{nil, 1}
+				// Do not apply the uploaded batch spec
+				applyBatchSpec: false,
+			})
+			if err != nil {
+				fmt.Printf("ERROR: %s\n", err)
+				return &exitCodeError{nil, 1}
+			}
+		} else {
+			out := output.NewOutput(flagSet.Output(), output.OutputOpts{Verbose: *verbose})
+			err = executeBatchSpec(ctx, executeBatchSpecOpts{
+				flags:  flags,
+				out:    out,
+				client: cfg.apiClient(flags.api, flagSet.Output()),
+				// Do not apply the uploaded batch spec
+				applyBatchSpec: false,
+			})
+			if err != nil {
+				printExecutionError(out, err)
+				out.Write("")
+				return &exitCodeError{nil, 1}
+			}
 		}
 
 		return nil

--- a/cmd/src/batch_text_logging.go
+++ b/cmd/src/batch_text_logging.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"time"
+)
+
+type batchesLogEvent struct {
+	Operation string `json:"operation"` // "PREPARING_DOCKER_IMAGES"
+
+	Timestamp time.Time `json:"timestamp"`
+
+	Status  string `json:"status"`            // "STARTED", "PROGRESS", "SUCCESS", "FAILURE"
+	Message string `json:"message,omitempty"` // "70% done"
+}
+
+func logOperationStart(op, msg string) {
+	logEvent(batchesLogEvent{Operation: op, Status: "STARTED", Message: msg})
+}
+
+func logOperationSuccess(op, msg string) {
+	logEvent(batchesLogEvent{Operation: op, Status: "SUCCESS", Message: msg})
+}
+
+func logOperationFailure(op, msg string) {
+	logEvent(batchesLogEvent{Operation: op, Status: "FAILURE", Message: msg})
+}
+
+func logOperationProgress(op, msg string) {
+	logEvent(batchesLogEvent{Operation: op, Status: "PROGRESS", Message: msg})
+}
+
+func logEvent(e batchesLogEvent) {
+	e.Timestamp = time.Now().UTC().Truncate(time.Millisecond)
+	json.NewEncoder(os.Stdout).Encode(e)
+}


### PR DESCRIPTION
This adds a `-text-only` flag to `src batch [apply|preview]` that is **for internal use only**.

It's a highly-experimental feature that should not be used if you're not sure about what you're doing.