### PR TITLE
batches: correctly fallback to nil for unmatched published fields

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4
 	github.com/pkg/errors v0.9.1
 	github.com/rivo/uniseg v0.2.0 // indirect
-	github.com/sourcegraph/batch-change-utils v0.0.0-20210309183117-206c057cc03e
+	github.com/sourcegraph/batch-change-utils v0.0.0-20210707230928-eb9cd8fd09b6
 	github.com/sourcegraph/go-diff v0.6.1
 	github.com/sourcegraph/jsonx v0.0.0-20200629203448-1a936bd500cf
 	github.com/sourcegraph/sourcegraph/lib v0.0.0-20210628190057-faa35110fad5

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4
 	github.com/pkg/errors v0.9.1
 	github.com/rivo/uniseg v0.2.0 // indirect
-	github.com/sourcegraph/batch-change-utils v0.0.0-20210707230928-eb9cd8fd09b6
+	github.com/sourcegraph/batch-change-utils v0.0.0-20210708162152-c9f35b905d94
 	github.com/sourcegraph/go-diff v0.6.1
 	github.com/sourcegraph/jsonx v0.0.0-20200629203448-1a936bd500cf
 	github.com/sourcegraph/sourcegraph/lib v0.0.0-20210628190057-faa35110fad5

--- a/go.sum
+++ b/go.sum
@@ -237,10 +237,8 @@ github.com/shurcooL/go-goon v0.0.0-20210110234559-7585751d9a17/go.mod h1:N5mDOms
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
-github.com/sourcegraph/batch-change-utils v0.0.0-20210309183117-206c057cc03e h1:8dpmTar1H4dS4f3WWTtG6FSK/GbjQl7alHRJlzNY0lo=
-github.com/sourcegraph/batch-change-utils v0.0.0-20210309183117-206c057cc03e/go.mod h1:kKNRPN6dxuXwC4UUhPVcAJsvz4EVEfI0jyN5HUJsazA=
-github.com/sourcegraph/batch-change-utils v0.0.0-20210707230928-eb9cd8fd09b6 h1:bOYiDmJDOYXsuvLknbapMWWCFswSjYybnnW8ukWEUxI=
-github.com/sourcegraph/batch-change-utils v0.0.0-20210707230928-eb9cd8fd09b6/go.mod h1:kKNRPN6dxuXwC4UUhPVcAJsvz4EVEfI0jyN5HUJsazA=
+github.com/sourcegraph/batch-change-utils v0.0.0-20210708162152-c9f35b905d94 h1:Yzs0ABVo9TXlfhIJZlHbj+T5a/e2lGyxH0bTTF1OtSE=
+github.com/sourcegraph/batch-change-utils v0.0.0-20210708162152-c9f35b905d94/go.mod h1:kKNRPN6dxuXwC4UUhPVcAJsvz4EVEfI0jyN5HUJsazA=
 github.com/sourcegraph/go-diff v0.6.1 h1:hmA1LzxW0n1c3Q4YbrFgg4P99GSnebYa3x8gr0HZqLQ=
 github.com/sourcegraph/go-diff v0.6.1/go.mod h1:iBszgVvyxdc8SFZ7gm69go2KDdt3ag071iBaWPF6cjs=
 github.com/sourcegraph/jsonx v0.0.0-20200629203448-1a936bd500cf h1:oAdWFqhStsWiiMP/vkkHiMXqFXzl1XfUNOdxKJbd6bI=

--- a/go.sum
+++ b/go.sum
@@ -239,6 +239,8 @@ github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/sourcegraph/batch-change-utils v0.0.0-20210309183117-206c057cc03e h1:8dpmTar1H4dS4f3WWTtG6FSK/GbjQl7alHRJlzNY0lo=
 github.com/sourcegraph/batch-change-utils v0.0.0-20210309183117-206c057cc03e/go.mod h1:kKNRPN6dxuXwC4UUhPVcAJsvz4EVEfI0jyN5HUJsazA=
+github.com/sourcegraph/batch-change-utils v0.0.0-20210707230928-eb9cd8fd09b6 h1:bOYiDmJDOYXsuvLknbapMWWCFswSjYybnnW8ukWEUxI=
+github.com/sourcegraph/batch-change-utils v0.0.0-20210707230928-eb9cd8fd09b6/go.mod h1:kKNRPN6dxuXwC4UUhPVcAJsvz4EVEfI0jyN5HUJsazA=
 github.com/sourcegraph/go-diff v0.6.1 h1:hmA1LzxW0n1c3Q4YbrFgg4P99GSnebYa3x8gr0HZqLQ=
 github.com/sourcegraph/go-diff v0.6.1/go.mod h1:iBszgVvyxdc8SFZ7gm69go2KDdt3ag071iBaWPF6cjs=
 github.com/sourcegraph/jsonx v0.0.0-20200629203448-1a936bd500cf h1:oAdWFqhStsWiiMP/vkkHiMXqFXzl1XfUNOdxKJbd6bI=

--- a/internal/batches/executor/changeset_specs.go
+++ b/internal/batches/executor/changeset_specs.go
@@ -72,6 +72,13 @@ func createChangesetSpecs(task *Task, result executionResult, features batches.F
 		var published interface{} = nil
 		if task.Template.Published != nil {
 			published = task.Template.Published.ValueWithSuffix(repo, branch)
+
+			// Backward compatibility: before optional published fields were
+			// allowed, ValueWithSuffix() would fall back to false, not nil. We
+			// need to replicate this behaviour here.
+			if published == nil && !features.AllowOptionalPublished {
+				published = false
+			}
 		} else if !features.AllowOptionalPublished {
 			return nil, errOptionalPublishedUnsupported
 		}

--- a/internal/batches/executor/changeset_specs_test.go
+++ b/internal/batches/executor/changeset_specs_test.go
@@ -127,6 +127,21 @@ func TestCreateChangesetSpecs(t *testing.T) {
 			result:   defaultResult,
 			want: []*batches.ChangesetSpec{
 				specWith(defaultChangesetSpec, func(s *batches.ChangesetSpec) {
+					s.Published = nil
+				}),
+			},
+			wantErr: "",
+		},
+		{
+			name: "publish by branch not matching on an old Sourcegraph version",
+			task: taskWith(defaultTask, func(task *Task) {
+				published := `[{"github.com/sourcegraph/*@another-branch-name": true}]`
+				task.Template.Published = parsePublishedFieldString(t, published)
+			}),
+			features: featuresWithoutOptionalPublished,
+			result:   defaultResult,
+			want: []*batches.ChangesetSpec{
+				specWith(defaultChangesetSpec, func(s *batches.ChangesetSpec) {
 					s.Published = false
 				}),
 			},


### PR DESCRIPTION
See https://github.com/sourcegraph/batch-change-utils/pull/12 for more context.

Note to self: this needs a mechanical `go get` update once that PR is merged before _this_ PR can be merged.