### PR TITLE
For internal use only: add `src batches exec` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to `src-cli` are documented in this file.
 
 ### Added
 
+- For internal use only: the `src batch exec` command executes the provided batch spec in the given workspaces.
+
 ### Changed
 
 ### Fixed

--- a/cmd/src/batch_apply.go
+++ b/cmd/src/batch_apply.go
@@ -5,10 +5,9 @@ import (
 	"flag"
 	"fmt"
 
+	"github.com/sourcegraph/sourcegraph/lib/output"
 	"github.com/sourcegraph/src-cli/internal/batches/ui"
 	"github.com/sourcegraph/src-cli/internal/cmderrors"
-
-	"github.com/sourcegraph/sourcegraph/lib/output"
 )
 
 func init() {

--- a/cmd/src/batch_apply.go
+++ b/cmd/src/batch_apply.go
@@ -5,9 +5,10 @@ import (
 	"flag"
 	"fmt"
 
-	"github.com/sourcegraph/sourcegraph/lib/output"
 	"github.com/sourcegraph/src-cli/internal/batches/ui"
 	"github.com/sourcegraph/src-cli/internal/cmderrors"
+
+	"github.com/sourcegraph/sourcegraph/lib/output"
 )
 
 func init() {
@@ -28,7 +29,7 @@ Examples:
 `
 
 	flagSet := flag.NewFlagSet("apply", flag.ExitOnError)
-	flags := newBatchExecuteFlags(flagSet, batchDefaultCacheDir(), batchDefaultTempDirPrefix())
+	flags := newBatchExecuteFlags(flagSet, false, batchDefaultCacheDir(), batchDefaultTempDirPrefix())
 
 	handler := func(args []string) error {
 		if err := flagSet.Parse(args); err != nil {

--- a/cmd/src/batch_common.go
+++ b/cmd/src/batch_common.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/hashicorp/go-multierror"
-
 	batcheslib "github.com/sourcegraph/sourcegraph/lib/batches"
 
 	"github.com/sourcegraph/src-cli/internal/api"

--- a/cmd/src/batch_common.go
+++ b/cmd/src/batch_common.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/hashicorp/go-multierror"
+
 	batcheslib "github.com/sourcegraph/sourcegraph/lib/batches"
 
 	"github.com/sourcegraph/src-cli/internal/api"

--- a/cmd/src/batch_common.go
+++ b/cmd/src/batch_common.go
@@ -49,27 +49,39 @@ type batchExecuteFlags struct {
 	textOnly bool
 }
 
-func newBatchExecuteFlags(flagSet *flag.FlagSet, cacheDir, tempDir string) *batchExecuteFlags {
+func newBatchExecuteFlags(flagSet *flag.FlagSet, workspaceExecution bool, cacheDir, tempDir string) *batchExecuteFlags {
 	caf := &batchExecuteFlags{
 		api: api.NewFlags(flagSet),
 	}
 
-	flagSet.BoolVar(
-		&caf.textOnly, "text-only", false,
-		"INTERNAL USE ONLY. EXPERIMENTAL. Switches off the TUI to only print JSON lines.",
-	)
-	flagSet.BoolVar(
-		&caf.allowUnsupported, "allow-unsupported", false,
-		"Allow unsupported code hosts.",
-	)
-	flagSet.BoolVar(
-		&caf.allowIgnored, "force-override-ignore", false,
-		"Do not ignore repositories that have a .batchignore file.",
-	)
-	flagSet.BoolVar(
-		&caf.apply, "apply", false,
-		"Ignored.",
-	)
+	if !workspaceExecution {
+		flagSet.BoolVar(
+			&caf.textOnly, "text-only", false,
+			"INTERNAL USE ONLY. EXPERIMENTAL. Switches off the TUI to only print JSON lines.",
+		)
+		flagSet.BoolVar(
+			&caf.allowUnsupported, "allow-unsupported", false,
+			"Allow unsupported code hosts.",
+		)
+		flagSet.BoolVar(
+			&caf.allowIgnored, "force-override-ignore", false,
+			"Do not ignore repositories that have a .batchignore file.",
+		)
+		flagSet.BoolVar(
+			&caf.apply, "apply", false,
+			"Ignored.",
+		)
+		flagSet.BoolVar(
+			&caf.keepLogs, "keep-logs", false,
+			"Retain logs after executing steps.",
+		)
+		flagSet.StringVar(
+			&caf.namespace, "namespace", "",
+			"The user or organization namespace to place the batch change within. Default is the currently authenticated user.",
+		)
+		flagSet.StringVar(&caf.namespace, "n", "", "Alias for -namespace.")
+	}
+
 	flagSet.StringVar(
 		&caf.cacheDir, "cache", cacheDir,
 		"Directory for caching results and repository archives.",
@@ -82,19 +94,11 @@ func newBatchExecuteFlags(flagSet *flag.FlagSet, cacheDir, tempDir string) *batc
 		&caf.tempDir, "tmp", tempDir,
 		"Directory for storing temporary data, such as log files. Default is /tmp. Can also be set with environment variable SRC_BATCH_TMP_DIR; if both are set, this flag will be used and not the environment variable.",
 	)
+
 	flagSet.StringVar(
 		&caf.file, "f", "",
 		"The batch spec file to read.",
 	)
-	flagSet.BoolVar(
-		&caf.keepLogs, "keep-logs", false,
-		"Retain logs after executing steps.",
-	)
-	flagSet.StringVar(
-		&caf.namespace, "namespace", "",
-		"The user or organization namespace to place the batch change within. Default is the currently authenticated user.",
-	)
-	flagSet.StringVar(&caf.namespace, "n", "", "Alias for -namespace.")
 
 	flagSet.IntVar(
 		&caf.parallelism, "j", runtime.GOMAXPROCS(0),

--- a/cmd/src/batch_exec.go
+++ b/cmd/src/batch_exec.go
@@ -84,8 +84,8 @@ type SerializeableWorkspace struct {
 		Name string `json:"name"`
 	} `json:"repository"`
 	Branch struct {
-		AbbrevName string `json:"abbrevName"`
-		Target     struct {
+		Name   string `json:"name"`
+		Target struct {
 			OID string `json:"oid"`
 		} `json:"target"`
 	} `json:"branch"`
@@ -109,14 +109,14 @@ func (ws SerializeableWorkspaces) ToRepoWorkspaces() []service.RepoWorkspace {
 				ID:   w.Repository.ID,
 				Name: w.Repository.Name,
 				Branch: graphql.Branch{
-					Name: w.Branch.AbbrevName,
+					Name: w.Branch.Name,
 					Target: graphql.Target{
 						OID: w.Branch.Target.OID,
 					},
 				},
 				ExternalRepository: struct{ ServiceType string }{ServiceType: "github"},
 				DefaultBranch: &graphql.Branch{
-					Name: w.Branch.AbbrevName,
+					Name: w.Branch.Name,
 					Target: graphql.Target{
 						OID: w.Branch.Target.OID,
 					},

--- a/cmd/src/batch_exec.go
+++ b/cmd/src/batch_exec.go
@@ -73,9 +73,10 @@ Examples:
 	})
 }
 
+// TODO: Put this in `lib` and use it here and in backend
 type WorkspacesResult struct {
-	RawSpec    string                  `json:"rawSpec"`
-	Workspaces SerializeableWorkspaces `json:"workspaces"`
+	RawSpec    string                    `json:"rawSpec"`
+	Workspaces []*SerializeableWorkspace `json:"workspaces"`
 }
 
 type SerializeableWorkspace struct {
@@ -95,9 +96,7 @@ type SerializeableWorkspace struct {
 	SearchResultPaths  []string          `json:"searchResultPaths"`
 }
 
-type SerializeableWorkspaces []*SerializeableWorkspace
-
-func (ws SerializeableWorkspaces) ToRepoWorkspaces() []service.RepoWorkspace {
+func convertWorkspaces(ws []*SerializeableWorkspace) []service.RepoWorkspace {
 	workspaces := make([]service.RepoWorkspace, 0, len(ws))
 	for _, w := range ws {
 		fileMatches := make(map[string]bool)
@@ -217,7 +216,7 @@ func executeBatchSpecInWorkspaces(ctx context.Context, opts executeBatchSpecOpts
 	})
 
 	opts.ui.CheckingCache()
-	tasks := svc.BuildTasks(ctx, batchSpec, input.Workspaces.ToRepoWorkspaces())
+	tasks := svc.BuildTasks(ctx, batchSpec, convertWorkspaces(input.Workspaces))
 	uncachedTasks, cachedSpecs, err := coord.CheckCache(ctx, tasks)
 	if err != nil {
 		return err

--- a/cmd/src/batch_exec.go
+++ b/cmd/src/batch_exec.go
@@ -1,0 +1,257 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+
+	"github.com/cockroachdb/errors"
+	"github.com/hashicorp/go-multierror"
+	"github.com/sourcegraph/src-cli/internal/batches/executor"
+	"github.com/sourcegraph/src-cli/internal/batches/graphql"
+	"github.com/sourcegraph/src-cli/internal/batches/service"
+	"github.com/sourcegraph/src-cli/internal/batches/ui"
+	"github.com/sourcegraph/src-cli/internal/batches/workspace"
+	"github.com/sourcegraph/src-cli/internal/cmderrors"
+
+	batcheslib "github.com/sourcegraph/sourcegraph/lib/batches"
+)
+
+func init() {
+	usage := `
+INTERNAL USER ONLY: 'src batch exec' executes the given raw batch spec in the given workspaces.
+
+Usage:
+
+    src batch exec -f batch-spec-with-workspaces.json
+
+Examples:
+
+    $ src batch apply -f batch-spec-with-workspaces.json
+`
+
+	flagSet := flag.NewFlagSet("exec", flag.ExitOnError)
+	flags := newBatchExecuteFlags(flagSet, batchDefaultCacheDir(), batchDefaultTempDirPrefix())
+
+	handler := func(args []string) error {
+		if err := flagSet.Parse(args); err != nil {
+			return err
+		}
+
+		if len(flagSet.Args()) != 0 {
+			return cmderrors.Usage("additional arguments not allowed")
+		}
+
+		// Only text output is allowed
+		flags.textOnly = true
+
+		ctx, cancel := contextCancelOnInterrupt(context.Background())
+		defer cancel()
+
+		err := executeBatchSpecInWorkspaces(ctx, executeBatchSpecOpts{
+			flags:  flags,
+			client: cfg.apiClient(flags.api, flagSet.Output()),
+			ui:     &ui.JSONLines{},
+		})
+		if err != nil {
+			return cmderrors.ExitCode(1, nil)
+		}
+
+		return nil
+	}
+
+	batchCommands = append(batchCommands, &command{
+		flagSet: flagSet,
+		handler: handler,
+		usageFunc: func() {
+			fmt.Fprintf(flag.CommandLine.Output(), "Usage of 'src batch %s':\n", flagSet.Name())
+			flagSet.PrintDefaults()
+			fmt.Println(usage)
+		},
+	})
+}
+
+type WorkspacesResult struct {
+	RawSpec    string                  `json:"rawSpec"`
+	Workspaces SerializeableWorkspaces `json:"workspaces"`
+}
+
+type SerializeableWorkspace struct {
+	Repository struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	} `json:"repository"`
+	Branch struct {
+		AbbrevName string `json:"abbrevName"`
+		Target     struct {
+			OID string `json:"oid"`
+		} `json:"target"`
+	} `json:"branch"`
+	Path               string            `json:"path"`
+	OnlyFetchWorkspace bool              `json:"onlyFetchWorkspace"`
+	Steps              []batcheslib.Step `json:"steps"`
+	SearchResultPaths  []string          `json:"searchResultPaths"`
+}
+
+type SerializeableWorkspaces []*SerializeableWorkspace
+
+func (ws SerializeableWorkspaces) ToRepoWorkspaces() []service.RepoWorkspace {
+	workspaces := make([]service.RepoWorkspace, 0, len(ws))
+	for _, w := range ws {
+		fileMatches := make(map[string]bool)
+		for _, path := range w.SearchResultPaths {
+			fileMatches[path] = true
+		}
+		workspaces = append(workspaces, service.RepoWorkspace{
+			Repo: &graphql.Repository{
+				ID:   w.Repository.ID,
+				Name: w.Repository.Name,
+				Branch: graphql.Branch{
+					Name: w.Branch.AbbrevName,
+					Target: graphql.Target{
+						OID: w.Branch.Target.OID,
+					},
+				},
+				ExternalRepository: struct{ ServiceType string }{ServiceType: "github"},
+				DefaultBranch: &graphql.Branch{
+					Name: w.Branch.AbbrevName,
+					Target: graphql.Target{
+						OID: w.Branch.Target.OID,
+					},
+				},
+				Commit:      graphql.Target{OID: w.Branch.Target.OID},
+				FileMatches: fileMatches,
+			},
+			Path:               w.Path,
+			Steps:              w.Steps,
+			OnlyFetchWorkspace: w.OnlyFetchWorkspace,
+		})
+	}
+	return workspaces
+}
+
+func executeBatchSpecInWorkspaces(ctx context.Context, opts executeBatchSpecOpts) (err error) {
+	defer func() {
+		if err != nil {
+			opts.ui.ExecutionError(err)
+		}
+	}()
+
+	svc := service.New(&service.Opts{
+		AllowUnsupported: opts.flags.allowUnsupported,
+		AllowIgnored:     opts.flags.allowIgnored,
+		Client:           opts.client,
+	})
+	if err := svc.DetermineFeatureFlags(ctx); err != nil {
+		return err
+	}
+
+	if err := checkExecutable("git", "version"); err != nil {
+		return err
+	}
+	if err := checkExecutable("docker", "version"); err != nil {
+		return err
+	}
+
+	f, err := batchOpenFileFlag(&opts.flags.file)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	data, err := io.ReadAll(f)
+	if err != nil {
+		return errors.Wrap(err, "reading batch spec")
+	}
+
+	var input WorkspacesResult
+	if err := json.Unmarshal(data, &input); err != nil {
+		return errors.Wrap(err, "unmarshaling input file")
+	}
+
+	// Parse flags and build up our service and executor options.
+	opts.ui.ParsingBatchSpec()
+	batchSpec, err := svc.ParseBatchSpec([]byte(input.RawSpec))
+	if err != nil {
+		if merr, ok := err.(*multierror.Error); ok {
+			opts.ui.ParsingBatchSpecFailure(merr)
+			return cmderrors.ExitCode(2, nil)
+		} else {
+			// This shouldn't happen; let's just punt and let the normal
+			// rendering occur.
+			return err
+		}
+	}
+	opts.ui.ParsingBatchSpecSuccess()
+
+	opts.ui.PreparingContainerImages()
+	images, err := svc.EnsureDockerImages(ctx, batchSpec, opts.ui.PreparingContainerImagesProgress)
+	if err != nil {
+		return err
+	}
+	opts.ui.PreparingContainerImagesSuccess()
+
+	opts.ui.DeterminingWorkspaceCreatorType()
+	workspaceCreator := workspace.NewCreator(ctx, opts.flags.workspace, opts.flags.cacheDir, opts.flags.tempDir, images)
+	if workspaceCreator.Type() == workspace.CreatorTypeVolume {
+		_, err = svc.EnsureImage(ctx, workspace.DockerVolumeWorkspaceImage)
+		if err != nil {
+			return err
+		}
+	}
+	opts.ui.DeterminingWorkspaceCreatorTypeSuccess(workspaceCreator.Type())
+
+	// EXECUTION OF TASKS
+	coord := svc.NewCoordinator(executor.NewCoordinatorOpts{
+		Creator:       workspaceCreator,
+		CacheDir:      opts.flags.cacheDir,
+		ClearCache:    opts.flags.clearCache,
+		SkipErrors:    opts.flags.skipErrors,
+		CleanArchives: opts.flags.cleanArchives,
+		Parallelism:   opts.flags.parallelism,
+		Timeout:       opts.flags.timeout,
+		KeepLogs:      opts.flags.keepLogs,
+		TempDir:       opts.flags.tempDir,
+	})
+
+	opts.ui.CheckingCache()
+	tasks := svc.BuildTasks(ctx, batchSpec, input.Workspaces.ToRepoWorkspaces())
+	uncachedTasks, cachedSpecs, err := coord.CheckCache(ctx, tasks)
+	if err != nil {
+		return err
+	}
+	opts.ui.CheckingCacheSuccess(len(cachedSpecs), len(uncachedTasks))
+
+	taskExecUI := opts.ui.ExecutingTasks(*verbose, opts.flags.parallelism)
+	freshSpecs, _, err := coord.Execute(ctx, uncachedTasks, batchSpec, taskExecUI)
+	if err != nil && !opts.flags.skipErrors {
+		return err
+	}
+	taskExecUI.Success()
+	if err != nil && opts.flags.skipErrors {
+		opts.ui.ExecutingTasksSkippingErrors(err)
+	}
+
+	specs := append(cachedSpecs, freshSpecs...)
+
+	ids := make([]graphql.ChangesetSpecID, len(specs))
+
+	if len(specs) > 0 {
+		opts.ui.UploadingChangesetSpecs(len(specs))
+
+		for i, spec := range specs {
+			id, err := svc.CreateChangesetSpec(ctx, spec)
+			if err != nil {
+				return err
+			}
+			ids[i] = id
+			opts.ui.UploadingChangesetSpecsProgress(i+1, len(specs))
+		}
+
+		opts.ui.UploadingChangesetSpecsSuccess(ids)
+	}
+
+	return nil
+}

--- a/cmd/src/batch_exec.go
+++ b/cmd/src/batch_exec.go
@@ -222,18 +222,12 @@ func convertWorkspaces(ws []*batcheslib.Workspace) []service.RepoWorkspace {
 		for _, path := range w.SearchResultPaths {
 			fileMatches[path] = true
 		}
+
 		workspaces = append(workspaces, service.RepoWorkspace{
 			Repo: &graphql.Repository{
 				ID:   w.Repository.ID,
 				Name: w.Repository.Name,
 				Branch: graphql.Branch{
-					Name: w.Branch.Name,
-					Target: graphql.Target{
-						OID: w.Branch.Target.OID,
-					},
-				},
-				ExternalRepository: struct{ ServiceType string }{ServiceType: "github"},
-				DefaultBranch: &graphql.Branch{
 					Name: w.Branch.Name,
 					Target: graphql.Target{
 						OID: w.Branch.Target.OID,

--- a/cmd/src/batch_preview.go
+++ b/cmd/src/batch_preview.go
@@ -5,9 +5,10 @@ import (
 	"flag"
 	"fmt"
 
-	"github.com/sourcegraph/sourcegraph/lib/output"
 	"github.com/sourcegraph/src-cli/internal/batches/ui"
 	"github.com/sourcegraph/src-cli/internal/cmderrors"
+
+	"github.com/sourcegraph/sourcegraph/lib/output"
 )
 
 func init() {
@@ -26,7 +27,7 @@ Examples:
 `
 
 	flagSet := flag.NewFlagSet("preview", flag.ExitOnError)
-	flags := newBatchExecuteFlags(flagSet, batchDefaultCacheDir(), batchDefaultTempDirPrefix())
+	flags := newBatchExecuteFlags(flagSet, false, batchDefaultCacheDir(), batchDefaultTempDirPrefix())
 
 	handler := func(args []string) error {
 		if err := flagSet.Parse(args); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/sourcegraph/batch-change-utils v0.0.0-20210708162152-c9f35b905d94
 	github.com/sourcegraph/go-diff v0.6.1
 	github.com/sourcegraph/jsonx v0.0.0-20200629203448-1a936bd500cf
-	github.com/sourcegraph/sourcegraph/lib v0.0.0-20210907100420-bac67ad72375
+	github.com/sourcegraph/sourcegraph/lib v0.0.0-20210908093416-2bfda92388c7
 	github.com/ssor/bom v0.0.0-20170718123548-6386211fdfcf // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	golang.org/x/net v0.0.0-20210614182718-04defd469f4e

--- a/go.sum
+++ b/go.sum
@@ -261,8 +261,8 @@ github.com/sourcegraph/go-diff v0.6.1 h1:hmA1LzxW0n1c3Q4YbrFgg4P99GSnebYa3x8gr0H
 github.com/sourcegraph/go-diff v0.6.1/go.mod h1:iBszgVvyxdc8SFZ7gm69go2KDdt3ag071iBaWPF6cjs=
 github.com/sourcegraph/jsonx v0.0.0-20200629203448-1a936bd500cf h1:oAdWFqhStsWiiMP/vkkHiMXqFXzl1XfUNOdxKJbd6bI=
 github.com/sourcegraph/jsonx v0.0.0-20200629203448-1a936bd500cf/go.mod h1:ppFaPm6kpcHnZGqQTFhUIAQRIEhdQDWP1PCv4/ON354=
-github.com/sourcegraph/sourcegraph/lib v0.0.0-20210907100420-bac67ad72375 h1:LRWLkOq2jsxKpxAr1tu6JmY9xjmxZV9Rjae9VdtTtCQ=
-github.com/sourcegraph/sourcegraph/lib v0.0.0-20210907100420-bac67ad72375/go.mod h1:ZK8mHKWdapYI8iIQwsO7QUxf44RjiNGKkOZa9aYIjTc=
+github.com/sourcegraph/sourcegraph/lib v0.0.0-20210908093416-2bfda92388c7 h1:7Y110pCBLzr+V8xSTGjgkOh4fFFfOIVWaKw+wUSg1vY=
+github.com/sourcegraph/sourcegraph/lib v0.0.0-20210908093416-2bfda92388c7/go.mod h1:ZK8mHKWdapYI8iIQwsO7QUxf44RjiNGKkOZa9aYIjTc=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=

--- a/internal/batches/ui/tui.go
+++ b/internal/batches/ui/tui.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/hashicorp/go-multierror"
 	"github.com/neelance/parallel"
+
 	"github.com/sourcegraph/sourcegraph/lib/output"
 
 	"github.com/sourcegraph/src-cli/internal/api"

--- a/internal/batches/ui/tui.go
+++ b/internal/batches/ui/tui.go
@@ -8,7 +8,6 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/hashicorp/go-multierror"
 	"github.com/neelance/parallel"
-
 	"github.com/sourcegraph/sourcegraph/lib/output"
 
 	"github.com/sourcegraph/src-cli/internal/api"


### PR DESCRIPTION
This adds the for-internal-use-only `src batch exec` command that will be used by server-side batch changes to execute a batch spec in specific workspaces on different machines, concurrently.

**Note:** the vast majority of the added code you see here is copy&pasted from `batch_common.go`. I really _don't_ want to add more conditionals to the huge function in there though, so I created a new one. Yes, there's duplication, but it's so much easier to understand and to maintain. And we'll likely make a lot of changes to this new function here anyway, so effort to generalize and DRY this code will probably be wasted.

### Example


Given the following input file, `input.json`

```json
{
  "rawSpec": "\nname: text-only-output-4\ndescription: Just a test campaign spec to test text only output\n\non:\n  - repository: github.com/sourcegraph/automation-testing\n  # - repository: github.com/sourcegraph-testing/mkcert\n  # - repository: github.com/sourcegraph-testing/tidb\n  # - repository: github.com/sourcegraph-testing/titan\n  # - repository: github.com/sourcegraph-testing/etcd\n  # - repository: github.com/sourcegraph-testing/tiny-go-test-repository\n\nsteps:\n  - run: |\n      echo \"this is step 1\" >> README.txt\n      echo \"this is step 1\"\n      echo \"this is step 1\" 1>&2\n    container: alpine:3\n  - run: |\n      echo \"this is step 2\" >> README.md\n      echo \"this is step 2\"\n      echo \"this is step 2\" 1>&2\n    container: alpine:3\n  - run: |\n      echo \"this is step 3\" >> README.md\n      echo \"this is step 3\"\n      echo \"this is step 3\" 1>&2\n    container: alpine:3\n    outputs:\n      myOutput:\n        value: \"my-output.txt\"\n  - run: |\n      echo \"this is step 4\" >> README.md\n      cat README.md\n      echo \"previous_step.modified_files=${{ previous_step.modified_files }}\" >> README.md\n      ls -lrt\n    container: alpine:3\n  - run: echo \"this is step 5\" >> ${{ outputs.myOutput }}\n    container: alpine:3\n\nchangesetTemplate:\n  title: Testing step caching\n  body:  Testing step caching\n  branch: thorsten/text-only-output-2\n  published: true\n  commit:\n    message: Caching testing\n",
  "workspaces": [
    {
      "repository": {
        "id": "UmVwb3NpdG9yeTo3",
        "name": "github.com/sourcegraph/automation-testing"
      },
      "branch": {
        "abbrevName": "master",
        "target": {
          "oid": "d559e66a56e6615759f60f543475fd69e347f592"
        }
      },
      "path": "",
      "onlyFetchWorkspace": false,
      "steps": [
        {
          "run": "echo \"this is step 1\" >> README.txt\necho \"this is step 1\"\necho \"this is step 1\" 1>&2",
          "container": "alpine:3",
          "env": {}
        }
      ],
      "searchResultPaths": []
    }
  ]
}
```

we can use `src batch exec` to execute the `workspaces.steps` (not the `steps` in the included raw batch spec!!) in the given `workspaces`:

```
src batch exec -f input.json
```