### PR TITLE
refactor: One RepoWorkspace per workspace

### DIFF
--- a/internal/batches/service/build_tasks.go
+++ b/internal/batches/service/build_tasks.go
@@ -11,7 +11,7 @@ import (
 )
 
 // buildTasks returns tasks for all the workspaces determined for the given spec.
-func buildTasks(ctx context.Context, spec *batcheslib.BatchSpec, repos []*graphql.Repository, workspaces []RepoWorkspaces) ([]*executor.Task, error) {
+func buildTasks(ctx context.Context, spec *batcheslib.BatchSpec, repos []*graphql.Repository, workspaces []RepoWorkspace) ([]*executor.Task, error) {
 	repoByID := make(map[string]*graphql.Repository)
 	for _, repo := range repos {
 		repoByID[repo.ID] = repo
@@ -23,19 +23,13 @@ func buildTasks(ctx context.Context, spec *batcheslib.BatchSpec, repos []*graphq
 		if !ok {
 			return nil, errors.New("invalid state, didn't find repo for workspace definition")
 		}
-		for _, path := range ws.Paths {
-			fetchWorkspace := ws.OnlyFetchWorkspace
-			if path == "" {
-				fetchWorkspace = false
-			}
-			t, ok, err := buildTask(spec, repo, path, fetchWorkspace)
-			if err != nil {
-				return nil, err
-			}
+		t, ok, err := buildTask(spec, repo, ws.Path, ws.OnlyFetchWorkspace)
+		if err != nil {
+			return nil, err
+		}
 
-			if ok {
-				tasks = append(tasks, t)
-			}
+		if ok {
+			tasks = append(tasks, t)
 		}
 	}
 

--- a/internal/batches/service/service.go
+++ b/internal/batches/service/service.go
@@ -182,11 +182,11 @@ func (svc *Service) EnsureImage(ctx context.Context, name string) (docker.Image,
 	return img, nil
 }
 
-func (svc *Service) DetermineWorkspaces(ctx context.Context, repos []*graphql.Repository, spec *batcheslib.BatchSpec) ([]RepoWorkspaces, error) {
+func (svc *Service) DetermineWorkspaces(ctx context.Context, repos []*graphql.Repository, spec *batcheslib.BatchSpec) ([]RepoWorkspace, error) {
 	return findWorkspaces(ctx, spec, svc, repos)
 }
 
-func (svc *Service) BuildTasks(ctx context.Context, repos []*graphql.Repository, spec *batcheslib.BatchSpec, workspaces []RepoWorkspaces) ([]*executor.Task, error) {
+func (svc *Service) BuildTasks(ctx context.Context, repos []*graphql.Repository, spec *batcheslib.BatchSpec, workspaces []RepoWorkspace) ([]*executor.Task, error) {
 	return buildTasks(ctx, spec, repos, workspaces)
 }
 


### PR DESCRIPTION
This makes it easier to map 1 repo workspace to 1 task, useful in SSBC when we split per workspace.