### PR TITLE
batches: disable network access by default

### DIFF
--- a/internal/batches/batch_spec.go
+++ b/internal/batches/batch_spec.go
@@ -93,6 +93,7 @@ type Step struct {
 	Env       env.Environment   `json:"env,omitempty" yaml:"env"`
 	Files     map[string]string `json:"files,omitempty" yaml:"files,omitempty"`
 	Outputs   Outputs           `json:"outputs,omitempty" yaml:"outputs,omitempty"`
+	AllowNetwork bool           `json:"allow_network,omitempty" yaml:"allow_network,omitempty"`
 
 	If interface{} `json:"if,omitempty" yaml:"if,omitempty"`
 

--- a/internal/batches/executor/run_steps.go
+++ b/internal/batches/executor/run_steps.go
@@ -292,6 +292,10 @@ func executeSingleStep(
 		args = append(args, "-e", k+"="+v)
 	}
 
+	if !step.AllowNetwork {
+		args = append(args, "--network", "none")
+	}
+
 	args = append(args, "--entrypoint", shell)
 
 	cmd := exec.CommandContext(ctx, "docker", args...)

--- a/schema/batch_spec.schema.json
+++ b/schema/batch_spec.schema.json
@@ -112,6 +112,11 @@
             "description": "The Docker image used to launch the Docker container in which the shell command is run.",
             "examples": ["alpine:3"]
           },
+          "allow_network": {
+            "type": "boolean",
+            "description": "Allow the container to access network.",
+            "default": false
+          },
           "outputs": {
             "type": "object",
             "description": "Output variables of this step that can be referenced in the changesetTemplate or other steps via outputs.<name-of-output>",

--- a/schema/batch_spec_stringdata.go
+++ b/schema/batch_spec_stringdata.go
@@ -117,6 +117,11 @@ const BatchSpecJSON = `{
             "description": "The Docker image used to launch the Docker container in which the shell command is run.",
             "examples": ["alpine:3"]
           },
+          "allow_network": {
+            "type": "boolean",
+            "description": "Allow the container to access network.",
+            "default": false
+          },
           "outputs": {
             "type": "object",
             "description": "Output variables of this step that can be referenced in the changesetTemplate or other steps via outputs.<name-of-output>",


### PR DESCRIPTION
Most of the time the container should not need network access as all
the tools to change the files should be available in the Docker image
already. Preventing network access by default reduces chance that
some code in the Docker image would send the source to the internet.