### PR TITLE
executor UI: extract StepsExecutionUI from TaskExecutionUI and implement it in TUI and JSON

### DIFF
--- a/internal/batches/executor/coordinator.go
+++ b/internal/batches/executor/coordinator.go
@@ -2,13 +2,13 @@ package executor
 
 import (
 	"context"
-	"io"
 	"reflect"
 	"strconv"
 	"time"
 
 	"github.com/cockroachdb/errors"
 	"github.com/hashicorp/go-multierror"
+
 	batcheslib "github.com/sourcegraph/sourcegraph/lib/batches"
 
 	"github.com/sourcegraph/src-cli/internal/api"
@@ -205,22 +205,6 @@ func (c *Coordinator) cacheAndBuildSpec(ctx context.Context, taskResult taskResu
 
 	ui.TaskChangesetSpecsBuilt(taskResult.task, specs)
 	return specs, nil
-}
-
-type TaskExecutionUI interface {
-	Start([]*Task)
-	Success()
-
-	TaskStarted(*Task)
-	TaskFinished(*Task, error)
-
-	TaskChangesetSpecsBuilt(*Task, []*batcheslib.ChangesetSpec)
-
-	// TODO: This should be split up into methods that are more specific.
-	TaskCurrentlyExecuting(*Task, string)
-
-	StepStdoutWriter(context.Context, *Task, int) io.WriteCloser
-	StepStderrWriter(context.Context, *Task, int) io.WriteCloser
 }
 
 // Execute executes the given Tasks and the importChangeset statements in the

--- a/internal/batches/executor/coordinator_test.go
+++ b/internal/batches/executor/coordinator_test.go
@@ -3,7 +3,6 @@ package executor
 import (
 	"context"
 	"fmt"
-	"io"
 	"strings"
 	"sync"
 	"testing"
@@ -11,6 +10,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/sourcegraph/batch-change-utils/overridable"
+
 	batcheslib "github.com/sourcegraph/sourcegraph/lib/batches"
 	"github.com/sourcegraph/sourcegraph/lib/batches/git"
 	"github.com/sourcegraph/sourcegraph/lib/batches/template"
@@ -545,18 +545,8 @@ func (d *dummyTaskExecutionUI) TaskChangesetSpecsBuilt(t *Task, specs []*batches
 	d.specs[t] = specs
 }
 
-type discardCloser struct {
-	io.Writer
-}
-
-func (discardCloser) Close() error { return nil }
-
-func (d *dummyTaskExecutionUI) TaskCurrentlyExecuting(*Task, string) {}
-func (d *dummyTaskExecutionUI) StepStdoutWriter(ctx context.Context, task *Task, step int) io.WriteCloser {
-	return discardCloser{io.Discard}
-}
-func (d *dummyTaskExecutionUI) StepStderrWriter(ctx context.Context, task *Task, step int) io.WriteCloser {
-	return discardCloser{io.Discard}
+func (d *dummyTaskExecutionUI) StepsExecutionUI(t *Task) StepsExecutionUI {
+	return NoopStepsExecUI{}
 }
 
 var _ taskExecutor = &dummyExecutor{}

--- a/internal/batches/executor/executor.go
+++ b/internal/batches/executor/executor.go
@@ -176,11 +176,6 @@ func (x *executor) do(ctx context.Context, task *Task, ui TaskExecutionUI) (err 
 		tempDir:     x.opts.TempDir,
 
 		ui: ui.StepsExecutionUI(task),
-		// reportProgress: func(currentlyExecuting string) {
-		// 	ui.TaskCurrentlyExecuting(task, currentlyExecuting)
-		// },
-		// newUiStdoutWriter: ui.StepStdoutWriter,
-		// newUiStderrWriter: ui.StepStderrWriter,
 	}
 
 	result, stepResults, err := runSteps(runCtx, opts)

--- a/internal/batches/executor/executor.go
+++ b/internal/batches/executor/executor.go
@@ -174,11 +174,13 @@ func (x *executor) do(ctx context.Context, task *Task, ui TaskExecutionUI) (err 
 		wc:          x.opts.Creator,
 		ensureImage: x.opts.EnsureImage,
 		tempDir:     x.opts.TempDir,
-		reportProgress: func(currentlyExecuting string) {
-			ui.TaskCurrentlyExecuting(task, currentlyExecuting)
-		},
-		newUiStdoutWriter: ui.StepStdoutWriter,
-		newUiStderrWriter: ui.StepStderrWriter,
+
+		ui: ui.StepsExecutionUI(task),
+		// reportProgress: func(currentlyExecuting string) {
+		// 	ui.TaskCurrentlyExecuting(task, currentlyExecuting)
+		// },
+		// newUiStdoutWriter: ui.StepStdoutWriter,
+		// newUiStderrWriter: ui.StepStderrWriter,
 	}
 
 	result, stepResults, err := runSteps(runCtx, opts)

--- a/internal/batches/executor/run_steps.go
+++ b/internal/batches/executor/run_steps.go
@@ -69,10 +69,6 @@ type executionOpts struct {
 	logger log.TaskLogger
 
 	ui StepsExecutionUI
-	// reportProgress func(string)
-
-	// newUiStdoutWriter func(context.Context, *Task, int) io.WriteCloser
-	// newUiStderrWriter func(context.Context, *Task, int) io.WriteCloser
 }
 
 func runSteps(ctx context.Context, opts *executionOpts) (result executionResult, stepResults []stepExecutionResult, err error) {
@@ -125,12 +121,6 @@ func runSteps(ctx context.Context, opts *executionOpts) (result executionResult,
 		}
 
 		opts.ui.SkippingStepsUpto(startStep)
-		// switch startStep {
-		// case 1:
-		// 	opts.reportProgress("Skipping step 1. Found cached result.")
-		// default:
-		// 	opts.reportProgress(fmt.Sprintf("Skipping steps 1 to %d. Found cached results.", startStep))
-		// }
 	}
 
 	for i := startStep; i < len(opts.task.Steps); i++ {
@@ -164,7 +154,6 @@ func runSteps(ctx context.Context, opts *executionOpts) (result executionResult,
 			return execResult, nil, errors.Wrap(err, "evaluating step condition")
 		}
 		if !cond {
-			// opts.reportProgress(fmt.Sprintf("Skipping step %d", i+1))
 			opts.ui.StepSkipped(i + 1)
 			continue
 		}
@@ -245,7 +234,6 @@ func executeSingleStep(
 	// ----------
 	// PREPARATION
 	// ----------
-	// opts.reportProgress(fmt.Sprintf("Preparing step %d", i+1))
 	opts.ui.StepPreparing(i + 1)
 
 	cidFile, cleanup, err := createCidFile(ctx, opts.tempDir, util.SlugForRepo(opts.task.Repository.Name, opts.task.Repository.Rev()))
@@ -288,7 +276,6 @@ func executeSingleStep(
 	// ----------
 	// EXECUTION
 	// ----------
-	// opts.reportProgress(runScript)
 	opts.ui.StepStarted(i+1, runScript)
 
 	workspaceOpts, err := workspace.DockerRunOpts(ctx, workDir)

--- a/internal/batches/executor/ui.go
+++ b/internal/batches/executor/ui.go
@@ -1,0 +1,72 @@
+package executor
+
+import (
+	"context"
+	"io"
+
+	batcheslib "github.com/sourcegraph/sourcegraph/lib/batches"
+	"github.com/sourcegraph/sourcegraph/lib/batches/git"
+)
+
+type TaskExecutionUI interface {
+	Start([]*Task)
+	Success()
+
+	TaskStarted(*Task)
+	TaskFinished(*Task, error)
+
+	TaskChangesetSpecsBuilt(*Task, []*batcheslib.ChangesetSpec)
+
+	StepsExecutionUI(*Task) StepsExecutionUI
+}
+
+type StepsExecutionUI interface {
+	ArchiveDownloadStarted()
+	ArchiveDownloadFinished()
+
+	WorkspaceInitializationStarted()
+	WorkspaceInitializationFinished()
+
+	SkippingStepsUpto(int)
+
+	StepSkipped(int)
+
+	StepPreparing(int)
+	StepStarted(int, string)
+
+	StepStdoutWriter(context.Context, *Task, int) io.WriteCloser
+	StepStderrWriter(context.Context, *Task, int) io.WriteCloser
+
+	CalculatingDiffStarted()
+	CalculatingDiffFinished()
+
+	StepFinished(idx int, diff []byte, changes *git.Changes, outputs map[string]interface{})
+}
+
+// NoopStepsExecUI is an implementation of StepsExecutionUI that does nothing.
+type NoopStepsExecUI struct{}
+
+func (noop NoopStepsExecUI) ArchiveDownloadStarted()                {}
+func (noop NoopStepsExecUI) ArchiveDownloadFinished()               {}
+func (noop NoopStepsExecUI) WorkspaceInitializationStarted()        {}
+func (noop NoopStepsExecUI) WorkspaceInitializationFinished()       {}
+func (noop NoopStepsExecUI) SkippingStepsUpto(startStep int)        {}
+func (noop NoopStepsExecUI) StepSkipped(step int)                   {}
+func (noop NoopStepsExecUI) StepPreparing(step int)                 {}
+func (noop NoopStepsExecUI) StepStarted(step int, runScript string) {}
+func (noop NoopStepsExecUI) StepStdoutWriter(ctx context.Context, task *Task, step int) io.WriteCloser {
+	return discardCloser{io.Discard}
+}
+func (noop NoopStepsExecUI) StepStderrWriter(ctx context.Context, task *Task, step int) io.WriteCloser {
+	return discardCloser{io.Discard}
+}
+func (noop NoopStepsExecUI) CalculatingDiffStarted()  {}
+func (noop NoopStepsExecUI) CalculatingDiffFinished() {}
+func (noop NoopStepsExecUI) StepFinished(idx int, diff []byte, changes *git.Changes, outputs map[string]interface{}) {
+}
+
+type discardCloser struct {
+	io.Writer
+}
+
+func (discardCloser) Close() error { return nil }

--- a/internal/batches/ui/json_lines.go
+++ b/internal/batches/ui/json_lines.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sourcegraph/src-cli/internal/batches/workspace"
 
 	batcheslib "github.com/sourcegraph/sourcegraph/lib/batches"
+	"github.com/sourcegraph/sourcegraph/lib/batches/git"
 )
 
 var _ ExecUI = &JSONLines{}
@@ -290,37 +291,97 @@ func (ui *taskExecutionJSONLines) TaskChangesetSpecsBuilt(task *executor.Task, s
 	}})
 }
 
-func (ui *taskExecutionJSONLines) TaskCurrentlyExecuting(task *executor.Task, message string) {
+func (ui *taskExecutionJSONLines) StepsExecutionUI(task *executor.Task) executor.StepsExecutionUI {
 	lt, ok := ui.linesTasks[task]
 	if !ok {
 		panic("unknown task started")
 	}
 
-	logEvent(batchesLogEvent{
-		Operation: "EXECUTING_TASK",
-		Status:    "PROGRESS",
-		Message:   message,
-		Metadata: map[string]interface{}{
-			"task": lt,
-		},
-	})
+	return &stepsExecutionJSONLines{linesTask: &lt}
+}
+
+type stepsExecutionJSONLines struct {
+	linesTask *jsonLinesTask
 }
 
 const stepFlushDuration = 500 * time.Millisecond
 
-func (ui *taskExecutionJSONLines) StepStdoutWriter(ctx context.Context, task *executor.Task, step int) io.WriteCloser {
-	lt, ok := ui.linesTasks[task]
-	if !ok {
-		panic("unknown task started")
-	}
+func (ui *stepsExecutionJSONLines) ArchiveDownloadStarted() {
+	logEvent(batchesLogEvent{
+		Operation: "TASK_DOWNLOADING_ARCHIVE",
+		Status:    "STARTED",
+		Message:   "Downloading archive",
+		Metadata:  map[string]interface{}{"task": ui.linesTask},
+	})
+}
 
+func (ui *stepsExecutionJSONLines) ArchiveDownloadFinished() {
+	logEvent(batchesLogEvent{
+		Operation: "TASK_DOWNLOADING_ARCHIVE",
+		Status:    "FINISHED",
+		Metadata:  map[string]interface{}{"task": ui.linesTask},
+	})
+}
+func (ui *stepsExecutionJSONLines) WorkspaceInitializationStarted() {
+	logEvent(batchesLogEvent{
+		Operation: "TASK_INITIALIZING_WORKSPACE",
+		Status:    "STARTED",
+		Message:   "Initializing workspace",
+		Metadata:  map[string]interface{}{"task": ui.linesTask},
+	})
+}
+func (ui *stepsExecutionJSONLines) WorkspaceInitializationFinished() {
+	logEvent(batchesLogEvent{
+		Operation: "TASK_INITIALIZING_WORKSPACE",
+		Status:    "FINISHED",
+		Metadata:  map[string]interface{}{"task": ui.linesTask},
+	})
+}
+
+func (ui *stepsExecutionJSONLines) SkippingStepsUpto(startStep int) {
+	logEvent(batchesLogEvent{
+		Operation: "TASK_SKIPPING_STEPS",
+		Status:    "PROGRESS",
+		Message:   fmt.Sprintf("Skipping steps. Starting at %d.", startStep),
+		Metadata:  map[string]interface{}{"task": ui.linesTask, "startStep": startStep},
+	})
+}
+
+func (ui *stepsExecutionJSONLines) StepSkipped(step int) {
+	logEvent(batchesLogEvent{
+		Operation: "TASK_STEP_SKIPPED",
+		Status:    "PROGRESS",
+		Message:   fmt.Sprintf("Skipping step %d.", step),
+		Metadata:  map[string]interface{}{"task": ui.linesTask, "step": step},
+	})
+}
+
+func (ui *stepsExecutionJSONLines) StepPreparing(step int) {
+	logEvent(batchesLogEvent{
+		Operation: "TASK_PREPARING_STEP",
+		Status:    "PROGRESS",
+		Message:   fmt.Sprintf("Preparing step %d.", step),
+		Metadata:  map[string]interface{}{"task": ui.linesTask, "step": step},
+	})
+}
+
+func (ui *stepsExecutionJSONLines) StepStarted(step int, runScript string) {
+	logEvent(batchesLogEvent{
+		Operation: "STEP",
+		Status:    "STARTED",
+		Message:   fmt.Sprintf("Starting step %d", step),
+		Metadata:  map[string]interface{}{"task": ui.linesTask, "step": step, "runScript": runScript},
+	})
+}
+
+func (ui *stepsExecutionJSONLines) StepStdoutWriter(ctx context.Context, task *executor.Task, step int) io.WriteCloser {
 	sink := func(data string) {
 		logEvent(batchesLogEvent{
 			Operation: "STEP",
 			Status:    "PROGRESS",
 			Message:   data,
 			Metadata: map[string]interface{}{
-				"task":        lt,
+				"task":        ui.linesTask,
 				"step":        step,
 				"output_type": "stdout",
 			},
@@ -329,19 +390,14 @@ func (ui *taskExecutionJSONLines) StepStdoutWriter(ctx context.Context, task *ex
 	return NewIntervalWriter(ctx, stepFlushDuration, sink)
 }
 
-func (ui *taskExecutionJSONLines) StepStderrWriter(ctx context.Context, task *executor.Task, step int) io.WriteCloser {
-	lt, ok := ui.linesTasks[task]
-	if !ok {
-		panic("unknown task started")
-	}
-
+func (ui *stepsExecutionJSONLines) StepStderrWriter(ctx context.Context, task *executor.Task, step int) io.WriteCloser {
 	sink := func(data string) {
 		logEvent(batchesLogEvent{
 			Operation: "STEP",
 			Status:    "PROGRESS",
 			Message:   data,
 			Metadata: map[string]interface{}{
-				"task":        lt,
+				"task":        ui.linesTask,
 				"step":        step,
 				"output_type": "stderr",
 			},
@@ -349,4 +405,34 @@ func (ui *taskExecutionJSONLines) StepStderrWriter(ctx context.Context, task *ex
 	}
 
 	return NewIntervalWriter(ctx, stepFlushDuration, sink)
+}
+
+func (ui *stepsExecutionJSONLines) StepFinished(step int, diff []byte, changes *git.Changes, outputs map[string]interface{}) {
+	logEvent(batchesLogEvent{
+		Operation: "STEP",
+		Status:    "SUCCESS",
+		Message:   fmt.Sprintf("Finished step %d", step),
+		Metadata: map[string]interface{}{
+			"task":    ui.linesTask,
+			"step":    step,
+			"diff":    string(diff),
+			"changes": changes,
+			"outputs": outputs,
+		},
+	})
+}
+
+func (ui *stepsExecutionJSONLines) CalculatingDiffStarted()  {
+	logEvent(batchesLogEvent{
+		Operation: "TASK_CALCULATING_DIFF",
+		Status:    "STARTED",
+		Metadata:  map[string]interface{}{"task": ui.linesTask},
+	})
+}
+func (ui *stepsExecutionJSONLines) CalculatingDiffFinished() {
+	logEvent(batchesLogEvent{
+		Operation: "TASK_CALCULATING_DIFF",
+		Status:    "SUCCESS",
+		Metadata:  map[string]interface{}{"task": ui.linesTask},
+	})
 }

--- a/internal/batches/ui/json_lines.go
+++ b/internal/batches/ui/json_lines.go
@@ -422,7 +422,7 @@ func (ui *stepsExecutionJSONLines) StepFinished(step int, diff []byte, changes *
 	})
 }
 
-func (ui *stepsExecutionJSONLines) CalculatingDiffStarted()  {
+func (ui *stepsExecutionJSONLines) CalculatingDiffStarted() {
 	logEvent(batchesLogEvent{
 		Operation: "TASK_CALCULATING_DIFF",
 		Status:    "STARTED",

--- a/internal/batches/ui/task_exec_tui.go
+++ b/internal/batches/ui/task_exec_tui.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sourcegraph/src-cli/internal/batches/executor"
 
 	batcheslib "github.com/sourcegraph/sourcegraph/lib/batches"
+	"github.com/sourcegraph/sourcegraph/lib/batches/git"
 	"github.com/sourcegraph/sourcegraph/lib/output"
 )
 
@@ -218,18 +219,29 @@ func (ui *taskExecTUI) TaskCurrentlyExecuting(task *executor.Task, message strin
 	ui.progress.StatusBarUpdatef(bar, ts.String())
 }
 
-type discardCloser struct {
-	io.Writer
-}
+func (ui *taskExecTUI) StepsExecutionUI(task *executor.Task) executor.StepsExecutionUI {
+	ui.mu.Lock()
+	defer ui.mu.Unlock()
 
-func (discardCloser) Close() error { return nil }
+	ts, ok := ui.statuses[task]
+	if !ok {
+		ui.out.Verbose("warning: task not found in internal 'statuses'")
+		return executor.NoopStepsExecUI{}
+	}
 
-func (ui *taskExecTUI) StepStdoutWriter(ctx context.Context, task *executor.Task, stepidx int) io.WriteCloser {
-	return discardCloser{io.Discard}
-}
+	bar, found := ui.findStatusBar(ts)
+	if !found {
+		ui.out.Verbose("warning: no free status bar found to display task status")
+		return executor.NoopStepsExecUI{}
+	}
 
-func (ui *taskExecTUI) StepStderrWriter(ctx context.Context, task *executor.Task, stepidx int) io.WriteCloser {
-	return discardCloser{io.Discard}
+	return &stepsExecTUI{
+		task: task,
+		updateStatusBar: func(message string) {
+			ts.currentlyExecuting = message
+			ui.progress.StatusBarUpdatef(bar, message)
+		},
+	}
 }
 
 func (ui *taskExecTUI) TaskFinished(task *executor.Task, err error) {
@@ -413,3 +425,54 @@ func diffStatDiagram(stat diff.Stat) string {
 		output.StyleReset,
 	)
 }
+
+type stepsExecTUI struct {
+	task            *executor.Task
+	updateStatusBar func(string)
+}
+
+func (ui stepsExecTUI) ArchiveDownloadStarted() {
+	ui.updateStatusBar("Downloading archive")
+}
+func (ui stepsExecTUI) ArchiveDownloadFinished() {}
+func (ui stepsExecTUI) WorkspaceInitializationStarted() {
+	ui.updateStatusBar("Initializing workspace")
+}
+func (ui stepsExecTUI) WorkspaceInitializationFinished() {}
+func (ui stepsExecTUI) SkippingStepsUpto(startStep int) {
+	switch startStep {
+	case 1:
+		ui.updateStatusBar("Skipping step 1. Found cached result.")
+	default:
+		ui.updateStatusBar(fmt.Sprintf("Skipping steps 1 to %d. Found cached results.", startStep))
+	}
+}
+
+func (ui stepsExecTUI) StepSkipped(step int) {
+	ui.updateStatusBar(fmt.Sprintf("Skipping step %d", step))
+}
+func (ui stepsExecTUI) StepPreparing(step int) {
+	ui.updateStatusBar(fmt.Sprintf("Preparing %d", step))
+}
+func (ui stepsExecTUI) StepStarted(step int, runScript string) {
+	ui.updateStatusBar(runScript)
+}
+
+func (ui stepsExecTUI) StepStdoutWriter(ctx context.Context, task *executor.Task, step int) io.WriteCloser {
+	return discardCloser{io.Discard}
+}
+func (ui stepsExecTUI) StepStderrWriter(ctx context.Context, task *executor.Task, step int) io.WriteCloser {
+	return discardCloser{io.Discard}
+}
+func (ui stepsExecTUI) CalculatingDiffStarted() {
+	ui.updateStatusBar("Calculating diff")
+}
+func (ui stepsExecTUI) CalculatingDiffFinished() {
+	// noop right now
+}
+func (ui stepsExecTUI) StepFinished(idx int, diff []byte, changes *git.Changes, outputs map[string]interface{}) {
+	// noop right now
+}
+
+type discardCloser struct{ io.Writer }
+func (discardCloser) Close() error { return nil }

--- a/internal/batches/ui/task_exec_tui.go
+++ b/internal/batches/ui/task_exec_tui.go
@@ -239,7 +239,7 @@ func (ui *taskExecTUI) StepsExecutionUI(task *executor.Task) executor.StepsExecu
 		task: task,
 		updateStatusBar: func(message string) {
 			ts.currentlyExecuting = message
-			ui.progress.StatusBarUpdatef(bar, message)
+			ui.progress.StatusBarUpdatef(bar, ts.String())
 		},
 	}
 }

--- a/internal/batches/ui/task_exec_tui.go
+++ b/internal/batches/ui/task_exec_tui.go
@@ -475,4 +475,5 @@ func (ui stepsExecTUI) StepFinished(idx int, diff []byte, changes *git.Changes, 
 }
 
 type discardCloser struct{ io.Writer }
+
 func (discardCloser) Close() error { return nil }


### PR DESCRIPTION
This is a follow-up to https://github.com/sourcegraph/src-cli/pull/597 and splits up the existing interface into two.

That allows us to remove all formatting from `runSteps` and `executeSingleStep` and also provide more information for the JSON interface (e.g. when a step is finished).

**Note**: the `OPERATION` and `STATUS` fields in the `logEvents` don't make a lot of sense. Happy to change everything there. 