### PR TITLE
ssbc: Log final env when resolved

### DIFF
--- a/internal/batches/executor/run_steps.go
+++ b/internal/batches/executor/run_steps.go
@@ -265,7 +265,6 @@ func executeSingleStep(
 	if err != nil {
 		return bytes.Buffer{}, bytes.Buffer{}, errors.Wrap(err, "resolving step environment")
 	}
-
 	// Render the step.Env variables as templates.
 	env, err := template.RenderStepMap(stepEnv, stepContext)
 	if err != nil {
@@ -275,7 +274,7 @@ func executeSingleStep(
 	// ----------
 	// EXECUTION
 	// ----------
-	opts.ui.StepStarted(i+1, runScript)
+	opts.ui.StepStarted(i+1, runScript, env)
 
 	workspaceOpts, err := workspace.DockerRunOpts(ctx, workDir)
 	if err != nil {

--- a/internal/batches/executor/ui.go
+++ b/internal/batches/executor/ui.go
@@ -38,7 +38,7 @@ type StepsExecutionUI interface {
 	StepSkipped(int)
 
 	StepPreparing(int)
-	StepStarted(int, string)
+	StepStarted(stepIdx int, runScript string, env map[string]string)
 
 	StepOutputWriter(context.Context, *Task, int) StepOutputWriter
 
@@ -51,14 +51,14 @@ type StepsExecutionUI interface {
 // NoopStepsExecUI is an implementation of StepsExecutionUI that does nothing.
 type NoopStepsExecUI struct{}
 
-func (noop NoopStepsExecUI) ArchiveDownloadStarted()                {}
-func (noop NoopStepsExecUI) ArchiveDownloadFinished()               {}
-func (noop NoopStepsExecUI) WorkspaceInitializationStarted()        {}
-func (noop NoopStepsExecUI) WorkspaceInitializationFinished()       {}
-func (noop NoopStepsExecUI) SkippingStepsUpto(startStep int)        {}
-func (noop NoopStepsExecUI) StepSkipped(step int)                   {}
-func (noop NoopStepsExecUI) StepPreparing(step int)                 {}
-func (noop NoopStepsExecUI) StepStarted(step int, runScript string) {}
+func (noop NoopStepsExecUI) ArchiveDownloadStarted()                                       {}
+func (noop NoopStepsExecUI) ArchiveDownloadFinished()                                      {}
+func (noop NoopStepsExecUI) WorkspaceInitializationStarted()                               {}
+func (noop NoopStepsExecUI) WorkspaceInitializationFinished()                              {}
+func (noop NoopStepsExecUI) SkippingStepsUpto(startStep int)                               {}
+func (noop NoopStepsExecUI) StepSkipped(step int)                                          {}
+func (noop NoopStepsExecUI) StepPreparing(step int)                                        {}
+func (noop NoopStepsExecUI) StepStarted(step int, runScript string, env map[string]string) {}
 func (noop NoopStepsExecUI) StepOutputWriter(ctx context.Context, task *Task, step int) StepOutputWriter {
 	return NoopStepOutputWriter{}
 }

--- a/internal/batches/ui/json_lines.go
+++ b/internal/batches/ui/json_lines.go
@@ -320,8 +320,8 @@ func (ui *stepsExecutionJSONLines) StepPreparing(step int) {
 	logOperationProgress(batcheslib.LogEventOperationTaskPreparingStep, map[string]interface{}{"taskID": ui.linesTask.ID, "step": step})
 }
 
-func (ui *stepsExecutionJSONLines) StepStarted(step int, runScript string) {
-	logOperationStart(batcheslib.LogEventOperationTaskStep, map[string]interface{}{"taskID": ui.linesTask.ID, "step": step, "runScript": runScript})
+func (ui *stepsExecutionJSONLines) StepStarted(step int, runScript string, env map[string]string) {
+	logOperationStart(batcheslib.LogEventOperationTaskStep, map[string]interface{}{"taskID": ui.linesTask.ID, "step": step, "runScript": runScript, "env": env})
 }
 
 func (ui *stepsExecutionJSONLines) StepOutputWriter(ctx context.Context, task *executor.Task, step int) executor.StepOutputWriter {

--- a/internal/batches/ui/task_exec_tui.go
+++ b/internal/batches/ui/task_exec_tui.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/sourcegraph/go-diff/diff"
+
 	"github.com/sourcegraph/src-cli/internal/batches/executor"
 
 	batcheslib "github.com/sourcegraph/sourcegraph/lib/batches"
@@ -453,7 +454,7 @@ func (ui stepsExecTUI) StepSkipped(step int) {
 func (ui stepsExecTUI) StepPreparing(step int) {
 	ui.updateStatusBar(fmt.Sprintf("Preparing %d", step))
 }
-func (ui stepsExecTUI) StepStarted(step int, runScript string) {
+func (ui stepsExecTUI) StepStarted(step int, runScript string, _ map[string]string) {
 	ui.updateStatusBar(runScript)
 }
 


### PR DESCRIPTION
When determining workspaces, we determine the env, too. The values are preliminary though, as they might depend on what's set in the environment of src-cli or use template variables that aren't known at time of workspace determination. This logs the final set of env vars as used for the step.