### PR TITLE
all: use /usr/bin/env bash

### DIFF
--- a/cmd/src/test.sh
+++ b/cmd/src/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cleanup() {
 	src orgs members remove -org-id=$(src org get -f '{{.ID}}' -name=abc-org) -user-id=$(src users get -f '{{.ID}}' -username=alice)

--- a/internal/batches/executor/testdata/dummydocker/docker
+++ b/internal/batches/executor/testdata/dummydocker/docker
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script is used by the executor integration test to simulate Docker.
 # It gets put into $PATH as "docker" and accepts the "run" command.


### PR DESCRIPTION
some *nix systems don't have `/bin/bash`. `/usr/bin/env` is more
portable. I came accross this issue while running the tests on nixos.