### PR TITLE
add EventPathMatch to the streaming API types

### DIFF
--- a/cmd/src/search_stream.go
+++ b/cmd/src/search_stream.go
@@ -146,6 +146,19 @@ func textDecoder(query string, t *template.Template, w io.Writer) streaming.Deco
 						logError(fmt.Sprintf("error when executing template: %s\n", err))
 						return
 					}
+				case *streaming.EventPathMatch:
+					err := t.ExecuteTemplate(w, "path", struct {
+						Query string
+						*streaming.EventPathMatch
+					}{
+						Query:          query,
+						EventPathMatch: match,
+					},
+					)
+					if err != nil {
+						logError(fmt.Sprintf("error when executing template: %s\n", err))
+						return
+					}
 				case *streaming.EventRepoMatch:
 					err := t.ExecuteTemplate(w, "repo", struct {
 						SourcegraphEndpoint string
@@ -201,6 +214,17 @@ func isLimitHit(progress *streaming.Progress) bool {
 }
 
 const streamingTemplate = `
+{{define "path"}}
+	{{- /* Repository and file name */ -}}
+	{{- color "search-repository"}}{{.Repository}}{{color "nc" -}}
+	{{- " › " -}}
+	{{- color "search-filename"}}{{.Path}}{{color "nc" -}}
+	{{- color "success"}}{{matchOrMatches 0}}{{color "nc" -}}
+	{{- "\n" -}}
+	{{- color "search-border"}}{{"--------------------------------------------------------------------------------\n"}}{{color "nc"}}
+	{{- "\n" -}}
+{{- end -}}
+
 {{define "file"}}
 	{{- /* Repository and file name */ -}}
 	{{- color "search-repository"}}{{.Repository}}{{color "nc" -}}

--- a/internal/streaming/client.go
+++ b/internal/streaming/client.go
@@ -166,6 +166,8 @@ func (r *eventMatchUnmarshaller) UnmarshalJSON(b []byte) error {
 		r.EventMatch = &EventSymbolMatch{}
 	case CommitMatchType:
 		r.EventMatch = &EventCommitMatch{}
+	case PathMatchType:
+		r.EventMatch = &EventPathMatch{}
 	default:
 		return fmt.Errorf("unknown MatchType %v", typeU.Type)
 	}

--- a/internal/streaming/events.go
+++ b/internal/streaming/events.go
@@ -27,6 +27,19 @@ type EventFileMatch struct {
 
 func (e *EventFileMatch) eventMatch() {}
 
+// EventPathMatch is a subset of zoekt.FileMatch for our Event API.
+type EventPathMatch struct {
+	// Type is always PathMatchType. Included here for marshalling.
+	Type MatchType `json:"type"`
+
+	Path       string   `json:"name"`
+	Repository string   `json:"repository"`
+	Branches   []string `json:"branches,omitempty"`
+	Version    string   `json:"version,omitempty"`
+}
+
+func (e *EventPathMatch) eventMatch() {}
+
 // EventLineMatch is a subset of zoekt.LineMatch for our Event API.
 type EventLineMatch struct {
 	Line             string     `json:"line"`
@@ -123,6 +136,7 @@ const (
 	RepoMatchType
 	SymbolMatchType
 	CommitMatchType
+	PathMatchType
 )
 
 func (t MatchType) MarshalJSON() ([]byte, error) {
@@ -135,6 +149,8 @@ func (t MatchType) MarshalJSON() ([]byte, error) {
 		return []byte(`"symbol"`), nil
 	case CommitMatchType:
 		return []byte(`"commit"`), nil
+	case PathMatchType:
+		return []byte(`"path"`), nil
 	default:
 		return nil, fmt.Errorf("unknown MatchType: %d", t)
 	}
@@ -150,6 +166,8 @@ func (t *MatchType) UnmarshalJSON(b []byte) error {
 		*t = SymbolMatchType
 	} else if bytes.Equal(b, []byte(`"commit"`)) {
 		*t = CommitMatchType
+	} else if bytes.Equal(b, []byte(`"path"`)) {
+		*t = PathMatchType
 	} else {
 		return fmt.Errorf("unknown MatchType: %s", b)
 	}


### PR DESCRIPTION
Paired with  https://github.com/sourcegraph/sourcegraph/pull/22996

I assume the steps now are:
1) Release this as a new version (once the [File -> Content PR](https://github.com/sourcegraph/src-cli/pull/569) is merged as well)
2) Bump the [minimum src version](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/internal/src-cli/consts.go?subtree=true) in https://github.com/sourcegraph/sourcegraph/pull/22996
3) Merge https://github.com/sourcegraph/sourcegraph/pull/22996

I will not merge either of these PRs until after the version cut, because I don't want to get them partially applied. 