### PR TITLE
Support serving bare repositories

### DIFF
--- a/internal/servegit/serve.go
+++ b/internal/servegit/serve.go
@@ -193,9 +193,11 @@ func (s *Serve) Repos() ([]Repo, error) {
 
 		// Check whether a particular directory is a repository or not.
 		//
-		// A directory which also is a repository (have .git folder inside it)
-		// will contain nil error. If it does, proceed to configure.
-		if !isGitRepo(path) {
+		// Valid paths are either bare repositories or git worktrees.
+		isBare := isBareRepo(path)
+		isGit := isGitRepo(path)
+
+		if !isGit && !isBare {
 			s.Debug.Printf("not a repository root: %s", path)
 			return nil
 		}
@@ -216,11 +218,9 @@ func (s *Serve) Repos() ([]Repo, error) {
 
 		// Check whether a repository is a bare repository or not.
 		//
-		// If it yields false, which means it is a non-bare repository,
-		// skip the directory so that it will not recurse to the subdirectories.
-		// If it is a bare repository, proceed to recurse.
-		gitdir := filepath.Join(path, ".git")
-		if !isBareRepo(gitdir) {
+		// Bare repositories shouldn't have any further child
+		// repositories. Only regular git worktrees can have children.
+		if isBare {
 			return filepath.SkipDir
 		}
 

--- a/internal/servegit/serve.go
+++ b/internal/servegit/serve.go
@@ -132,10 +132,6 @@ func (s *Serve) handler() http.Handler {
 
 // Checks if git thinks the given path is a valid .git folder for a repository
 func isBareRepo(path string) bool {
-	if fi, err := os.Stat(path); err != nil || !fi.IsDir() {
-		return false
-	}
-
 	c := exec.Command("git", "--git-dir", path, "rev-parse", "--is-bare-repository")
 	c.Dir = path
 	out, err := c.CombinedOutput()
@@ -149,10 +145,6 @@ func isBareRepo(path string) bool {
 
 // Check if git thinks the given path is a proper git checkout
 func isGitRepo(path string) bool {
-	if fi, err := os.Stat(path); err != nil || !fi.IsDir() {
-		return false
-	}
-
 	// Executing git rev-parse --git-dir in the root of a worktree returns .git
 	c := exec.Command("git", "rev-parse", "--git-dir")
 	c.Dir = path

--- a/internal/servegit/serve_test.go
+++ b/internal/servegit/serve_test.go
@@ -32,7 +32,7 @@ func TestReposHandler(t *testing.T) {
 		repos: []string{"project1", "project2"},
 	}, {
 		name:  "nested",
-		repos: []string{"project1", "project1/subproject", "project2", "dir/project3"},
+		repos: []string{"project1", "project1/subproject", "project2", "dir/project3", "dir/project4.bare"},
 	}}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -191,7 +191,9 @@ func gitInitRepos(t *testing.T, names ...string) string {
 			t.Fatal(err)
 		}
 
-		p = filepath.Join(p, ".git")
+		if !strings.HasSuffix(p, ".bare") {
+			p = filepath.Join(p, ".git")
+		}
 		gitInitBare(t, p)
 	}
 


### PR DESCRIPTION
This is in response to my own issue (#634) where I was asking for support for serving bare repositories from a directory.

This PR has a couple of changes. Some of them can be seen as a refactoring of sorts. The comments in the original implementation were a bit misleading as they appeared to be the other way around (compared to what the tests wanted). I took the liberty to rewrite them a bit. All of the original tests still pass. I've added one case where a bare repository is created (by suffixing the name of a repo with `.bare`) which seems to work. I am not happy about the repository name suffix hack that I had to add but it also doesn't seem like it is worth the effort to refactor the entire test machinery just because of this.

I am open for feedback on this.


cc @mrnugget & @keegancsmith who where very responsive to my issue