### PR TITLE
Print step output into a single buffer

### DIFF
--- a/internal/batches/executor/run_steps.go
+++ b/internal/batches/executor/run_steps.go
@@ -315,16 +315,14 @@ func executeSingleStep(
 
 	writerCtx, writerCancel := context.WithCancel(ctx)
 	defer writerCancel()
-	uiStdoutWriter := opts.ui.StepStdoutWriter(writerCtx, opts.task, i)
-	uiStderrWriter := opts.ui.StepStderrWriter(writerCtx, opts.task, i)
+	outputWriter := opts.ui.StepOutputWriter(writerCtx, opts.task, i)
 	defer func() {
-		uiStdoutWriter.Close()
-		uiStderrWriter.Close()
+		outputWriter.Close()
 	}()
 
 	var stdoutBuffer, stderrBuffer bytes.Buffer
-	stdout := io.MultiWriter(&stdoutBuffer, uiStdoutWriter, opts.logger.PrefixWriter("stdout"))
-	stderr := io.MultiWriter(&stderrBuffer, uiStderrWriter, opts.logger.PrefixWriter("stderr"))
+	stdout := io.MultiWriter(&stdoutBuffer, outputWriter.StdoutWriter(), opts.logger.PrefixWriter("stdout"))
+	stderr := io.MultiWriter(&stderrBuffer, outputWriter.StderrWriter(), opts.logger.PrefixWriter("stderr"))
 
 	// Setup readers that pipe the output into the given buffers
 	wg, err := process.PipeOutput(ctx, cmd, stdout, stderr)

--- a/internal/batches/executor/ui.go
+++ b/internal/batches/executor/ui.go
@@ -20,6 +20,12 @@ type TaskExecutionUI interface {
 	StepsExecutionUI(*Task) StepsExecutionUI
 }
 
+type StepOutputWriter interface {
+	StdoutWriter() io.Writer
+	StderrWriter() io.Writer
+	Close() error
+}
+
 type StepsExecutionUI interface {
 	ArchiveDownloadStarted()
 	ArchiveDownloadFinished()
@@ -34,8 +40,8 @@ type StepsExecutionUI interface {
 	StepPreparing(int)
 	StepStarted(int, string)
 
-	StepStdoutWriter(context.Context, *Task, int) io.WriteCloser
-	StepStderrWriter(context.Context, *Task, int) io.WriteCloser
+	StepOutputWriter(context.Context, *Task, int) StepOutputWriter
+	// StepStderrWriter(context.Context, *Task, int) io.WriteCloser
 
 	CalculatingDiffStarted()
 	CalculatingDiffFinished()
@@ -54,19 +60,16 @@ func (noop NoopStepsExecUI) SkippingStepsUpto(startStep int)        {}
 func (noop NoopStepsExecUI) StepSkipped(step int)                   {}
 func (noop NoopStepsExecUI) StepPreparing(step int)                 {}
 func (noop NoopStepsExecUI) StepStarted(step int, runScript string) {}
-func (noop NoopStepsExecUI) StepStdoutWriter(ctx context.Context, task *Task, step int) io.WriteCloser {
-	return discardCloser{io.Discard}
-}
-func (noop NoopStepsExecUI) StepStderrWriter(ctx context.Context, task *Task, step int) io.WriteCloser {
-	return discardCloser{io.Discard}
+func (noop NoopStepsExecUI) StepOutputWriter(ctx context.Context, task *Task, step int) StepOutputWriter {
+	return NoopStepOutputWriter{}
 }
 func (noop NoopStepsExecUI) CalculatingDiffStarted()  {}
 func (noop NoopStepsExecUI) CalculatingDiffFinished() {}
 func (noop NoopStepsExecUI) StepFinished(idx int, diff []byte, changes *git.Changes, outputs map[string]interface{}) {
 }
 
-type discardCloser struct {
-	io.Writer
-}
+type NoopStepOutputWriter struct{}
 
-func (discardCloser) Close() error { return nil }
+func (noop NoopStepOutputWriter) StdoutWriter() io.Writer { return io.Discard }
+func (noop NoopStepOutputWriter) StderrWriter() io.Writer { return io.Discard }
+func (noop NoopStepOutputWriter) Close() error            { return nil }

--- a/internal/batches/ui/interval_writer_test.go
+++ b/internal/batches/ui/interval_writer_test.go
@@ -20,7 +20,10 @@ func TestIntervalWriter(t *testing.T) {
 	ticker := glock.NewMockTicker(1 * time.Second)
 	writer := newIntervalWriter(ctx, ticker, sink)
 
-	writer.Write([]byte("1"))
+	stdoutWriter := writer.StdoutWriter()
+	stderrWriter := writer.StderrWriter()
+	stdoutWriter.Write([]byte("1"))
+	stderrWriter.Write([]byte("1"))
 	select {
 	case <-ch:
 		t.Fatalf("ch has data")
@@ -31,17 +34,22 @@ func TestIntervalWriter(t *testing.T) {
 
 	select {
 	case d := <-ch:
-		if d != "1" {
-			t.Fatalf("wrong data in sink")
+		want := "stdout: 1\nstderr: 1\n"
+		if d != want {
+			t.Fatalf("wrong data in sink. want=%q, have=%q", want, d)
 		}
 	case <-time.After(1 * time.Second):
 		t.Fatalf("ch has NO data")
 	}
 
-	writer.Write([]byte("2"))
-	writer.Write([]byte("3"))
-	writer.Write([]byte("4"))
-	writer.Write([]byte("5"))
+	stdoutWriter.Write([]byte("2"))
+	stderrWriter.Write([]byte("2"))
+	stdoutWriter.Write([]byte("3"))
+	stderrWriter.Write([]byte("3"))
+	stdoutWriter.Write([]byte("4"))
+	stderrWriter.Write([]byte("4"))
+	stdoutWriter.Write([]byte("5"))
+	stderrWriter.Write([]byte("5"))
 
 	select {
 	case <-ch:
@@ -54,8 +62,13 @@ func TestIntervalWriter(t *testing.T) {
 
 	select {
 	case d := <-ch:
-		if d != "2345" {
-			t.Fatalf("wrong data in sink")
+		want := "stdout: 2\nstderr: 2\n" +
+			"stdout: 3\nstderr: 3\n" +
+			"stdout: 4\nstderr: 4\n" +
+			"stdout: 5\nstderr: 5\n"
+
+		if d != want {
+			t.Fatalf("wrong data in sink. want")
 		}
 	case <-time.After(1 * time.Second):
 		t.Fatalf("ch has NO data")

--- a/internal/batches/ui/json_lines.go
+++ b/internal/batches/ui/json_lines.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"math/rand"
 	"os"
 	"strconv"
@@ -325,36 +324,34 @@ func (ui *stepsExecutionJSONLines) StepStarted(step int, runScript string) {
 	logOperationStart(batcheslib.LogEventOperationTaskStep, map[string]interface{}{"taskID": ui.linesTask.ID, "step": step, "runScript": runScript})
 }
 
-func (ui *stepsExecutionJSONLines) StepStdoutWriter(ctx context.Context, task *executor.Task, step int) io.WriteCloser {
+func (ui *stepsExecutionJSONLines) StepOutputWriter(ctx context.Context, task *executor.Task, step int) executor.StepOutputWriter {
 	sink := func(data string) {
 		logOperationProgress(
 			batcheslib.LogEventOperationTaskStep,
 			map[string]interface{}{
-				"taskID":      ui.linesTask.ID,
-				"step":        step,
-				"out":         data,
-				"output_type": "stdout",
+				"taskID": ui.linesTask.ID,
+				"step":   step,
+				"out":    data,
 			},
 		)
 	}
 	return NewIntervalWriter(ctx, stepFlushDuration, sink)
 }
 
-func (ui *stepsExecutionJSONLines) StepStderrWriter(ctx context.Context, task *executor.Task, step int) io.WriteCloser {
-	sink := func(data string) {
-		logOperationProgress(
-			batcheslib.LogEventOperationTaskStep,
-			map[string]interface{}{
-				"taskID":      ui.linesTask.ID,
-				"step":        step,
-				"out":         data,
-				"output_type": "stderr",
-			},
-		)
-	}
+// func (ui *stepsExecutionJSONLines) StepStderrWriter(ctx context.Context, task *executor.Task, step int) io.WriteCloser {
+// 	sink := func(data string) {
+// 		logOperationProgress(
+// 			batcheslib.LogEventOperationTaskStep,
+// 			map[string]interface{}{
+// 				"taskID":      ui.linesTask.ID,
+// 				"step":        step,
+// 				"out":         data,
+// 			},
+// 		)
+// 	}
 
-	return NewIntervalWriter(ctx, stepFlushDuration, sink)
-}
+// 	return NewIntervalWriter(ctx, stepFlushDuration, sink)
+// }
 
 func (ui *stepsExecutionJSONLines) StepFinished(step int, diff []byte, changes *git.Changes, outputs map[string]interface{}) {
 	logOperationSuccess(

--- a/internal/batches/ui/task_exec_tui.go
+++ b/internal/batches/ui/task_exec_tui.go
@@ -3,7 +3,6 @@ package ui
 import (
 	"context"
 	"fmt"
-	"io"
 	"sort"
 	"strings"
 	"sync"
@@ -458,12 +457,10 @@ func (ui stepsExecTUI) StepStarted(step int, runScript string) {
 	ui.updateStatusBar(runScript)
 }
 
-func (ui stepsExecTUI) StepStdoutWriter(ctx context.Context, task *executor.Task, step int) io.WriteCloser {
-	return discardCloser{io.Discard}
+func (ui stepsExecTUI) StepOutputWriter(ctx context.Context, task *executor.Task, step int) executor.StepOutputWriter {
+	return executor.NoopStepOutputWriter{}
 }
-func (ui stepsExecTUI) StepStderrWriter(ctx context.Context, task *executor.Task, step int) io.WriteCloser {
-	return discardCloser{io.Discard}
-}
+
 func (ui stepsExecTUI) CalculatingDiffStarted() {
 	ui.updateStatusBar("Calculating diff")
 }
@@ -473,7 +470,3 @@ func (ui stepsExecTUI) CalculatingDiffFinished() {
 func (ui stepsExecTUI) StepFinished(idx int, diff []byte, changes *git.Changes, outputs map[string]interface{}) {
 	// noop right now
 }
-
-type discardCloser struct{ io.Writer }
-
-func (discardCloser) Close() error { return nil }


### PR DESCRIPTION
This is a side-quest to EM2 https://github.com/sourcegraph/sourcegraph/issues/24421 because we realised that we'll make things harder for ourselves if we separate stdout/stderr into separate buffers.

We'd have to zip them up together in the UI but that's hard without having additional timing information.

But timing information is also a bit overkill (at least for now) so we thought we'd use a single buffer.

That's what this PR here contains.

Stdout and stderr are logged into a single buffer, each line prefixed with `stdout: ` and `stderr: ` respectively.

That works because the `process.PipeOutput` function only writes lines (not chunks) to the passed in writers. So it works even if commands print half a line on stdout, then half a line on stderr, and only then the rest.

### Example

Steps

```yaml
steps:
  - run: |
      echo "this is step 1" >> README.txt
      echo "this is step 1 stdout"
      echo "this is step 1 stderr" 1>&2
      echo -n "this is step 1 stdout half a line..."
      echo -n "this is step 1 stderr half a line..." 1>&2
      echo -n "...this the other half of step 1 stdout line"
      echo -n "...this the other half of step 1 stderr line" 1>&2
    container: alpine:3
  - run: |
      echo "this is step 2" >> README.md
      echo "this is step 2 stdout"
      echo "this is step 2 stderr" 1>&2
    container: alpine:3
  - run: |
      echo "this is step 3" >> README.md
      echo "this is step 3 stdout"
      echo "this is step 3 stderr" 1>&2
    container: alpine:3
    outputs:
      myOutput:
        value: "my-output.txt"
  - run: |
      echo "this is step 4" >> README.md
      cat README.md
      echo "previous_step.modified_files=${{ previous_step.modified_files }}" >> README.md
      ls -lrt
    container: alpine:3
  - run: echo "this is step 5" >> ${{ outputs.myOutput }}
    container: alpine:3
```

The resulting `TASK_STEP` JSON lines that contain output:

```json
{"operation":"TASK_STEP","timestamp":"2021-09-17T09:27:45.928Z","status":"PROGRESS","metadata":{"out":"stdout: this is step 1 stdout\nstdout: \nstderr: this is step 1 stderr\nstderr: \n","step":0,"taskID":"65qO4Zovx7V"}}
{"operation":"TASK_STEP","timestamp":"2021-09-17T09:27:45.947Z","status":"PROGRESS","metadata":{"out":"stderr: this is step 1 stderr half a line......this the other half of step 1 stdout line\nstderr: \nstdout: this is step 1 stdout half a line......this the other half of step 1 stdout line\nstdout: \n","step":0,"taskID":"65qO4Zovx7V"}}
{"operation":"TASK_STEP","timestamp":"2021-09-17T09:27:47.357Z","status":"PROGRESS","metadata":{"out":"stderr: this is step 2 stderr\nstderr: \nstdout: this is step 2 stdout\nstdout: \n","step":1,"taskID":"65qO4Zovx7V"}}
{"operation":"TASK_STEP","timestamp":"2021-09-17T09:27:48.835Z","status":"PROGRESS","metadata":{"out":"stderr: this is step 3 stderr\nstderr: \nstdout: this is step 3 stdout\nstdout: \n","step":2,"taskID":"65qO4Zovx7V"}}
{"operation":"TASK_STEP","timestamp":"2021-09-17T09:27:50.235Z","status":"PROGRESS","metadata":{"out":"stdout: # automation-testing\nstdout: \nstdout: This repository is used to test opening and closing pull request with Automation\nstdout: \nstdout: \nstdout: \nstdout: (c) Copyright Sourcegraph 2013-2020.\nstdout: \nstdout: (c) Copyright Sourcegraph 2013-2020.\nstdout: \nstdout: (c) Copyright Sourcegraph 2013-2020.this is step 2\nstdout: \nstdout: this is step 3\nstdout: \nstdout: this is step 4\nstdout: \nstdout: total 56\nstdout: \nstdout: -rw-rw-rw-    1 1000     1000            17 Sep 17 09:27 test.md\nstdout: \nstdout: drwxrwxrwx    4 1000     1000          4096 Sep 17 09:27 project2\nstdout: \nstdout: drwxrwxrwx    2 1000     1000          4096 Sep 17 09:27 project1\nstdout: \nstdout: drwxrwxrwx    2 1000     1000          4096 Sep 17 09:27 gopkg\nstdout: \nstdout: -rw-rw-rw-    1 1000     1000             0 Sep 17 09:27 foobar\nstdout: \nstdout: -rw-rw-rw-    1 1000     1000            17 Sep 17 09:27 file_without_newline_at_eof.txt\nstdout: \nstdout: -rw-rw-rw-    1 1000     1000           434 Sep 17 09:27 file_with_multiple_lines.txt\nstdout: \nstdout: -rw-rw-rw-    1 1000     1000            23 Sep 17 09:27 file3.txt\nstdout: \nstdout: -rw-rw-rw-    1 1000     1000            23 Sep 17 09:27 file2.txt\nstdout: \nstdout: -rw-rw-rw-    1 1000     1000            23 Sep 17 09:27 file1.txt\nstdout: \nstdout: drwxrwxrwx    3 1000     1000          4096 Sep 17 09:27 examples\nstdout: \nstdout: -rw-rw-rw-    1 1000     1000           706 Sep 17 09:27 circle-ci.yml\nstdout: \nstdout: -rw-rw-rw-    1 1000     1000           153 Sep 17 09:27 Dockerfile\nstdout: \nstdout: -rw-r--r--    1 root     root            15 Sep 17 09:27 README.txt\nstdout: \nstdout: -rw-rw-rw-    1 1000     1000           299 Sep 17 09:27 README.md\nstdout: \n","step":3,"taskID":"65qO4Zovx7V"}}
```