### PR TITLE
Fix printing of EXECUTING_TASKS start message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ All notable changes to `src-cli` are documented in this file.
 
 ### Fixed
 
+- For internal use only: `-text-only` silently ignored an error when trying to print log messages and did not print a `EXECUTING_TASKS` message.
+
 ### Removed
 
 ## 3.30.2


### PR DESCRIPTION
The code that's in here I had before, but somehow lost when restructuring things. Now the message works again and can be used as a trigger for the web UI to show a different "executing tasks" UI.