### PR TITLE
Fix empty diff being returned when single *cached* step had to be executed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ All notable changes to `src-cli` are documented in this file.
 
 ### Fixed
 
+- The per-step caching of batch spec execution results was broken when re-execution could use the cached results of a step and that step was the only one left to execute. That resulted in empty diffs being uploaded. This is now fixed. [#567](https://github.com/sourcegraph/src-cli/pull/567)
+
 ### Removed
 
 ## 3.30.0

--- a/internal/batches/executor/executor_test.go
+++ b/internal/batches/executor/executor_test.go
@@ -281,6 +281,41 @@ func TestExecutor_Integration(t *testing.T) {
 			},
 			wantErrInclude: "execution in github.com/sourcegraph/sourcegraph failed: run: exit 1",
 		},
+		{
+			name: "cached result for step 0",
+			archives: []mock.RepoArchive{
+				{Repo: testRepo1, Files: map[string]string{
+					"README.md": "# Welcome to the README\n",
+				}},
+			},
+			steps: []batches.Step{
+				{Run: `echo -e "foobar\n" >> README.md`},
+			},
+			tasks: []*Task{
+				{
+					CachedResultFound: true,
+					CachedResult: stepExecutionResult{
+						StepIndex: 0,
+						Diff: []byte(`diff --git README.md README.md
+index 02a19af..c9644dd 100644
+--- README.md
++++ README.md
+@@ -1 +1,2 @@
+ # Welcome to the README
++foobar
+`),
+						Outputs:            map[string]interface{}{},
+						PreviousStepResult: StepResult{},
+					},
+					Repository: testRepo1,
+				},
+			},
+			wantFilesChanged: filesByRepository{
+				testRepo1.ID: filesByPath{
+					rootPath: []string{"README.md"},
+				},
+			},
+		},
 	}
 
 	for _, tc := range tests {

--- a/internal/batches/executor/run_steps.go
+++ b/internal/batches/executor/run_steps.go
@@ -129,7 +129,7 @@ func runSteps(ctx context.Context, opts *executionOpts) (result executionResult,
 
 		if i > 0 {
 			stepContext.PreviousStep = results[i-1]
-			stepContext.Steps.Changes = results[i-1].files
+			stepContext.Steps.Changes = results[i-1].Files
 		}
 
 		cond, err := evalStepCondition(step.IfCondition(), &stepContext)
@@ -323,7 +323,7 @@ func runSteps(ctx context.Context, opts *executionOpts) (result executionResult,
 			return execResult, nil, errors.Wrap(err, "getting changed files in step")
 		}
 
-		result := StepResult{files: changes, Stdout: &stdoutBuffer, Stderr: &stderrBuffer}
+		result := StepResult{Files: changes, Stdout: &stdoutBuffer, Stderr: &stderrBuffer}
 		results[i] = result
 
 		// Set stepContext.Step to current step's results before rendering outputs
@@ -357,8 +357,8 @@ func runSteps(ctx context.Context, opts *executionOpts) (result executionResult,
 	}
 
 	execResult.Diff = string(diffOut)
-	if len(results) > 0 && results[len(results)-1].files != nil {
-		execResult.ChangedFiles = results[len(results)-1].files
+	if len(results) > 0 && results[len(results)-1].Files != nil {
+		execResult.ChangedFiles = results[len(results)-1].Files
 	}
 
 	return execResult, stepResults, err

--- a/internal/batches/executor/run_steps.go
+++ b/internal/batches/executor/run_steps.go
@@ -120,6 +120,9 @@ func runSteps(ctx context.Context, opts *executionOpts) (result executionResult,
 
 		if opts.task.CachedResultFound && i == startStep {
 			previousStepResult = opts.task.CachedResult.PreviousStepResult
+
+			stepContext.PreviousStep = previousStepResult
+			stepContext.Steps.Changes = previousStepResult.Files
 			stepContext.Outputs = opts.task.CachedResult.Outputs
 
 			if err := workspace.ApplyDiff(ctx, []byte(opts.task.CachedResult.Diff)); err != nil {

--- a/internal/batches/executor/run_steps.go
+++ b/internal/batches/executor/run_steps.go
@@ -141,182 +141,10 @@ func runSteps(ctx context.Context, opts *executionOpts) (result executionResult,
 			continue
 		}
 
-		opts.reportProgress(fmt.Sprintf("Preparing step %d", i+1))
-
-		// Find a location that we can use for a cidfile, which will contain the
-		// container ID that is used below. We can then use this to remove the
-		// container on a successful run, rather than leaving it dangling.
-		cidFile, err := ioutil.TempFile(opts.tempDir, opts.task.Repository.Slug()+"-container-id")
+		stdoutBuffer, stderrBuffer, err := executeSingleStep(ctx, opts, workspace, i, step, &stepContext)
 		if err != nil {
-			return execResult, nil, errors.Wrap(err, "Creating a CID file failed")
+			return execResult, nil, err
 		}
-
-		// However, Docker will fail if the cidfile actually exists, so we need
-		// to remove it. Because Windows can't remove open files, we'll first
-		// close it, even though that's unnecessary elsewhere.
-		cidFile.Close()
-		if err = os.Remove(cidFile.Name()); err != nil {
-			return execResult, nil, errors.Wrap(err, "removing cidfile")
-		}
-
-		// Since we went to all that effort, we can now defer a function that
-		// uses the cidfile to clean up after this function is done.
-		defer func() {
-			cid, err := ioutil.ReadFile(cidFile.Name())
-			_ = os.Remove(cidFile.Name())
-			if err == nil {
-				ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
-				defer cancel()
-				_ = exec.CommandContext(ctx, "docker", "rm", "-f", "--", string(cid)).Run()
-			}
-		}()
-
-		// We need to grab the digest for the exact image we're using.
-		digest, err := step.ImageDigest(ctx)
-		if err != nil {
-			return execResult, nil, errors.Wrapf(err, "getting digest for %v", step.DockerImage())
-		}
-
-		// For now, we only support shell scripts provided via the Run field.
-		shell, containerTemp, err := probeImageForShell(ctx, digest)
-		if err != nil {
-			return execResult, nil, errors.Wrapf(err, "probing image %q for shell", step.DockerImage())
-		}
-
-		// Set up a temporary file on the host filesystem to contain the
-		// script.
-		runScriptFile, err := ioutil.TempFile(opts.tempDir, "")
-		if err != nil {
-			return execResult, nil, errors.Wrap(err, "creating temporary file")
-		}
-		defer os.Remove(runScriptFile.Name())
-
-		// Parse step.Run as a template and render it into a buffer and the
-		// temp file we just created.
-		var runScript bytes.Buffer
-		out := io.MultiWriter(&runScript, runScriptFile)
-		if err := renderStepTemplate("step-run", step.Run, out, &stepContext); err != nil {
-			return execResult, nil, errors.Wrap(err, "parsing step run")
-		}
-
-		if err := runScriptFile.Close(); err != nil {
-			return execResult, nil, errors.Wrap(err, "closing temporary file")
-		}
-
-		// This file needs to be readable within the container regardless of the
-		// user the container is running as, so we'll set the appropriate group
-		// and other bits to make it so.
-		//
-		// A fun note: although os.File exposes a Chmod() method, we can't
-		// unconditionally use it because Windows cannot change the attributes
-		// of an open file. Rather than going to the trouble of having
-		// conditionally compiled files here, instead we'll just wait until the
-		// file is closed to twiddle the permission bits. Which is now!
-		if err := os.Chmod(runScriptFile.Name(), 0644); err != nil {
-			return execResult, nil, errors.Wrap(err, "setting permissions on the temporary file")
-		}
-
-		// Parse and render the step.Files.
-		files, err := renderStepMap(step.Files, &stepContext)
-		if err != nil {
-			return execResult, nil, errors.Wrap(err, "parsing step files")
-		}
-
-		// Create temp files with the rendered content of step.Files so that we
-		// can mount them into the container.
-		filesToMount := make(map[string]*os.File, len(files))
-		for name, content := range files {
-			fp, err := ioutil.TempFile(opts.tempDir, "")
-			if err != nil {
-				return execResult, nil, errors.Wrap(err, "creating temporary file")
-			}
-			defer os.Remove(fp.Name())
-
-			if _, err := fp.WriteString(content); err != nil {
-				return execResult, nil, errors.Wrap(err, "writing to temporary file")
-			}
-
-			if err := fp.Close(); err != nil {
-				return execResult, nil, errors.Wrap(err, "closing temporary file")
-			}
-
-			filesToMount[name] = fp
-		}
-
-		// Resolve step.Env given the current environment.
-		stepEnv, err := step.Env.Resolve(os.Environ())
-		if err != nil {
-			return execResult, nil, errors.Wrap(err, "resolving step environment")
-		}
-
-		// Render the step.Env variables as templates.
-		env, err := renderStepMap(stepEnv, &stepContext)
-		if err != nil {
-			return execResult, nil, errors.Wrap(err, "parsing step environment")
-		}
-
-		opts.reportProgress(runScript.String())
-		const workDir = "/work"
-		workspaceOpts, err := workspace.DockerRunOpts(ctx, workDir)
-		if err != nil {
-			return execResult, nil, errors.Wrap(err, "getting Docker options for workspace")
-		}
-
-		// Where should we execute the steps.run script?
-		scriptWorkDir := workDir
-		if opts.task.Path != "" {
-			scriptWorkDir = workDir + "/" + opts.task.Path
-		}
-
-		args := append([]string{
-			"run",
-			"--rm",
-			"--init",
-			"--cidfile", cidFile.Name(),
-			"--workdir", scriptWorkDir,
-			"--mount", fmt.Sprintf("type=bind,source=%s,target=%s,ro", runScriptFile.Name(), containerTemp),
-		}, workspaceOpts...)
-		for target, source := range filesToMount {
-			args = append(args, "--mount", fmt.Sprintf("type=bind,source=%s,target=%s,ro", source.Name(), target))
-		}
-
-		for k, v := range env {
-			args = append(args, "-e", k+"="+v)
-		}
-
-		args = append(args, "--entrypoint", shell)
-
-		cmd := exec.CommandContext(ctx, "docker", args...)
-		cmd.Args = append(cmd.Args, "--", digest, containerTemp)
-		if dir := workspace.WorkDir(); dir != nil {
-			cmd.Dir = *dir
-		}
-
-		var stdoutBuffer, stderrBuffer bytes.Buffer
-		cmd.Stdout = io.MultiWriter(&stdoutBuffer, opts.logger.PrefixWriter("stdout"))
-		cmd.Stderr = io.MultiWriter(&stderrBuffer, opts.logger.PrefixWriter("stderr"))
-
-		opts.logger.Logf("[Step %d] run: %q, container: %q", i+1, step.Run, step.Container)
-		opts.logger.Logf("[Step %d] full command: %q", i+1, strings.Join(cmd.Args, " "))
-
-		t0 := time.Now()
-		err = cmd.Run()
-		elapsed := time.Since(t0).Round(time.Millisecond)
-		if err != nil {
-			opts.logger.Logf("[Step %d] took %s; error running Docker container: %+v", i+1, elapsed, err)
-
-			return execResult, nil, stepFailedErr{
-				Err:         err,
-				Args:        cmd.Args,
-				Run:         runScript.String(),
-				Container:   step.Container,
-				TmpFilename: containerTemp,
-				Stdout:      strings.TrimSpace(stdoutBuffer.String()),
-				Stderr:      strings.TrimSpace(stderrBuffer.String()),
-			}
-		}
-
-		opts.logger.Logf("[Step %d] complete in %s", i+1, elapsed)
 
 		changes, err := workspace.Changes(ctx)
 		if err != nil {
@@ -362,6 +190,133 @@ func runSteps(ctx context.Context, opts *executionOpts) (result executionResult,
 	}
 
 	return execResult, stepResults, err
+}
+
+const workDir = "/work"
+
+func executeSingleStep(
+	ctx context.Context,
+	opts *executionOpts,
+	workspace workspace.Workspace,
+	i int,
+	step batches.Step,
+	stepContext *StepContext,
+) (bytes.Buffer, bytes.Buffer, error) {
+	// ----------
+	// PREPARATION
+	// ----------
+	opts.reportProgress(fmt.Sprintf("Preparing step %d", i+1))
+
+	cidFile, cleanup, err := createCidFile(ctx, opts.tempDir, opts.task.Repository.Slug())
+	if err != nil {
+		return bytes.Buffer{}, bytes.Buffer{}, err
+	}
+	defer cleanup()
+
+	// We need to grab the digest for the exact image we're using.
+	digest, err := step.ImageDigest(ctx)
+	if err != nil {
+		return bytes.Buffer{}, bytes.Buffer{}, errors.Wrapf(err, "getting digest for %v", step.DockerImage())
+	}
+
+	// For now, we only support shell scripts provided via the Run field.
+	shell, containerTemp, err := probeImageForShell(ctx, digest)
+	if err != nil {
+		return bytes.Buffer{}, bytes.Buffer{}, errors.Wrapf(err, "probing image %q for shell", step.DockerImage())
+	}
+
+	runScriptFile, runScript, cleanup, err := createRunScriptFile(ctx, opts.tempDir, step.Run, stepContext)
+	if err != nil {
+		return bytes.Buffer{}, bytes.Buffer{}, err
+	}
+
+	// Parse and render the step.Files.
+	filesToMount, cleanup, err := createFilesToMount(opts.tempDir, step, stepContext)
+	if err != nil {
+		return bytes.Buffer{}, bytes.Buffer{}, err
+	}
+	defer cleanup()
+
+	// Resolve step.Env given the current environment.
+	stepEnv, err := step.Env.Resolve(os.Environ())
+	if err != nil {
+		return bytes.Buffer{}, bytes.Buffer{}, errors.Wrap(err, "resolving step environment")
+	}
+
+	// Render the step.Env variables as templates.
+	env, err := renderStepMap(stepEnv, stepContext)
+	if err != nil {
+		return bytes.Buffer{}, bytes.Buffer{}, errors.Wrap(err, "parsing step environment")
+	}
+
+	// ----------
+	// EXECUTION
+	// ----------
+	opts.reportProgress(runScript)
+
+	workspaceOpts, err := workspace.DockerRunOpts(ctx, workDir)
+	if err != nil {
+		return bytes.Buffer{}, bytes.Buffer{}, errors.Wrap(err, "getting Docker options for workspace")
+	}
+
+	// Where should we execute the steps.run script?
+	scriptWorkDir := workDir
+	if opts.task.Path != "" {
+		scriptWorkDir = workDir + "/" + opts.task.Path
+	}
+
+	args := append([]string{
+		"run",
+		"--rm",
+		"--init",
+		"--cidfile", cidFile,
+		"--workdir", scriptWorkDir,
+		"--mount", fmt.Sprintf("type=bind,source=%s,target=%s,ro", runScriptFile, containerTemp),
+	}, workspaceOpts...)
+
+	for target, source := range filesToMount {
+		args = append(args, "--mount", fmt.Sprintf("type=bind,source=%s,target=%s,ro", source.Name(), target))
+	}
+
+	for k, v := range env {
+		args = append(args, "-e", k+"="+v)
+	}
+
+	args = append(args, "--entrypoint", shell)
+
+	cmd := exec.CommandContext(ctx, "docker", args...)
+	cmd.Args = append(cmd.Args, "--", digest, containerTemp)
+	if dir := workspace.WorkDir(); dir != nil {
+		cmd.Dir = *dir
+	}
+
+	var stdoutBuffer, stderrBuffer bytes.Buffer
+
+	cmd.Stdout = io.MultiWriter(&stdoutBuffer, opts.logger.PrefixWriter("stdout"))
+	cmd.Stderr = io.MultiWriter(&stderrBuffer, opts.logger.PrefixWriter("stderr"))
+
+	opts.logger.Logf("[Step %d] run: %q, container: %q", i+1, step.Run, step.Container)
+	opts.logger.Logf("[Step %d] full command: %q", i+1, strings.Join(cmd.Args, " "))
+
+	t0 := time.Now()
+	err = cmd.Run()
+	elapsed := time.Since(t0).Round(time.Millisecond)
+	if err != nil {
+		opts.logger.Logf("[Step %d] took %s; error running Docker container: %+v", i+1, elapsed, err)
+
+		return stdoutBuffer, stderrBuffer, stepFailedErr{
+			Err:         err,
+			Args:        cmd.Args,
+			Run:         runScript,
+			Container:   step.Container,
+			TmpFilename: containerTemp,
+			Stdout:      strings.TrimSpace(stdoutBuffer.String()),
+			Stderr:      strings.TrimSpace(stderrBuffer.String()),
+		}
+	}
+
+	opts.logger.Logf("[Step %d] complete in %s", i+1, elapsed)
+	return stdoutBuffer, stderrBuffer, nil
 }
 
 func setOutputs(stepOutputs batches.Outputs, global map[string]interface{}, stepCtx *StepContext) error {
@@ -440,6 +395,122 @@ func probeImageForShell(ctx context.Context, image string) (shell, tempfile stri
 	// If we got here, then all the attempts to probe the shell failed. Let's
 	// admit defeat and return. At least err is already in place.
 	return
+}
+
+// createFilesToMount creates temporary files with the contents of Step.Files
+// that are to be mounted into the container that executes the step.
+func createFilesToMount(tempDir string, step batches.Step, stepContext *StepContext) (map[string]*os.File, func(), error) {
+	// Parse and render the step.Files.
+	files, err := renderStepMap(step.Files, stepContext)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "parsing step files")
+	}
+
+	var toCleanup []string
+	cleanup := func() {
+		for _, fname := range toCleanup {
+			os.Remove(fname)
+		}
+	}
+
+	// Create temp files with the rendered content of step.Files so that we
+	// can mount them into the container.
+	filesToMount := make(map[string]*os.File, len(files))
+	for name, content := range files {
+		fp, err := ioutil.TempFile(tempDir, "")
+		if err != nil {
+			return nil, cleanup, errors.Wrap(err, "creating temporary file")
+		}
+		toCleanup = append(toCleanup, fp.Name())
+
+		if _, err := fp.WriteString(content); err != nil {
+			return nil, cleanup, errors.Wrap(err, "writing to temporary file")
+		}
+
+		if err := fp.Close(); err != nil {
+			return nil, cleanup, errors.Wrap(err, "closing temporary file")
+		}
+
+		filesToMount[name] = fp
+	}
+
+	return filesToMount, cleanup, nil
+}
+
+// createRunScriptFile creates a temporary file and renders stepRun into it.
+//
+// It returns the location of the file, its content, a function to cleanup the file and possible errors.
+func createRunScriptFile(ctx context.Context, tempDir string, stepRun string, stepCtx *StepContext) (string, string, func(), error) {
+	// Set up a temporary file on the host filesystem to contain the
+	// script.
+	runScriptFile, err := ioutil.TempFile(tempDir, "")
+	if err != nil {
+		return "", "", nil, errors.Wrap(err, "creating temporary file")
+	}
+	cleanup := func() { os.Remove(runScriptFile.Name()) }
+
+	// Parse step.Run as a template and render it into a buffer and the
+	// temp file we just created.
+	var runScript bytes.Buffer
+	out := io.MultiWriter(&runScript, runScriptFile)
+	if err := renderStepTemplate("step-run", stepRun, out, stepCtx); err != nil {
+		return "", "", nil, errors.Wrap(err, "parsing step run")
+	}
+
+	if err := runScriptFile.Close(); err != nil {
+		return "", "", nil, errors.Wrap(err, "closing temporary file")
+	}
+
+	// This file needs to be readable within the container regardless of the
+	// user the container is running as, so we'll set the appropriate group
+	// and other bits to make it so.
+	//
+	// A fun note: although os.File exposes a Chmod() method, we can't
+	// unconditionally use it because Windows cannot change the attributes
+	// of an open file. Rather than going to the trouble of having
+	// conditionally compiled files here, instead we'll just wait until the
+	// file is closed to twiddle the permission bits. Which is now!
+	if err := os.Chmod(runScriptFile.Name(), 0644); err != nil {
+		return "", "", nil, errors.Wrap(err, "setting permissions on the temporary file")
+	}
+
+	return runScriptFile.Name(), runScript.String(), cleanup, nil
+}
+
+// createCidFile creates a temporary file that will contain the container ID
+// when executing steps.
+// It returns the location of the file and a function that cleans up the
+// file.
+func createCidFile(ctx context.Context, tempDir string, repoSlug string) (string, func(), error) {
+	// Find a location that we can use for a cidfile, which will contain the
+	// container ID that is used below. We can then use this to remove the
+	// container on a successful run, rather than leaving it dangling.
+	cidFile, err := ioutil.TempFile(tempDir, repoSlug+"-container-id")
+	if err != nil {
+		return "", nil, errors.Wrap(err, "Creating a CID file failed")
+	}
+
+	// However, Docker will fail if the cidfile actually exists, so we need
+	// to remove it. Because Windows can't remove open files, we'll first
+	// close it, even though that's unnecessary elsewhere.
+	cidFile.Close()
+	if err = os.Remove(cidFile.Name()); err != nil {
+		return "", nil, errors.Wrap(err, "removing cidfile")
+	}
+
+	// Since we went to all that effort, we can now defer a function that
+	// uses the cidfile to clean up after this function is done.
+	cleanup := func() {
+		cid, err := ioutil.ReadFile(cidFile.Name())
+		_ = os.Remove(cidFile.Name())
+		if err == nil {
+			ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+			defer cancel()
+			_ = exec.CommandContext(ctx, "docker", "rm", "-f", "--", string(cid)).Run()
+		}
+	}
+
+	return cidFile.Name(), cleanup, nil
 }
 
 type stepFailedErr struct {

--- a/internal/batches/executor/run_steps.go
+++ b/internal/batches/executor/run_steps.go
@@ -90,6 +90,9 @@ func runSteps(ctx context.Context, opts *executionOpts) (result executionResult,
 		execResult.Outputs = opts.task.CachedResult.Outputs
 
 		startStep = opts.task.CachedResult.StepIndex + 1
+		if startStep == len(opts.task.Steps) {
+			startStep -= 1
+		}
 
 		switch startStep {
 		case 1:
@@ -118,7 +121,9 @@ func runSteps(ctx context.Context, opts *executionOpts) (result executionResult,
 				return execResult, nil, errors.Wrap(err, "getting changed files in step")
 			}
 
-			results[i-1] = opts.task.CachedResult.PreviousStepResult
+			if i != 0 {
+				results[i-1] = opts.task.CachedResult.PreviousStepResult
+			}
 			stepContext.Outputs = opts.task.CachedResult.Outputs
 		}
 

--- a/internal/batches/executor/templating.go
+++ b/internal/batches/executor/templating.go
@@ -145,7 +145,7 @@ func (stepCtx *StepContext) ToFuncMap() template.FuncMap {
 			return newStepResult(&stepCtx.Step)
 		},
 		"steps": func() map[string]interface{} {
-			res := newStepResult(&StepResult{files: stepCtx.Steps.Changes})
+			res := newStepResult(&StepResult{Files: stepCtx.Steps.Changes})
 			res["path"] = stepCtx.Steps.Path
 			return res
 		},
@@ -169,8 +169,8 @@ func (stepCtx *StepContext) ToFuncMap() template.FuncMap {
 
 // StepResult represents the result of a previously executed step.
 type StepResult struct {
-	// files are the changes made to files by the step.
-	files *git.Changes
+	// Files are the changes made to Files by the step.
+	Files *git.Changes
 
 	// Stdout is the output produced by the step on standard out.
 	Stdout *bytes.Buffer
@@ -180,32 +180,32 @@ type StepResult struct {
 
 // ModifiedFiles returns the files modified by a step.
 func (r StepResult) ModifiedFiles() []string {
-	if r.files != nil {
-		return r.files.Modified
+	if r.Files != nil {
+		return r.Files.Modified
 	}
 	return []string{}
 }
 
 // AddedFiles returns the files added by a step.
 func (r StepResult) AddedFiles() []string {
-	if r.files != nil {
-		return r.files.Added
+	if r.Files != nil {
+		return r.Files.Added
 	}
 	return []string{}
 }
 
 // DeletedFiles returns the files deleted by a step.
 func (r StepResult) DeletedFiles() []string {
-	if r.files != nil {
-		return r.files.Deleted
+	if r.Files != nil {
+		return r.Files.Deleted
 	}
 	return []string{}
 }
 
 // RenamedFiles returns the new name of files that have been renamed by a step.
 func (r StepResult) RenamedFiles() []string {
-	if r.files != nil {
-		return r.files.Renamed
+	if r.Files != nil {
+		return r.Files.Renamed
 	}
 	return []string{}
 }
@@ -257,7 +257,7 @@ func (tmplCtx *ChangesetTemplateContext) ToFuncMap() template.FuncMap {
 		"steps": func() map[string]interface{} {
 			// Wrap the *StepChanges in a StepResult so we can use nil-safe
 			// methods.
-			res := StepResult{files: tmplCtx.Steps.Changes}
+			res := StepResult{Files: tmplCtx.Steps.Changes}
 
 			return map[string]interface{}{
 				"modified_files": res.ModifiedFiles(),

--- a/internal/batches/executor/templating_test.go
+++ b/internal/batches/executor/templating_test.go
@@ -23,7 +23,7 @@ func TestEvalStepCondition(t *testing.T) {
 			Description: "This batch change is just an experiment",
 		},
 		PreviousStep: StepResult{
-			files:  testChanges,
+			Files:  testChanges,
 			Stdout: bytes.NewBufferString("this is previous step's stdout"),
 			Stderr: bytes.NewBufferString("this is previous step's stderr"),
 		},
@@ -88,7 +88,7 @@ func TestRenderStepTemplate(t *testing.T) {
 			Description: "This batch change is just an experiment",
 		},
 		PreviousStep: StepResult{
-			files:  testChanges,
+			Files:  testChanges,
 			Stdout: bytes.NewBufferString("this is previous step's stdout"),
 			Stderr: bytes.NewBufferString("this is previous step's stderr"),
 		},
@@ -97,7 +97,7 @@ func TestRenderStepTemplate(t *testing.T) {
 			"project":  parsedYaml,
 		},
 		Step: StepResult{
-			files:  testChanges,
+			Files:  testChanges,
 			Stdout: bytes.NewBufferString("this is current step's stdout"),
 			Stderr: bytes.NewBufferString("this is current step's stderr"),
 		},
@@ -232,7 +232,7 @@ ${{ steps.path }}
 func TestRenderStepMap(t *testing.T) {
 	stepCtx := &StepContext{
 		PreviousStep: StepResult{
-			files:  testChanges,
+			Files:  testChanges,
 			Stdout: bytes.NewBufferString("this is previous step's stdout"),
 			Stderr: bytes.NewBufferString("this is previous step's stderr"),
 		},

--- a/internal/batches/git/changes.go
+++ b/internal/batches/git/changes.go
@@ -3,6 +3,8 @@ package git
 import (
 	"fmt"
 	"strings"
+
+	"github.com/sourcegraph/go-diff/diff"
 )
 
 // Changes are the changes made to files in a repository.
@@ -40,6 +42,30 @@ func ParseGitStatus(out []byte) (Changes, error) {
 			files := strings.Split(file, " -> ")
 			newFile := files[len(files)-1]
 			result.Renamed = append(result.Renamed, newFile)
+		}
+	}
+
+	return result, nil
+}
+
+func ChangesInDiff(rawDiff []byte) (Changes, error) {
+	result := Changes{}
+
+	fileDiffs, err := diff.ParseMultiFileDiff(rawDiff)
+	if err != nil {
+		return result, err
+	}
+
+	for _, fd := range fileDiffs {
+		switch {
+		case fd.NewName == "/dev/null":
+			result.Deleted = append(result.Deleted, fd.OrigName)
+		case fd.OrigName == "/dev/null":
+			result.Added = append(result.Added, fd.NewName)
+		case fd.OrigName == fd.NewName:
+			result.Modified = append(result.Modified, fd.OrigName)
+		case fd.OrigName != fd.NewName:
+			result.Renamed = append(result.Renamed, fd.NewName)
 		}
 	}
 

--- a/internal/batches/git/changes_test.go
+++ b/internal/batches/git/changes_test.go
@@ -30,3 +30,51 @@ R  README.md -> README.markdown
 		t.Fatalf("wrong output:\n%s", cmp.Diff(want, parsed))
 	}
 }
+
+func TestChangesInDiff(t *testing.T) {
+	const input = `diff --git README.md README.md
+index c9644dd..2552420 100644
+--- README.md
++++ README.md
+@@ -1,2 +1,3 @@
+ # Welcome to the README
+ foobar
++barfoo and what else?
+diff --git a_new_file_appears.txt a_new_file_appears.txt
+new file mode 100644
+index 0000000..09f946b
+--- /dev/null
++++ a_new_file_appears.txt
+@@ -0,0 +1 @@
++boom! like magic it appears
+diff --git another_file.txt another_cool_file.txt
+similarity index 100%
+rename from another_file.txt
+rename to another_cool_file.txt
+diff --git yet_another_file.txt yet_another_file.txt
+deleted file mode 100644
+index c27a40c..0000000
+--- yet_another_file.txt
++++ /dev/null
+@@ -1,3 +0,0 @@
+-this is yet another file
+-this time though
+-with tree lines
+`
+
+	changes, err := ChangesInDiff([]byte(input))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := Changes{
+		Modified: []string{"README.md"},
+		Added:    []string{"a_new_file_appears.txt"},
+		Deleted:  []string{"yet_another_file.txt"},
+		Renamed:  []string{"another_cool_file.txt"},
+	}
+
+	if !cmp.Equal(want, changes) {
+		t.Fatalf("wrong output:\n%s", cmp.Diff(want, changes))
+	}
+}


### PR DESCRIPTION
This PR fixes a bug in the step-wise caching logic that @eseliger and I ran into last week.

### Problem

When no cached result for the *complete* task was found, but a cached result for a single step and that step was the only left to execute then an empty diff was returned.

### How to reproduce

1. Execute a batch spec with the following steps

    ```yaml
    steps:
      - run: echo "this is step 1" >> README.txt
        container: alpine:3
      - run: echo "this is step 2" >> README.md
        container: alpine:3
    ```
    the complete results and the results for each step are now cached.
2. Update the batch spec and re-execute:
    ```yaml
    steps:
      - run: echo "this is step 1" >> README.txt
        container: alpine:3
    ```

This will produce an empty diff because the `Coordinator` did not find a cached result for the complete task/batch spec, but for the first step.

`runSteps` didn't handle this case though, when only a single step had to be executed but that was also cached.

### The fix

Take a look at my comments in the diffs here in GitHub to see what the fix is. Spoiler: it's just a condition and an early exit to handle the case of "cached step result == the only step to execute".

In order to get to this fix though I wrote a lot of tests, found one other bug (`Files` was not cached), and cleaned up the 300 line long `runSteps` function.

`runSteps` is now much easier to understand and doesn't contain _all_ levels of abstraction. The outer `runSteps` concerns itself with which steps need to be executed and how to handle their results and `executeSingleStep` does the lower-level work of rendering templates, starting containers, setting up the logger, etc.