### PR TITLE
internal/batches: include the url field in repositories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ All notable changes to `src-cli` are documented in this file.
 
 ### Fixed
 
+- `src batch repos` failed with a template error in src-cli 3.31.1 and 3.32.0. This has been fixed. [#625](https://github.com/sourcegraph/src-cli/pull/625)
+
 ### Removed
 
 ## 3.31.1

--- a/internal/batches/graphql/repository.go
+++ b/internal/batches/graphql/repository.go
@@ -6,6 +6,7 @@ const RepositoryFieldsFragment = `
 fragment repositoryFields on Repository {
     id
     name
+    url
     externalRepository {
         serviceType
     }
@@ -33,6 +34,7 @@ type Branch struct {
 type Repository struct {
 	ID                 string
 	Name               string
+	URL                string
 	ExternalRepository struct{ ServiceType string }
 
 	DefaultBranch *Branch


### PR DESCRIPTION
Removing this in #598 broke the `src batch repos` command, which used the `url` field when rendering the link to the repo in Sourcegraph.