### PR TITLE
Streamline and improve JSON UI

### DIFF
--- a/cmd/src/batch_common.go
+++ b/cmd/src/batch_common.go
@@ -337,7 +337,7 @@ func executeBatchSpec(ctx context.Context, opts executeBatchSpecOpts) (err error
 			opts.ui.UploadingChangesetSpecsProgress(i+1, len(specs))
 		}
 
-		opts.ui.UploadingChangesetSpecsSuccess()
+		opts.ui.UploadingChangesetSpecsSuccess(ids)
 	} else if len(repos) == 0 {
 		opts.ui.NoChangesetSpecs()
 	}

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/cockroachdb/errors v1.8.6
 	github.com/cockroachdb/redact v1.1.3 // indirect
 	github.com/derision-test/glock v0.0.0-20210316032053-f5b74334bb29
+	github.com/dineshappavoo/basex v0.0.0-20170425072625-481a6f6dc663
 	github.com/dustin/go-humanize v1.0.0
 	github.com/gobwas/glob v0.2.3
 	github.com/google/go-cmp v0.5.6

--- a/go.sum
+++ b/go.sum
@@ -49,6 +49,8 @@ github.com/derision-test/go-mockgen v1.1.2/go.mod h1:9H3VGTWYnL1VJoHHCuPKDpPFmNQ
 github.com/dgraph-io/badger v1.6.0/go.mod h1:zwt7syl517jmP8s94KqSxTlM6IMsdhYy6psNgSztDR4=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
+github.com/dineshappavoo/basex v0.0.0-20170425072625-481a6f6dc663 h1:fctNkSsavbXpt8geFWZb8n+noCqS8MrOXRJ/YfdZ2dQ=
+github.com/dineshappavoo/basex v0.0.0-20170425072625-481a6f6dc663/go.mod h1:Kad2hux31v/IyD4Rf4wAwIyK48995rs3qAl9IUAhc2k=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/efritz/pentimento v0.0.0-20190429011147-ade47d831101/go.mod h1:5ALWO82UZwfAtNRUtwzsWimcrcuYzyieTyyXOXrP6EQ=

--- a/internal/batches/service/service.go
+++ b/internal/batches/service/service.go
@@ -152,9 +152,9 @@ func (svc *Service) CreateChangesetSpec(ctx context.Context, spec *batcheslib.Ch
 //
 // Progress information is reported back to the given progress function: perc
 // will be a value between 0.0 and 1.0, inclusive.
-func (svc *Service) EnsureDockerImages(ctx context.Context, spec *batcheslib.BatchSpec, progress func(perc float64)) (map[string]docker.Image, error) {
-	total := len(spec.Steps) + 1
-	progress(0)
+func (svc *Service) EnsureDockerImages(ctx context.Context, spec *batcheslib.BatchSpec, progress func(done, total int)) (map[string]docker.Image, error) {
+	total := len(spec.Steps)
+	progress(0, total)
 
 	// TODO: this _really_ should be parallelised, since the image cache takes
 	// care to only pull the same image once.
@@ -166,10 +166,9 @@ func (svc *Service) EnsureDockerImages(ctx context.Context, spec *batcheslib.Bat
 		}
 		images[spec.Steps[i].Container] = img
 
-		progress(float64(i) / float64(total))
+		progress(i+1, total)
 	}
 
-	progress(1)
 	return images, nil
 }
 

--- a/internal/batches/ui/exec_ui.go
+++ b/internal/batches/ui/exec_ui.go
@@ -16,7 +16,7 @@ type ExecUI interface {
 	ResolvingNamespaceSuccess(namespace string)
 
 	PreparingContainerImages()
-	PreparingContainerImagesProgress(percent float64)
+	PreparingContainerImagesProgress(done, total int)
 	PreparingContainerImagesSuccess()
 
 	DeterminingWorkspaceCreatorType()
@@ -39,7 +39,7 @@ type ExecUI interface {
 	NoChangesetSpecs()
 	UploadingChangesetSpecs(num int)
 	UploadingChangesetSpecsProgress(done, total int)
-	UploadingChangesetSpecsSuccess()
+	UploadingChangesetSpecsSuccess(ids []graphql.ChangesetSpecID)
 
 	CreatingBatchSpec()
 	CreatingBatchSpecSuccess()

--- a/internal/batches/ui/tui.go
+++ b/internal/batches/ui/tui.go
@@ -68,8 +68,8 @@ func (ui *TUI) PreparingContainerImages() {
 	}}, nil)
 }
 
-func (ui *TUI) PreparingContainerImagesProgress(percent float64) {
-	ui.progress.SetValue(0, percent)
+func (ui *TUI) PreparingContainerImagesProgress(done, total int) {
+	ui.progress.SetValue(0, float64(done)/float64(total))
 }
 
 func (ui *TUI) PreparingContainerImagesSuccess() {
@@ -181,7 +181,7 @@ func (ui *TUI) UploadingChangesetSpecsProgress(done, total int) {
 	ui.progress.SetValue(0, float64(done))
 }
 
-func (ui *TUI) UploadingChangesetSpecsSuccess() {
+func (ui *TUI) UploadingChangesetSpecsSuccess(ids []graphql.ChangesetSpecID) {
 	ui.progress.Complete()
 }
 


### PR DESCRIPTION
Next step I will move the step output definition into the shared lib, so we can use it server-side for parsing.

This requires a server-side change which I am going to publish when we release SRC CLI so we have a version match in the executors, too.