### PR TITLE
Move fallback from `.` to `""` in workspace path into workspace finder

### DIFF
--- a/internal/batches/service/build_tasks.go
+++ b/internal/batches/service/build_tasks.go
@@ -14,32 +14,21 @@ func buildTasks(ctx context.Context, spec *batcheslib.BatchSpec, workspaces []Re
 	tasks := make([]*executor.Task, 0, len(workspaces))
 
 	for _, ws := range workspaces {
-		tasks = append(tasks, buildTask(spec, ws))
+		task := &executor.Task{
+			Repository:         ws.Repo,
+			Path:               ws.Path,
+			Steps:              ws.Steps,
+			OnlyFetchWorkspace: ws.OnlyFetchWorkspace,
+
+			TransformChanges: spec.TransformChanges,
+			Template:         spec.ChangesetTemplate,
+			BatchChangeAttributes: &template.BatchChangeAttributes{
+				Name:        spec.Name,
+				Description: spec.Description,
+			},
+		}
+		tasks = append(tasks, task)
 	}
 
 	return tasks
-}
-
-func buildTask(spec *batcheslib.BatchSpec, workspace RepoWorkspace) *executor.Task {
-	batchChange := template.BatchChangeAttributes{
-		Name:        spec.Name,
-		Description: spec.Description,
-	}
-
-	// "." means the path is root, but in the executor we use "" to signify root.
-	path := workspace.Path
-	if path == "." {
-		path = ""
-	}
-
-	return &executor.Task{
-		Repository:         workspace.Repo,
-		Path:               path,
-		Steps:              workspace.Steps,
-		OnlyFetchWorkspace: workspace.OnlyFetchWorkspace,
-
-		TransformChanges:      spec.TransformChanges,
-		Template:              spec.ChangesetTemplate,
-		BatchChangeAttributes: &batchChange,
-	}
 }

--- a/internal/batches/service/service.go
+++ b/internal/batches/service/service.go
@@ -681,11 +681,16 @@ func (svc *Service) FindDirectoriesInRepos(ctx context.Context, fileName string,
 
 			var dirs []string
 			for f := range files {
+				dir := path.Dir(f)
+				// "." means the path is root, but in the executor we use "" to signify root.
+				if dir == "." {
+					dir = ""
+				}
 				// We use path.Dir and not filepath.Dir here, because while
 				// src-cli might be executed on Windows, we need the paths to
 				// be Unix paths, since they will be used inside Docker
 				// containers.
-				dirs = append(dirs, path.Dir(f))
+				dirs = append(dirs, dir)
 			}
 
 			results[repo] = dirs

--- a/internal/batches/service/service_test.go
+++ b/internal/batches/service/service_test.go
@@ -364,7 +364,7 @@ func TestService_FindDirectoriesInRepos(t *testing.T) {
 
 	want := map[*graphql.Repository][]string{
 		repos[0]: {"examples/project3", "project1", "project2"},
-		repos[1]: {"docs/client1", ".", "docs/client2/examples"},
+		repos[1]: {"docs/client1", "", "docs/client2/examples"},
 	}
 
 	if !cmp.Equal(want, results, cmpopts.SortSlices(sortStrings)) {


### PR DESCRIPTION
I don't see where this could happen. We get the path from the search API and that returns "" for the root. Can we remove this special handling?