### PR TITLE
Allow using count:all in repo query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ All notable changes to `src-cli` are documented in this file.
 
 ### Fixed
 
-- `count:all` was not supported in repository search queries for batch changes. This is now fixed. [#XX](https://github.com/sourcegraph/src-cli/pull/XX)
+- `count:all` was not supported in repository search queries for batch changes. This is now fixed. [#566](https://github.com/sourcegraph/src-cli/pull/566)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ All notable changes to `src-cli` are documented in this file.
 
 ### Fixed
 
+- `count:all` was not supported in repository search queries for batch changes. This is now fixed. [#XX](https://github.com/sourcegraph/src-cli/pull/XX)
+
 ### Removed
 
 ## 3.29.2

--- a/internal/batches/service/service.go
+++ b/internal/batches/service/service.go
@@ -651,7 +651,7 @@ func (svc *Service) FindDirectoriesInRepos(ctx context.Context, fileName string,
 	return results, nil
 }
 
-var defaultQueryCountRegex = regexp.MustCompile(`\bcount:\d+\b`)
+var defaultQueryCountRegex = regexp.MustCompile(`\bcount:(\d+|all)\b`)
 
 const hardCodedCount = " count:999999"
 

--- a/internal/batches/service/service_test.go
+++ b/internal/batches/service/service_test.go
@@ -19,6 +19,7 @@ func TestSetDefaultQueryCount(t *testing.T) {
 	for in, want := range map[string]string{
 		"":                     hardCodedCount,
 		"count:10":             "count:10",
+		"count:all":            "count:all",
 		"r:foo":                "r:foo" + hardCodedCount,
 		"r:foo count:10":       "r:foo count:10",
 		"r:foo count:10 f:bar": "r:foo count:10 f:bar",


### PR DESCRIPTION
Using `count:all` would have added a second `count:999999` which breaks the search query. 