### PR TITLE
test: don't rely on root being a git repo

### DIFF
--- a/internal/codeintel/gitutil_test.go
+++ b/internal/codeintel/gitutil_test.go
@@ -2,18 +2,42 @@ package codeintel
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
 )
 
 func TestInferRepo(t *testing.T) {
-	repo, err := InferRepo()
+	cur, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(cur)
+
+	tempDir := t.TempDir()
+	err = os.Chdir(tempDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = runGitCommand("init")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := "github.com/a/b"
+
+	_, err = runGitCommand("remote", "add", "origin", want)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := InferRepo()
 	if err != nil {
 		t.Fatalf("unexpected error inferring repo: %s", err)
 	}
 
-	if repo != "github.com/sourcegraph/src-cli" {
-		t.Errorf("unexpected remote repo. want=%q have=%q", "github.com/sourcegraph/src-cli", repo)
+	if got != want {
+		t.Errorf("unexpected remote repo. want=%q have=%q", want, got)
 	}
 }
 


### PR DESCRIPTION
The test `TestInferRepo` unnecesarily depends on the root being a git
repository. This change updates `TestInferRepo` to create a fresh git
repo in a temporary dir.

Why?

I want to add src-cli to the nixos package repository. During the build
stage, nixos downloads a tar of the repo. The tar, however, is not a git
repo and thus `TestInferRepo` fails.