### PR TITLE
Fix null in JSON log lines output by removing nil slice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,9 @@ All notable changes to `src-cli` are documented in this file.
 ### Changed
 
 ### Fixed
+
 - `src search -stream` displayed the number of lines that contain matches instead of the number of matches.
+- For internal use only: the `EXECUTING_TASKS` JSON log line now always contains an array of `tasks` instead of possibly having `null` as the `tasks` value.
 
 ### Removed
 

--- a/internal/batches/ui/json_lines.go
+++ b/internal/batches/ui/json_lines.go
@@ -226,7 +226,7 @@ type taskExecutionJSONLines struct {
 
 func (ui *taskExecutionJSONLines) Start(tasks []*executor.Task) {
 	ui.linesTasks = make(map[*executor.Task]jsonLinesTask, len(tasks))
-	var linesTasks []jsonLinesTask
+	linesTasks := []jsonLinesTask{}
 	for _, t := range tasks {
 		linesTask := jsonLinesTask{
 			Repository:             t.Repository.Name,


### PR DESCRIPTION
@eseliger ran into this yesterday. Easy to reproduce: when all tasks are cached then none will need to be re-executed and `tasks` in the log message would be `null`.