### PR TITLE
Fix typo in message printed during batch runs

### DIFF
--- a/internal/batches/ui/tui.go
+++ b/internal/batches/ui/tui.go
@@ -57,7 +57,7 @@ func (ui *TUI) ResolvingNamespace() {
 }
 
 func (ui *TUI) ResolvingNamespaceSuccess(_namespace string) {
-	batchCompletePending(ui.pending, "Resolving namesapce")
+	batchCompletePending(ui.pending, "Resolving namespace")
 }
 
 func (ui *TUI) PreparingContainerImages() {


### PR DESCRIPTION
While doing a `src batch` run I noticed there was a typo in the output. Traced that to this line of code. Please accept the fix.

Thanks!~