### PR TITLE
Fix displaying of errors in 'src batch validate'

### DIFF
--- a/cmd/src/batch_common.go
+++ b/cmd/src/batch_common.go
@@ -229,8 +229,9 @@ func executeBatchSpec(ctx context.Context, opts executeBatchSpecOpts) (err error
 	opts.ui.ParsingBatchSpec()
 	batchSpec, rawSpec, err := parseBatchSpec(&opts.flags.file, svc)
 	if err != nil {
-		if merr, ok := err.(*multierror.Error); ok {
-			opts.ui.ParsingBatchSpecFailure(merr)
+		var multiErr *multierror.Error
+		if errors.As(err, &multiErr) {
+			opts.ui.ParsingBatchSpecFailure(multiErr)
 			return cmderrors.ExitCode(2, nil)
 		} else {
 			// This shouldn't happen; let's just punt and let the normal

--- a/cmd/src/batch_exec.go
+++ b/cmd/src/batch_exec.go
@@ -112,8 +112,9 @@ func executeBatchSpecInWorkspaces(ctx context.Context, opts executeBatchSpecOpts
 	opts.ui.ParsingBatchSpec()
 	batchSpec, err := svc.ParseBatchSpec([]byte(input.RawSpec))
 	if err != nil {
-		if merr, ok := err.(*multierror.Error); ok {
-			opts.ui.ParsingBatchSpecFailure(merr)
+		var multiErr *multierror.Error
+		if errors.As(err, &multiErr) {
+			opts.ui.ParsingBatchSpecFailure(multiErr)
 			return cmderrors.ExitCode(2, nil)
 		} else {
 			// This shouldn't happen; let's just punt and let the normal

--- a/cmd/src/batch_validate.go
+++ b/cmd/src/batch_validate.go
@@ -41,17 +41,19 @@ Examples:
 			return cmderrors.Usage("additional arguments not allowed")
 		}
 
+		out := output.NewOutput(flagSet.Output(), output.OutputOpts{Verbose: *verbose})
+		ui := &ui.TUI{Out: out}
 		svc := service.New(&service.Opts{
 			Client: cfg.apiClient(apiFlags, flagSet.Output()),
 		})
 
 		if err := svc.DetermineFeatureFlags(ctx); err != nil {
+			ui.ExecutionError(err)
 			return err
 		}
 
-		out := output.NewOutput(flagSet.Output(), output.OutputOpts{Verbose: *verbose})
 		if _, _, err := parseBatchSpec(fileFlag, svc); err != nil {
-			(&ui.TUI{Out: out}).ParsingBatchSpecFailure(err)
+			ui.ParsingBatchSpecFailure(err)
 			return err
 		}
 

--- a/internal/batches/ui/tui.go
+++ b/internal/batches/ui/tui.go
@@ -43,13 +43,16 @@ func (ui *TUI) ParsingBatchSpecSuccess() {
 }
 
 func (ui *TUI) ParsingBatchSpecFailure(err error) {
-	if merr, ok := err.(*multierror.Error); ok {
-		block := ui.Out.Block(output.Line("\u274c", output.StyleWarning, "Batch spec failed validation."))
-		defer block.Close()
+	block := ui.Out.Block(output.Line("\u274c", output.StyleWarning, "Batch spec failed validation."))
+	defer block.Close()
 
-		for i, err := range merr.Errors {
+	var multiErr *multierror.Error
+	if errors.As(err, &multiErr) {
+		for i, err := range multiErr.Errors {
 			block.Writef("%d. %s", i+1, err)
 		}
+	} else {
+		block.Writef("1. %s", err)
 	}
 }
 


### PR DESCRIPTION
Before this 'src batch validate' would...

1. not print an error if talking to the Sourcegraph instance failed
2. not unpack multi errors correctly and printing all of them

This fixes both issues.