### PR TITLE
api: add User-Agent header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to `src-cli` are documented in this file.
 
 ### Added
 
+- Requests to Sourcegraph will now include the operating system and architecture `src` is running on by default. To disable this, set the `SRC_DISABLE_USER_AGENT_TELEMETRY` environment variable to any non-empty string, or provide the `-user-agent-telemetry=false` flag on the command line. [#15769](https://github.com/sourcegraph/sourcegraph/issues/15769)
+
 ### Changed
 
 ### Fixed

--- a/README.markdown
+++ b/README.markdown
@@ -127,6 +127,18 @@ mv /usr/local/bin/src /usr/local/bin/src-cli
 
 You can then invoke it via `src-cli`.
 
+## Telemetry
+
+`src` includes the operating system and architecture in the `User-Agent` header sent to Sourcegraph. For example, running `src` version 3.21.10 on an x86-64 Linux host will result in this header:
+
+```
+src-cli/3.21.10 linux amd64
+```
+
+To disable this and _only_ send the version, you can set `-user-agent-telemetry=false` for a single command, or set the `SRC_DISABLE_USER_AGENT_TELEMETRY` environment variable to any non-blank string.
+
+As with [other Sourcegraph telemetry](https://docs.sourcegraph.com/dev/background-information/telemetry), any collected data is only sent to Sourcegraph.com in aggregate form.
+
 ## Development
 
 Some useful notes on developing `src` can be found in [DEVELOPMENT.md](DEVELOPMENT.md).

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -166,7 +166,7 @@ func (c *client) createHTTPRequest(ctx context.Context, method, p string, body i
 	if c.opts.Flags.UserAgentTelemetry() {
 		req.Header.Set("User-Agent", fmt.Sprintf("src-cli/%s %s %s", version.BuildTag, runtime.GOOS, runtime.GOARCH))
 	} else {
-		req.Header.Set("User-Agent", "src-cli")
+		req.Header.Set("User-Agent", "src-cli/"+version.BuildTag)
 	}
 	if c.opts.AccessToken != "" {
 		req.Header.Set("Authorization", "token "+c.opts.AccessToken)

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -163,7 +163,11 @@ func (c *client) createHTTPRequest(ctx context.Context, method, p string, body i
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("User-Agent", fmt.Sprintf("src-cli/%s %s %s", version.BuildTag, runtime.GOOS, runtime.GOARCH))
+	if c.opts.Flags.UserAgentTelemetry() {
+		req.Header.Set("User-Agent", fmt.Sprintf("src-cli/%s %s %s", version.BuildTag, runtime.GOOS, runtime.GOARCH))
+	} else {
+		req.Header.Set("User-Agent", "src-cli")
+	}
 	if c.opts.AccessToken != "" {
 		req.Header.Set("Authorization", "token "+c.opts.AccessToken)
 	}

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"runtime"
 	"strings"
 
 	ioaux "github.com/jig/teereadcloser"
@@ -161,6 +162,7 @@ func (c *client) createHTTPRequest(ctx context.Context, method, p string, body i
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("User-Agent", fmt.Sprintf("src-cli/%s %s %s", "XXX", runtime.GOOS, runtime.GOARCH))
 	if c.opts.AccessToken != "" {
 		req.Header.Set("Authorization", "token "+c.opts.AccessToken)
 	}

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -16,6 +16,7 @@ import (
 	ioaux "github.com/jig/teereadcloser"
 	"github.com/kballard/go-shellquote"
 	"github.com/mattn/go-isatty"
+	"github.com/sourcegraph/src-cli/internal/version"
 )
 
 // Client instances provide methods to create API requests.
@@ -162,7 +163,7 @@ func (c *client) createHTTPRequest(ctx context.Context, method, p string, body i
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("User-Agent", fmt.Sprintf("src-cli/%s %s %s", "XXX", runtime.GOOS, runtime.GOARCH))
+	req.Header.Set("User-Agent", fmt.Sprintf("src-cli/%s %s %s", version.BuildTag, runtime.GOOS, runtime.GOARCH))
 	if c.opts.AccessToken != "" {
 		req.Header.Set("Authorization", "token "+c.opts.AccessToken)
 	}

--- a/internal/api/flags.go
+++ b/internal/api/flags.go
@@ -9,6 +9,7 @@ type Flags struct {
 	getCurl            *bool
 	trace              *bool
 	insecureSkipVerify *bool
+	userAgentTelemetry *bool
 }
 
 func (f *Flags) Trace() bool {
@@ -26,15 +27,18 @@ func NewFlags(flagSet *flag.FlagSet) *Flags {
 		getCurl:            flagSet.Bool("get-curl", false, "Print the curl command for executing this query and exit (WARNING: includes printing your access token!)"),
 		trace:              flagSet.Bool("trace", false, "Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing"),
 		insecureSkipVerify: flagSet.Bool("insecure-skip-verify", false, "Skip validation of TLS certificates against trusted chains"),
+		userAgentTelemetry: flagSet.Bool("user-agent-telemetry", true, "Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph (default: true)"),
 	}
 }
 
 func defaultFlags() *Flags {
-	d := false
+	f := false
+	t := true
 	return &Flags{
-		dump:               &d,
-		getCurl:            &d,
-		trace:              &d,
-		insecureSkipVerify: &d,
+		dump:               &f,
+		getCurl:            &f,
+		trace:              &f,
+		insecureSkipVerify: &f,
+		userAgentTelemetry: &t,
 	}
 }

--- a/internal/api/flags.go
+++ b/internal/api/flags.go
@@ -1,6 +1,9 @@
 package api
 
-import "flag"
+import (
+	"flag"
+	"os"
+)
 
 // Flags encapsulates the standard flags that should be added to all commands
 // that issue API requests.
@@ -19,6 +22,13 @@ func (f *Flags) Trace() bool {
 	return *(f.trace)
 }
 
+func (f *Flags) UserAgentTelemetry() bool {
+	if f.userAgentTelemetry == nil {
+		return defaultUserAgentTelemetry()
+	}
+	return *(f.userAgentTelemetry)
+}
+
 // NewFlags instantiates a new Flags structure and attaches flags to the given
 // flag set.
 func NewFlags(flagSet *flag.FlagSet) *Flags {
@@ -27,18 +37,22 @@ func NewFlags(flagSet *flag.FlagSet) *Flags {
 		getCurl:            flagSet.Bool("get-curl", false, "Print the curl command for executing this query and exit (WARNING: includes printing your access token!)"),
 		trace:              flagSet.Bool("trace", false, "Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing"),
 		insecureSkipVerify: flagSet.Bool("insecure-skip-verify", false, "Skip validation of TLS certificates against trusted chains"),
-		userAgentTelemetry: flagSet.Bool("user-agent-telemetry", true, "Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph (default: true)"),
+		userAgentTelemetry: flagSet.Bool("user-agent-telemetry", defaultUserAgentTelemetry(), "Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph (default: true)"),
 	}
 }
 
 func defaultFlags() *Flags {
-	f := false
-	t := true
+	telemetry := defaultUserAgentTelemetry()
+	d := false
 	return &Flags{
-		dump:               &f,
-		getCurl:            &f,
-		trace:              &f,
-		insecureSkipVerify: &f,
-		userAgentTelemetry: &t,
+		dump:               &d,
+		getCurl:            &d,
+		trace:              &d,
+		insecureSkipVerify: &d,
+		userAgentTelemetry: &telemetry,
 	}
+}
+
+func defaultUserAgentTelemetry() bool {
+	return os.Getenv("SRC_DISABLE_USER_AGENT_TELEMETRY") == ""
 }

--- a/internal/api/flags.go
+++ b/internal/api/flags.go
@@ -37,7 +37,7 @@ func NewFlags(flagSet *flag.FlagSet) *Flags {
 		getCurl:            flagSet.Bool("get-curl", false, "Print the curl command for executing this query and exit (WARNING: includes printing your access token!)"),
 		trace:              flagSet.Bool("trace", false, "Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing"),
 		insecureSkipVerify: flagSet.Bool("insecure-skip-verify", false, "Skip validation of TLS certificates against trusted chains"),
-		userAgentTelemetry: flagSet.Bool("user-agent-telemetry", defaultUserAgentTelemetry(), "Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph (default: true)"),
+		userAgentTelemetry: flagSet.Bool("user-agent-telemetry", defaultUserAgentTelemetry(), "Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph"),
 	}
 }
 


### PR DESCRIPTION
This PR unconditionally changes the User-Agent to `src-cli`, rather than the default Go user-agent, and adds the OS and architecture to src for support and product purposes by default. This can be disabled via an environment variable and/or flag, and is documented accordingly.

Closes sourcegraph/sourcegraph#15769.