### PR TITLE
Fix importing changesets with no docker images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ All notable changes to `src-cli` are documented in this file.
 
 ### Fixed
 
+- Fixes an issue where src-cli would panic when importing existing changesets.
+
 ### Removed
 
 ## 3.31.1

--- a/cmd/src/batch_exec.go
+++ b/cmd/src/batch_exec.go
@@ -125,22 +125,26 @@ func executeBatchSpecInWorkspaces(ctx context.Context, opts executeBatchSpecOpts
 	}
 	opts.ui.ParsingBatchSpecSuccess()
 
-	opts.ui.PreparingContainerImages()
-	images, err := svc.EnsureDockerImages(ctx, batchSpec, opts.ui.PreparingContainerImagesProgress)
-	if err != nil {
-		return err
-	}
-	opts.ui.PreparingContainerImagesSuccess()
+	var workspaceCreator workspace.Creator
 
-	opts.ui.DeterminingWorkspaceCreatorType()
-	workspaceCreator := workspace.NewCreator(ctx, opts.flags.workspace, opts.flags.cacheDir, opts.flags.tempDir, images)
-	if workspaceCreator.Type() == workspace.CreatorTypeVolume {
-		_, err = svc.EnsureImage(ctx, workspace.DockerVolumeWorkspaceImage)
+	if svc.HasDockerImages(batchSpec) {
+		opts.ui.PreparingContainerImages()
+		images, err := svc.EnsureDockerImages(ctx, batchSpec, opts.ui.PreparingContainerImagesProgress)
 		if err != nil {
 			return err
 		}
+		opts.ui.PreparingContainerImagesSuccess()
+
+		opts.ui.DeterminingWorkspaceCreatorType()
+		workspaceCreator = workspace.NewCreator(ctx, opts.flags.workspace, opts.flags.cacheDir, opts.flags.tempDir, images)
+		if workspaceCreator.Type() == workspace.CreatorTypeVolume {
+			_, err = svc.EnsureImage(ctx, workspace.DockerVolumeWorkspaceImage)
+			if err != nil {
+				return err
+			}
+		}
+		opts.ui.DeterminingWorkspaceCreatorTypeSuccess(workspaceCreator.Type())
 	}
-	opts.ui.DeterminingWorkspaceCreatorTypeSuccess(workspaceCreator.Type())
 
 	// EXECUTION OF TASKS
 	coord := svc.NewCoordinator(executor.NewCoordinatorOpts{

--- a/internal/batches/service/service.go
+++ b/internal/batches/service/service.go
@@ -172,6 +172,10 @@ func (svc *Service) EnsureDockerImages(ctx context.Context, spec *batcheslib.Bat
 	return images, nil
 }
 
+func (svc *Service) HasDockerImages(spec *batcheslib.BatchSpec) bool {
+	return len(spec.Steps) > 0
+}
+
 func (svc *Service) EnsureImage(ctx context.Context, name string) (docker.Image, error) {
 	img := svc.imageCache.Get(name)
 


### PR DESCRIPTION
When only importing changesets, no docker images would need to be pulled. In the TUI, a division by zero would be made and the input for the tab UI would be NaN. This caused an error, that was reported in https://github.com/sourcegraph/src-cli/issues/629.

Closes https://github.com/sourcegraph/src-cli/issues/629