### PR TITLE
text-only output: log stdout/stderr of steps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,9 @@ require (
 	github.com/sourcegraph/batch-change-utils v0.0.0-20210708162152-c9f35b905d94
 	github.com/sourcegraph/go-diff v0.6.1
 	github.com/sourcegraph/jsonx v0.0.0-20200629203448-1a936bd500cf
-	github.com/sourcegraph/sourcegraph/lib v0.0.0-20210902215418-71593bf836f9
+	github.com/sourcegraph/sourcegraph/lib v0.0.0-20210903080558-3f16affc1edc
+	github.com/ssor/bom v0.0.0-20170718123548-6386211fdfcf // indirect
+	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	golang.org/x/net v0.0.0-20210614182718-04defd469f4e
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 	jaytaylor.com/html2text v0.0.0-20200412013138-3577fbdbcff7
@@ -46,8 +48,6 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/rivo/uniseg v0.1.0 // indirect
 	github.com/rogpeppe/go-internal v1.8.0 // indirect
-	github.com/ssor/bom v0.0.0-20170718123548-6386211fdfcf // indirect
-	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
 	golang.org/x/sys v0.0.0-20210616094352-59db8d763f22 // indirect

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,8 @@ go 1.17
 require (
 	github.com/Masterminds/semver v1.5.0
 	github.com/cockroachdb/errors v1.8.6
+	github.com/cockroachdb/redact v1.1.3 // indirect
+	github.com/derision-test/glock v0.0.0-20210316032053-f5b74334bb29
 	github.com/dustin/go-humanize v1.0.0
 	github.com/gobwas/glob v0.2.3
 	github.com/google/go-cmp v0.5.6
@@ -30,7 +32,6 @@ require (
 require (
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
 	github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f // indirect
-	github.com/cockroachdb/redact v1.1.3 // indirect
 	github.com/cockroachdb/sentry-go v0.6.1-cockroachdb.2 // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -43,6 +43,8 @@ github.com/dave/jennifer v1.4.1/go.mod h1:7jEdnm+qBcxl8PC0zyp7vxcpSRnzXSt9r39tpT
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/derision-test/glock v0.0.0-20210316032053-f5b74334bb29 h1:O07j7ewg0eFHRx+7bxCA/7z86HJexl7HLY9kyVMmPDo=
+github.com/derision-test/glock v0.0.0-20210316032053-f5b74334bb29/go.mod h1:jKtLdBMrF+XQatqvg46wiWdDfDSSDjdhO4dOM2FX9H4=
 github.com/derision-test/go-mockgen v1.1.2/go.mod h1:9H3VGTWYnL1VJoHHCuPKDpPFmNQ1uVyNlpX6P63l5Sk=
 github.com/dgraph-io/badger v1.6.0/go.mod h1:zwt7syl517jmP8s94KqSxTlM6IMsdhYy6psNgSztDR4=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
@@ -274,6 +276,7 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=

--- a/go.sum
+++ b/go.sum
@@ -257,8 +257,8 @@ github.com/sourcegraph/go-diff v0.6.1 h1:hmA1LzxW0n1c3Q4YbrFgg4P99GSnebYa3x8gr0H
 github.com/sourcegraph/go-diff v0.6.1/go.mod h1:iBszgVvyxdc8SFZ7gm69go2KDdt3ag071iBaWPF6cjs=
 github.com/sourcegraph/jsonx v0.0.0-20200629203448-1a936bd500cf h1:oAdWFqhStsWiiMP/vkkHiMXqFXzl1XfUNOdxKJbd6bI=
 github.com/sourcegraph/jsonx v0.0.0-20200629203448-1a936bd500cf/go.mod h1:ppFaPm6kpcHnZGqQTFhUIAQRIEhdQDWP1PCv4/ON354=
-github.com/sourcegraph/sourcegraph/lib v0.0.0-20210902215418-71593bf836f9 h1:afOQUKamJAosvaIgAJKFrJ7BbQ06BxJLlNU2Z+wfzOc=
-github.com/sourcegraph/sourcegraph/lib v0.0.0-20210902215418-71593bf836f9/go.mod h1:ZK8mHKWdapYI8iIQwsO7QUxf44RjiNGKkOZa9aYIjTc=
+github.com/sourcegraph/sourcegraph/lib v0.0.0-20210903080558-3f16affc1edc h1:iMV2Nc/fCn3PrG9vgFgXN2LdY6mDfcGuzQe9ObCT/U4=
+github.com/sourcegraph/sourcegraph/lib v0.0.0-20210903080558-3f16affc1edc/go.mod h1:ZK8mHKWdapYI8iIQwsO7QUxf44RjiNGKkOZa9aYIjTc=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
@@ -283,8 +283,9 @@ github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyC
 github.com/valyala/fasthttp v1.6.0/go.mod h1:FstJa9V+Pj9vQ7OJie2qMHdwemEDaDiSdBnvPM1Su9w=
 github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=
 github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a/go.mod h1:v3UYOV9WzVtRmSR+PDvWpU/qWl4Wa5LApYYX4ZtKbio=
-github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f h1:J9EGpcZtP0E/raorCMxlFGSTBrsSlaDGf3jU/qvAE2c=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
+github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb h1:zGWFAtiMcyryUHoUjUJX0/lt1H2+i2Ka2n+D3DImSNo=
+github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
 github.com/xeipuuv/gojsonschema v1.2.0 h1:LhYJRs+L4fBtjZUfuSZIKGeVu0QRy8e5Xi7D17UxZ74=

--- a/internal/batches/executor/coordinator.go
+++ b/internal/batches/executor/coordinator.go
@@ -2,6 +2,7 @@ package executor
 
 import (
 	"context"
+	"io"
 	"reflect"
 	"strconv"
 	"time"
@@ -217,8 +218,8 @@ type TaskExecutionUI interface {
 	// TODO: This should be split up into methods that are more specific.
 	TaskCurrentlyExecuting(*Task, string)
 
-	TaskStdout(*Task, string)
-	TaskStderr(*Task, string)
+	TaskStdoutWriter(context.Context, *Task) io.Writer
+	TaskStderrWriter(context.Context, *Task) io.Writer
 }
 
 // Execute executes the given Tasks and the importChangeset statements in the

--- a/internal/batches/executor/coordinator.go
+++ b/internal/batches/executor/coordinator.go
@@ -9,7 +9,6 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/hashicorp/go-multierror"
 	batcheslib "github.com/sourcegraph/sourcegraph/lib/batches"
-
 	"github.com/sourcegraph/src-cli/internal/api"
 	"github.com/sourcegraph/src-cli/internal/batches"
 	"github.com/sourcegraph/src-cli/internal/batches/docker"
@@ -217,6 +216,9 @@ type TaskExecutionUI interface {
 
 	// TODO: This should be split up into methods that are more specific.
 	TaskCurrentlyExecuting(*Task, string)
+
+	TaskStdout(*Task, string)
+	TaskStderr(*Task, string)
 }
 
 // Execute executes the given Tasks and the importChangeset statements in the

--- a/internal/batches/executor/coordinator.go
+++ b/internal/batches/executor/coordinator.go
@@ -218,8 +218,8 @@ type TaskExecutionUI interface {
 	// TODO: This should be split up into methods that are more specific.
 	TaskCurrentlyExecuting(*Task, string)
 
-	TaskStdoutWriter(context.Context, *Task) io.Writer
-	TaskStderrWriter(context.Context, *Task) io.Writer
+	StepStdoutWriter(context.Context, *Task, int) io.WriteCloser
+	StepStderrWriter(context.Context, *Task, int) io.WriteCloser
 }
 
 // Execute executes the given Tasks and the importChangeset statements in the

--- a/internal/batches/executor/coordinator_test.go
+++ b/internal/batches/executor/coordinator_test.go
@@ -544,7 +544,6 @@ func (d *dummyTaskExecutionUI) TaskChangesetSpecsBuilt(t *Task, specs []*batches
 	d.specs[t] = specs
 }
 
-
 type discardCloser struct {
 	io.Writer
 }

--- a/internal/batches/executor/coordinator_test.go
+++ b/internal/batches/executor/coordinator_test.go
@@ -544,6 +544,8 @@ func (d *dummyTaskExecutionUI) TaskChangesetSpecsBuilt(t *Task, specs []*batches
 }
 
 func (d *dummyTaskExecutionUI) TaskCurrentlyExecuting(*Task, string) {}
+func (d *dummyTaskExecutionUI) TaskStdout(*Task, string)             {}
+func (d *dummyTaskExecutionUI) TaskStderr(*Task, string)             {}
 
 var _ taskExecutor = &dummyExecutor{}
 

--- a/internal/batches/executor/coordinator_test.go
+++ b/internal/batches/executor/coordinator_test.go
@@ -3,6 +3,7 @@ package executor
 import (
 	"context"
 	"fmt"
+	"io"
 	"strings"
 	"sync"
 	"testing"
@@ -544,8 +545,12 @@ func (d *dummyTaskExecutionUI) TaskChangesetSpecsBuilt(t *Task, specs []*batches
 }
 
 func (d *dummyTaskExecutionUI) TaskCurrentlyExecuting(*Task, string) {}
-func (d *dummyTaskExecutionUI) TaskStdout(*Task, string)             {}
-func (d *dummyTaskExecutionUI) TaskStderr(*Task, string)             {}
+func (d *dummyTaskExecutionUI) TaskStdoutWriter(ctx context.Context, task *Task) io.Writer {
+	return io.Discard
+}
+func (d *dummyTaskExecutionUI) TaskStderrWriter(ctx context.Context, task *Task) io.Writer {
+	return io.Discard
+}
 
 var _ taskExecutor = &dummyExecutor{}
 

--- a/internal/batches/executor/coordinator_test.go
+++ b/internal/batches/executor/coordinator_test.go
@@ -544,12 +544,19 @@ func (d *dummyTaskExecutionUI) TaskChangesetSpecsBuilt(t *Task, specs []*batches
 	d.specs[t] = specs
 }
 
-func (d *dummyTaskExecutionUI) TaskCurrentlyExecuting(*Task, string) {}
-func (d *dummyTaskExecutionUI) TaskStdoutWriter(ctx context.Context, task *Task) io.Writer {
-	return io.Discard
+
+type discardCloser struct {
+	io.Writer
 }
-func (d *dummyTaskExecutionUI) TaskStderrWriter(ctx context.Context, task *Task) io.Writer {
-	return io.Discard
+
+func (discardCloser) Close() error { return nil }
+
+func (d *dummyTaskExecutionUI) TaskCurrentlyExecuting(*Task, string) {}
+func (d *dummyTaskExecutionUI) StepStdoutWriter(ctx context.Context, task *Task, step int) io.WriteCloser {
+	return discardCloser{io.Discard}
+}
+func (d *dummyTaskExecutionUI) StepStderrWriter(ctx context.Context, task *Task, step int) io.WriteCloser {
+	return discardCloser{io.Discard}
 }
 
 var _ taskExecutor = &dummyExecutor{}

--- a/internal/batches/executor/executor.go
+++ b/internal/batches/executor/executor.go
@@ -177,8 +177,8 @@ func (x *executor) do(ctx context.Context, task *Task, ui TaskExecutionUI) (err 
 		reportProgress: func(currentlyExecuting string) {
 			ui.TaskCurrentlyExecuting(task, currentlyExecuting)
 		},
-		uiStdoutWriter: ui.TaskStdoutWriter(runCtx, task),
-		uiStderrWriter: ui.TaskStderrWriter(runCtx, task),
+		newUiStdoutWriter: ui.StepStdoutWriter,
+		newUiStderrWriter: ui.StepStderrWriter,
 	}
 
 	result, stepResults, err := runSteps(runCtx, opts)

--- a/internal/batches/executor/executor.go
+++ b/internal/batches/executor/executor.go
@@ -1,7 +1,6 @@
 package executor
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"os/exec"
@@ -178,8 +177,8 @@ func (x *executor) do(ctx context.Context, task *Task, ui TaskExecutionUI) (err 
 		reportProgress: func(currentlyExecuting string) {
 			ui.TaskCurrentlyExecuting(task, currentlyExecuting)
 		},
-		uiStdoutWriter: &uiWriter{task: task, fn: ui.TaskStdout},
-		uiStderrWriter: &uiWriter{task: task, fn: ui.TaskStderr},
+		uiStdoutWriter: ui.TaskStdoutWriter(runCtx, task),
+		uiStderrWriter: ui.TaskStderrWriter(runCtx, task),
 	}
 
 	result, stepResults, err := runSteps(runCtx, opts)
@@ -194,22 +193,6 @@ func (x *executor) do(ctx context.Context, task *Task, ui TaskExecutionUI) (err 
 
 	return nil
 }
-
-// TODO: Buffer and flush output
-type uiWriter struct {
-	task *Task
-	fn   func(*Task, string)
-}
-
-func (uiw *uiWriter) Write(p []byte) (int, error) {
-	for _, line := range bytes.Split(p, []byte("\n")) {
-		if string(line) != "" {
-			uiw.fn(uiw.task, string(line))
-		}
-	}
-	return len(p), nil
-}
-
 func (x *executor) addResult(task *Task, result executionResult, stepResults []stepExecutionResult) {
 	x.resultsMu.Lock()
 	defer x.resultsMu.Unlock()

--- a/internal/batches/executor/run_steps.go
+++ b/internal/batches/executor/run_steps.go
@@ -65,6 +65,9 @@ type executionOpts struct {
 
 	logger         log.TaskLogger
 	reportProgress func(string)
+
+	uiStdoutWriter io.Writer
+	uiStderrWriter io.Writer
 }
 
 func runSteps(ctx context.Context, opts *executionOpts) (result executionResult, stepResults []stepExecutionResult, err error) {
@@ -310,8 +313,9 @@ func executeSingleStep(
 
 	var stdoutBuffer, stderrBuffer bytes.Buffer
 
-	cmd.Stdout = io.MultiWriter(&stdoutBuffer, opts.logger.PrefixWriter("stdout"))
-	cmd.Stderr = io.MultiWriter(&stderrBuffer, opts.logger.PrefixWriter("stderr"))
+	// TODO: We need to handle closing of these
+	cmd.Stdout = io.MultiWriter(&stdoutBuffer, opts.uiStdoutWriter, opts.logger.PrefixWriter("stdout"))
+	cmd.Stderr = io.MultiWriter(&stderrBuffer, opts.uiStderrWriter, opts.logger.PrefixWriter("stderr"))
 
 	opts.logger.Logf("[Step %d] run: %q, container: %q", i+1, step.Run, step.Container)
 	opts.logger.Logf("[Step %d] full command: %q", i+1, strings.Join(cmd.Args, " "))

--- a/internal/batches/ui/interval_writer.go
+++ b/internal/batches/ui/interval_writer.go
@@ -1,0 +1,105 @@
+package ui
+
+import (
+	"bytes"
+	"context"
+	"time"
+
+	"github.com/derision-test/glock"
+)
+
+// IntervalWriter is a io.Writer that flushes to the given sink on the given
+// interval.
+type IntervalWriter struct {
+	sink func(string)
+
+	ticker glock.Ticker
+
+	// buf is used to keep partial lines buffered before flushing them (either
+	// on the next newline or after tickDuration)
+	buf        *bytes.Buffer
+	writes     chan []byte
+	writesDone chan struct{}
+
+	closed chan struct{}
+	done   chan struct{}
+}
+
+func newIntervalWriter(ctx context.Context, ticker glock.Ticker, sink func(string)) *IntervalWriter {
+	l := &IntervalWriter{
+		sink:   sink,
+		ticker: ticker,
+
+		writes:     make(chan []byte),
+		writesDone: make(chan struct{}),
+
+		buf: &bytes.Buffer{},
+
+		closed: make(chan struct{}, 1),
+		done:   make(chan struct{}, 1),
+	}
+
+	go l.writeLines(ctx)
+
+	return l
+}
+
+// NewLogger returns a new Logger instance and spawns a goroutine in the
+// background that regularily flushed the logged output to the given sink.
+//
+// If the passed in ctx is canceled the goroutine will exit.
+func NewIntervalWriter(ctx context.Context, interval time.Duration, sink func(string)) *IntervalWriter {
+	return newIntervalWriter(ctx, glock.NewRealTicker(interval), sink)
+}
+
+func (l *IntervalWriter) flush() {
+	if l.buf.Len() == 0 {
+		return
+	}
+	l.sink(l.buf.String())
+	l.buf.Reset()
+}
+
+// Close flushes the
+func (l *IntervalWriter) Close() error {
+	l.closed <- struct{}{}
+	<-l.done
+	return nil
+}
+
+// Write handler of IntervalWriter.
+func (l *IntervalWriter) Write(p []byte) (int, error) {
+	l.writes <- p
+	<-l.writesDone
+	return len(p), nil
+}
+
+func (l *IntervalWriter) writeLines(ctx context.Context) {
+	defer func() {
+		l.flush()
+		l.ticker.Stop()
+		l.done <- struct{}{}
+	}()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+
+		case <-l.closed:
+			return
+
+		case w, ok := <-l.writes:
+			if !ok {
+				return
+			}
+
+			if _, err := l.buf.Write(w); err != nil {
+				break
+			}
+			l.writesDone <- struct{}{}
+		case <-l.ticker.Chan():
+			l.flush()
+		}
+	}
+}

--- a/internal/batches/ui/interval_writer_test.go
+++ b/internal/batches/ui/interval_writer_test.go
@@ -1,0 +1,63 @@
+package ui
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/derision-test/glock"
+)
+
+func TestIntervalWriter(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	ch := make(chan string, 500)
+
+	sink := func(data string) {
+		ch <- data
+	}
+
+	ticker := glock.NewMockTicker(1 * time.Second)
+	writer := newIntervalWriter(ctx, ticker, sink)
+
+	writer.Write([]byte("1"))
+	select {
+	case <-ch:
+		t.Fatalf("ch has data")
+	default:
+	}
+
+	ticker.BlockingAdvance(1 * time.Second)
+
+	select {
+	case d := <-ch:
+		if d != "1" {
+			t.Fatalf("wrong data in sink")
+		}
+	case <-time.After(1 * time.Second):
+		t.Fatalf("ch has NO data")
+	}
+
+	writer.Write([]byte("2"))
+	writer.Write([]byte("3"))
+	writer.Write([]byte("4"))
+	writer.Write([]byte("5"))
+
+	select {
+	case <-ch:
+		t.Fatalf("ch has data")
+	default:
+	}
+
+	cancel()
+	writer.Close()
+
+	select {
+	case d := <-ch:
+		if d != "2345" {
+			t.Fatalf("wrong data in sink")
+		}
+	case <-time.After(1 * time.Second):
+		t.Fatalf("ch has NO data")
+	}
+}

--- a/internal/batches/ui/json_lines.go
+++ b/internal/batches/ui/json_lines.go
@@ -6,11 +6,12 @@ import (
 	"os"
 	"time"
 
-	batcheslib "github.com/sourcegraph/sourcegraph/lib/batches"
 	"github.com/sourcegraph/src-cli/internal/batches"
 	"github.com/sourcegraph/src-cli/internal/batches/executor"
 	"github.com/sourcegraph/src-cli/internal/batches/graphql"
 	"github.com/sourcegraph/src-cli/internal/batches/workspace"
+
+	batcheslib "github.com/sourcegraph/sourcegraph/lib/batches"
 )
 
 var _ ExecUI = &JSONLines{}
@@ -296,6 +297,36 @@ func (ui *taskExecutionJSONLines) TaskCurrentlyExecuting(task *executor.Task, me
 		Operation: "EXECUTING_TASK",
 		Status:    "PROGRESS",
 		Message:   message,
+		Metadata: map[string]interface{}{
+			"task": lt,
+		},
+	})
+}
+
+func (ui *taskExecutionJSONLines) TaskStdout(task *executor.Task, line string) {
+	lt, ok := ui.linesTasks[task]
+	if !ok {
+		panic("unknown task started")
+	}
+	logEvent(batchesLogEvent{
+		Operation: "TASK_STDOUT",
+		Status:    "PROGRESS",
+		Message:   line,
+		Metadata: map[string]interface{}{
+			"task": lt,
+		},
+	})
+}
+
+func (ui *taskExecutionJSONLines) TaskStderr(task *executor.Task, line string) {
+	lt, ok := ui.linesTasks[task]
+	if !ok {
+		panic("unknown task started")
+	}
+	logEvent(batchesLogEvent{
+		Operation: "TASK_STDERR",
+		Status:    "PROGRESS",
+		Message:   line,
 		Metadata: map[string]interface{}{
 			"task": lt,
 		},

--- a/internal/batches/ui/task_exec_tui.go
+++ b/internal/batches/ui/task_exec_tui.go
@@ -8,9 +8,10 @@ import (
 	"time"
 
 	"github.com/sourcegraph/go-diff/diff"
+	"github.com/sourcegraph/src-cli/internal/batches/executor"
+
 	batcheslib "github.com/sourcegraph/sourcegraph/lib/batches"
 	"github.com/sourcegraph/sourcegraph/lib/output"
-	"github.com/sourcegraph/src-cli/internal/batches/executor"
 )
 
 type taskStatus struct {
@@ -213,6 +214,14 @@ func (ui *taskExecTUI) TaskCurrentlyExecuting(task *executor.Task, message strin
 	}
 
 	ui.progress.StatusBarUpdatef(bar, ts.String())
+}
+
+func (ui *taskExecTUI) TaskStdout(task *executor.Task, line string) {
+	// noop
+}
+
+func (ui *taskExecTUI) TaskStderr(task *executor.Task, line string) {
+	// noop
 }
 
 func (ui *taskExecTUI) TaskFinished(task *executor.Task, err error) {

--- a/internal/batches/ui/task_exec_tui.go
+++ b/internal/batches/ui/task_exec_tui.go
@@ -1,7 +1,9 @@
 package ui
 
 import (
+	"context"
 	"fmt"
+	"io"
 	"sort"
 	"strings"
 	"sync"
@@ -216,12 +218,12 @@ func (ui *taskExecTUI) TaskCurrentlyExecuting(task *executor.Task, message strin
 	ui.progress.StatusBarUpdatef(bar, ts.String())
 }
 
-func (ui *taskExecTUI) TaskStdout(task *executor.Task, line string) {
-	// noop
+func (ui *taskExecTUI) TaskStdoutWriter(ctx context.Context, task *executor.Task) io.Writer {
+	return io.Discard
 }
 
-func (ui *taskExecTUI) TaskStderr(task *executor.Task, line string) {
-	// noop
+func (ui *taskExecTUI) TaskStderrWriter(ctx context.Context, task *executor.Task) io.Writer {
+	return io.Discard
 }
 
 func (ui *taskExecTUI) TaskFinished(task *executor.Task, err error) {

--- a/internal/batches/ui/task_exec_tui.go
+++ b/internal/batches/ui/task_exec_tui.go
@@ -218,12 +218,18 @@ func (ui *taskExecTUI) TaskCurrentlyExecuting(task *executor.Task, message strin
 	ui.progress.StatusBarUpdatef(bar, ts.String())
 }
 
-func (ui *taskExecTUI) TaskStdoutWriter(ctx context.Context, task *executor.Task) io.Writer {
-	return io.Discard
+type discardCloser struct {
+	io.Writer
 }
 
-func (ui *taskExecTUI) TaskStderrWriter(ctx context.Context, task *executor.Task) io.Writer {
-	return io.Discard
+func (discardCloser) Close() error { return nil }
+
+func (ui *taskExecTUI) StepStdoutWriter(ctx context.Context, task *executor.Task, stepidx int) io.WriteCloser {
+	return discardCloser{io.Discard}
+}
+
+func (ui *taskExecTUI) StepStderrWriter(ctx context.Context, task *executor.Task, stepidx int) io.WriteCloser {
+	return discardCloser{io.Discard}
 }
 
 func (ui *taskExecTUI) TaskFinished(task *executor.Task, err error) {


### PR DESCRIPTION
This is part of https://github.com/sourcegraph/sourcegraph/issues/23496 and adds the logging of STDOUT/STDERR of steps to the `-text-only` output. Please see the comment I left for more info on how the interface could be improved/extended.

Also: turns out I don't need the `process.Logger` that was extracted in https://github.com/sourcegraph/sourcegraph/pull/24545 and instead what's needed is the `IntervalLogger` here that flushes the captured output with a delay (so we don't create a new huge JSON message for every line)