### PR TITLE
Fix nil-panic if repository has no default branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ All notable changes to `src-cli` are documented in this file.
 
 ### Fixed
 
+- Fixes a nil-panic that could be caused when `src batch [preview|apply]` would encounter a repository that was currently being cloned or is empty.
+
 ### Removed
 
 ## 3.31.2


### PR DESCRIPTION
This is the fix for the issue reported in https://github.com/sourcegraph/customer/issues/537.

The problem:

1. Sometimes repositories don't have a default branch, because they're being cloned or updated by Sourcegraph. See code here: [`git.DefaultBranch`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@1cbb9023b0c77e6fa132298df1b2b5a768288d67/-/blob/internal/vcs/git/default_branch.go?L6)
2. We skip the repositories with no repositories, *but too late*. With the introduction of `.batchignore` we added additional code that broke that check.