### PR TITLE
Add JSONLinesCache to write cache entries to stdout

### DIFF
--- a/cmd/src/batch_apply.go
+++ b/cmd/src/batch_apply.go
@@ -5,9 +5,10 @@ import (
 	"flag"
 	"fmt"
 
-	"github.com/sourcegraph/sourcegraph/lib/output"
 	"github.com/sourcegraph/src-cli/internal/batches/ui"
 	"github.com/sourcegraph/src-cli/internal/cmderrors"
+
+	"github.com/sourcegraph/sourcegraph/lib/output"
 )
 
 func init() {
@@ -50,13 +51,11 @@ Examples:
 			execUI = &ui.TUI{Out: out}
 		}
 
-		err := executeBatchSpec(ctx, executeBatchSpecOpts{
+		err := executeBatchSpec(ctx, execUI, executeBatchSpecOpts{
 			flags:  flags,
 			client: cfg.apiClient(flags.api, flagSet.Output()),
 
 			applyBatchSpec: true,
-
-			ui: execUI,
 		})
 		if err != nil {
 			return cmderrors.ExitCode(1, nil)

--- a/cmd/src/batch_common.go
+++ b/cmd/src/batch_common.go
@@ -296,6 +296,7 @@ func executeBatchSpec(ctx context.Context, opts executeBatchSpecOpts) (err error
 	coord := svc.NewCoordinator(executor.NewCoordinatorOpts{
 		Creator:          workspaceCreator,
 		CacheDir:         opts.flags.cacheDir,
+		Cache:            executor.NewDiskCache(opts.flags.cacheDir),
 		ClearCache:       opts.flags.clearCache,
 		SkipErrors:       opts.flags.skipErrors,
 		CleanArchives:    opts.flags.cleanArchives,

--- a/cmd/src/batch_common.go
+++ b/cmd/src/batch_common.go
@@ -193,18 +193,16 @@ type executeBatchSpecOpts struct {
 
 	applyBatchSpec bool
 
-	ui ui.ExecUI
-
 	client api.Client
 }
 
 // executeBatchSpec performs all the steps required to upload the batch spec to
 // Sourcegraph, including execution as needed and applying the resulting batch
 // spec if specified.
-func executeBatchSpec(ctx context.Context, opts executeBatchSpecOpts) (err error) {
+func executeBatchSpec(ctx context.Context, ui ui.ExecUI, opts executeBatchSpecOpts) (err error) {
 	defer func() {
 		if err != nil {
-			opts.ui.ExecutionError(err)
+			ui.ExecutionError(err)
 		}
 	}()
 
@@ -228,12 +226,12 @@ func executeBatchSpec(ctx context.Context, opts executeBatchSpecOpts) (err error
 	}
 
 	// Parse flags and build up our service and executor options.
-	opts.ui.ParsingBatchSpec()
+	ui.ParsingBatchSpec()
 	batchSpec, rawSpec, err := parseBatchSpec(&opts.flags.file, svc)
 	if err != nil {
 		var multiErr *multierror.Error
 		if errors.As(err, &multiErr) {
-			opts.ui.ParsingBatchSpecFailure(multiErr)
+			ui.ParsingBatchSpecFailure(multiErr)
 			return cmderrors.ExitCode(2, nil)
 		} else {
 			// This shouldn't happen; let's just punt and let the normal
@@ -241,26 +239,26 @@ func executeBatchSpec(ctx context.Context, opts executeBatchSpecOpts) (err error
 			return err
 		}
 	}
-	opts.ui.ParsingBatchSpecSuccess()
+	ui.ParsingBatchSpecSuccess()
 
-	opts.ui.ResolvingNamespace()
+	ui.ResolvingNamespace()
 	namespace, err := svc.ResolveNamespace(ctx, opts.flags.namespace)
 	if err != nil {
 		return err
 	}
-	opts.ui.ResolvingNamespaceSuccess(namespace)
+	ui.ResolvingNamespaceSuccess(namespace)
 
 	var workspaceCreator workspace.Creator
 
 	if svc.HasDockerImages(batchSpec) {
-		opts.ui.PreparingContainerImages()
-		images, err := svc.EnsureDockerImages(ctx, batchSpec, opts.ui.PreparingContainerImagesProgress)
+		ui.PreparingContainerImages()
+		images, err := svc.EnsureDockerImages(ctx, batchSpec, ui.PreparingContainerImagesProgress)
 		if err != nil {
 			return err
 		}
-		opts.ui.PreparingContainerImagesSuccess()
+		ui.PreparingContainerImagesSuccess()
 
-		opts.ui.DeterminingWorkspaceCreatorType()
+		ui.DeterminingWorkspaceCreatorType()
 		workspaceCreator = workspace.NewCreator(ctx, opts.flags.workspace, opts.flags.cacheDir, opts.flags.tempDir, images)
 		if workspaceCreator.Type() == workspace.CreatorTypeVolume {
 			_, err = svc.EnsureImage(ctx, workspace.DockerVolumeWorkspaceImage)
@@ -268,29 +266,29 @@ func executeBatchSpec(ctx context.Context, opts executeBatchSpecOpts) (err error
 				return err
 			}
 		}
-		opts.ui.DeterminingWorkspaceCreatorTypeSuccess(workspaceCreator.Type())
+		ui.DeterminingWorkspaceCreatorTypeSuccess(workspaceCreator.Type())
 	}
 
-	opts.ui.ResolvingRepositories()
+	ui.ResolvingRepositories()
 	repos, err := svc.ResolveRepositories(ctx, batchSpec)
 	if err != nil {
 		if repoSet, ok := err.(batches.UnsupportedRepoSet); ok {
-			opts.ui.ResolvingRepositoriesDone(repos, repoSet, nil)
+			ui.ResolvingRepositoriesDone(repos, repoSet, nil)
 		} else if repoSet, ok := err.(batches.IgnoredRepoSet); ok {
-			opts.ui.ResolvingRepositoriesDone(repos, nil, repoSet)
+			ui.ResolvingRepositoriesDone(repos, nil, repoSet)
 		} else {
 			return errors.Wrap(err, "resolving repositories")
 		}
 	} else {
-		opts.ui.ResolvingRepositoriesDone(repos, nil, nil)
+		ui.ResolvingRepositoriesDone(repos, nil, nil)
 	}
 
-	opts.ui.DeterminingWorkspaces()
+	ui.DeterminingWorkspaces()
 	workspaces, err := svc.DetermineWorkspaces(ctx, repos, batchSpec)
 	if err != nil {
 		return err
 	}
-	opts.ui.DeterminingWorkspacesSuccess(len(workspaces))
+	ui.DeterminingWorkspacesSuccess(len(workspaces))
 
 	// EXECUTION OF TASKS
 	coord := svc.NewCoordinator(executor.NewCoordinatorOpts{
@@ -307,15 +305,15 @@ func executeBatchSpec(ctx context.Context, opts executeBatchSpecOpts) (err error
 		ImportChangesets: true,
 	})
 
-	opts.ui.CheckingCache()
+	ui.CheckingCache()
 	tasks := svc.BuildTasks(ctx, batchSpec, workspaces)
 	uncachedTasks, cachedSpecs, err := coord.CheckCache(ctx, tasks)
 	if err != nil {
 		return err
 	}
-	opts.ui.CheckingCacheSuccess(len(cachedSpecs), len(uncachedTasks))
+	ui.CheckingCacheSuccess(len(cachedSpecs), len(uncachedTasks))
 
-	taskExecUI := opts.ui.ExecutingTasks(*verbose, opts.flags.parallelism)
+	taskExecUI := ui.ExecutingTasks(*verbose, opts.flags.parallelism)
 	freshSpecs, logFiles, err := coord.Execute(ctx, uncachedTasks, batchSpec, taskExecUI)
 	if err != nil && !opts.flags.skipErrors {
 		return err
@@ -324,7 +322,7 @@ func executeBatchSpec(ctx context.Context, opts executeBatchSpecOpts) (err error
 		if err == nil {
 			taskExecUI.Success()
 		} else {
-			opts.ui.ExecutingTasksSkippingErrors(err)
+			ui.ExecutingTasksSkippingErrors(err)
 		}
 	} else {
 		if err != nil {
@@ -334,7 +332,7 @@ func executeBatchSpec(ctx context.Context, opts executeBatchSpecOpts) (err error
 	}
 
 	if len(logFiles) > 0 && opts.flags.keepLogs {
-		opts.ui.LogFilesKept(logFiles)
+		ui.LogFilesKept(logFiles)
 	}
 
 	specs := append(cachedSpecs, freshSpecs...)
@@ -347,7 +345,7 @@ func executeBatchSpec(ctx context.Context, opts executeBatchSpecOpts) (err error
 	ids := make([]graphql.ChangesetSpecID, len(specs))
 
 	if len(specs) > 0 {
-		opts.ui.UploadingChangesetSpecs(len(specs))
+		ui.UploadingChangesetSpecs(len(specs))
 
 		for i, spec := range specs {
 			id, err := svc.CreateChangesetSpec(ctx, spec)
@@ -355,33 +353,33 @@ func executeBatchSpec(ctx context.Context, opts executeBatchSpecOpts) (err error
 				return err
 			}
 			ids[i] = id
-			opts.ui.UploadingChangesetSpecsProgress(i+1, len(specs))
+			ui.UploadingChangesetSpecsProgress(i+1, len(specs))
 		}
 
-		opts.ui.UploadingChangesetSpecsSuccess(ids)
+		ui.UploadingChangesetSpecsSuccess(ids)
 	} else if len(repos) == 0 {
-		opts.ui.NoChangesetSpecs()
+		ui.NoChangesetSpecs()
 	}
 
-	opts.ui.CreatingBatchSpec()
+	ui.CreatingBatchSpec()
 	id, url, err := svc.CreateBatchSpec(ctx, namespace, rawSpec, ids)
 	if err != nil {
-		return opts.ui.CreatingBatchSpecError(err)
+		return ui.CreatingBatchSpecError(err)
 	}
 	previewURL := cfg.Endpoint + url
-	opts.ui.CreatingBatchSpecSuccess(previewURL)
+	ui.CreatingBatchSpecSuccess(previewURL)
 
 	if !opts.applyBatchSpec {
-		opts.ui.PreviewBatchSpec(previewURL)
+		ui.PreviewBatchSpec(previewURL)
 		return
 	}
 
-	opts.ui.ApplyingBatchSpec()
+	ui.ApplyingBatchSpec()
 	batch, err := svc.ApplyBatchChange(ctx, id)
 	if err != nil {
 		return err
 	}
-	opts.ui.ApplyingBatchSpecSuccess(cfg.Endpoint + batch.URL)
+	ui.ApplyingBatchSpecSuccess(cfg.Endpoint + batch.URL)
 
 	return nil
 }

--- a/cmd/src/batch_exec.go
+++ b/cmd/src/batch_exec.go
@@ -147,11 +147,18 @@ func executeBatchSpecInWorkspaces(ctx context.Context, opts executeBatchSpecOpts
 		opts.ui.DeterminingWorkspaceCreatorTypeSuccess(workspaceCreator.Type())
 	}
 
+	lines, ok := opts.ui.(*ui.JSONLines)
+	if !ok {
+		panic("foobar")
+	}
+
+	cache := &executor.JSONLinesCache{Writer: lines}
+
 	// EXECUTION OF TASKS
 	coord := svc.NewCoordinator(executor.NewCoordinatorOpts{
 		Creator:       workspaceCreator,
 		CacheDir:      opts.flags.cacheDir,
-		Cache:         &ui.JSONLinesCache{},
+		Cache:         cache,
 		ClearCache:    opts.flags.clearCache,
 		SkipErrors:    opts.flags.skipErrors,
 		CleanArchives: opts.flags.cleanArchives,

--- a/cmd/src/batch_exec.go
+++ b/cmd/src/batch_exec.go
@@ -52,10 +52,9 @@ Examples:
 		ctx, cancel := contextCancelOnInterrupt(context.Background())
 		defer cancel()
 
-		err := executeBatchSpecInWorkspaces(ctx, executeBatchSpecOpts{
+		err := executeBatchSpecInWorkspaces(ctx, &ui.JSONLines{}, executeBatchSpecOpts{
 			flags:  flags,
 			client: cfg.apiClient(flags.api, flagSet.Output()),
-			ui:     &ui.JSONLines{},
 		})
 		if err != nil {
 			return cmderrors.ExitCode(1, nil)
@@ -75,10 +74,10 @@ Examples:
 	})
 }
 
-func executeBatchSpecInWorkspaces(ctx context.Context, opts executeBatchSpecOpts) (err error) {
+func executeBatchSpecInWorkspaces(ctx context.Context, ui *ui.JSONLines, opts executeBatchSpecOpts) (err error) {
 	defer func() {
 		if err != nil {
-			opts.ui.ExecutionError(err)
+			ui.ExecutionError(err)
 		}
 	}()
 
@@ -111,12 +110,12 @@ func executeBatchSpecInWorkspaces(ctx context.Context, opts executeBatchSpecOpts
 	repoWorkspaces := convertWorkspaces(input.Workspaces)
 
 	// Parse the raw batch spec contained in the input
-	opts.ui.ParsingBatchSpec()
+	ui.ParsingBatchSpec()
 	batchSpec, err := svc.ParseBatchSpec([]byte(input.RawSpec))
 	if err != nil {
 		var multiErr *multierror.Error
 		if errors.As(err, &multiErr) {
-			opts.ui.ParsingBatchSpecFailure(multiErr)
+			ui.ParsingBatchSpecFailure(multiErr)
 			return cmderrors.ExitCode(2, nil)
 		} else {
 			// This shouldn't happen; let's just punt and let the normal
@@ -124,19 +123,19 @@ func executeBatchSpecInWorkspaces(ctx context.Context, opts executeBatchSpecOpts
 			return err
 		}
 	}
-	opts.ui.ParsingBatchSpecSuccess()
+	ui.ParsingBatchSpecSuccess()
 
 	var workspaceCreator workspace.Creator
 
 	if svc.HasDockerImages(batchSpec) {
-		opts.ui.PreparingContainerImages()
-		images, err := svc.EnsureDockerImages(ctx, batchSpec, opts.ui.PreparingContainerImagesProgress)
+		ui.PreparingContainerImages()
+		images, err := svc.EnsureDockerImages(ctx, batchSpec, ui.PreparingContainerImagesProgress)
 		if err != nil {
 			return err
 		}
-		opts.ui.PreparingContainerImagesSuccess()
+		ui.PreparingContainerImagesSuccess()
 
-		opts.ui.DeterminingWorkspaceCreatorType()
+		ui.DeterminingWorkspaceCreatorType()
 		workspaceCreator = workspace.NewCreator(ctx, opts.flags.workspace, opts.flags.cacheDir, opts.flags.tempDir, images)
 		if workspaceCreator.Type() == workspace.CreatorTypeVolume {
 			_, err = svc.EnsureImage(ctx, workspace.DockerVolumeWorkspaceImage)
@@ -144,21 +143,14 @@ func executeBatchSpecInWorkspaces(ctx context.Context, opts executeBatchSpecOpts
 				return err
 			}
 		}
-		opts.ui.DeterminingWorkspaceCreatorTypeSuccess(workspaceCreator.Type())
+		ui.DeterminingWorkspaceCreatorTypeSuccess(workspaceCreator.Type())
 	}
-
-	lines, ok := opts.ui.(*ui.JSONLines)
-	if !ok {
-		panic("foobar")
-	}
-
-	cache := &executor.JSONLinesCache{Writer: lines}
 
 	// EXECUTION OF TASKS
 	coord := svc.NewCoordinator(executor.NewCoordinatorOpts{
 		Creator:       workspaceCreator,
 		CacheDir:      opts.flags.cacheDir,
-		Cache:         cache,
+		Cache:         &executor.JSONLinesCache{Writer: ui},
 		ClearCache:    opts.flags.clearCache,
 		SkipErrors:    opts.flags.skipErrors,
 		CleanArchives: opts.flags.cleanArchives,
@@ -170,21 +162,21 @@ func executeBatchSpecInWorkspaces(ctx context.Context, opts executeBatchSpecOpts
 		ImportChangesets: false,
 	})
 
-	opts.ui.CheckingCache()
+	ui.CheckingCache()
 	tasks := svc.BuildTasks(ctx, batchSpec, repoWorkspaces)
 	uncachedTasks, cachedSpecs, err := coord.CheckCache(ctx, tasks)
 	if err != nil {
 		return err
 	}
-	opts.ui.CheckingCacheSuccess(len(cachedSpecs), len(uncachedTasks))
+	ui.CheckingCacheSuccess(len(cachedSpecs), len(uncachedTasks))
 
-	taskExecUI := opts.ui.ExecutingTasks(*verbose, opts.flags.parallelism)
+	taskExecUI := ui.ExecutingTasks(*verbose, opts.flags.parallelism)
 	freshSpecs, _, err := coord.Execute(ctx, uncachedTasks, batchSpec, taskExecUI)
 	if err == nil || opts.flags.skipErrors {
 		if err == nil {
 			taskExecUI.Success()
 		} else {
-			opts.ui.ExecutingTasksSkippingErrors(err)
+			ui.ExecutingTasksSkippingErrors(err)
 		}
 	} else {
 		if err != nil {
@@ -197,16 +189,16 @@ func executeBatchSpecInWorkspaces(ctx context.Context, opts executeBatchSpecOpts
 
 	ids := make([]graphql.ChangesetSpecID, len(specs))
 
-	opts.ui.UploadingChangesetSpecs(len(specs))
+	ui.UploadingChangesetSpecs(len(specs))
 	for i, spec := range specs {
 		id, err := svc.CreateChangesetSpec(ctx, spec)
 		if err != nil {
 			return err
 		}
 		ids[i] = id
-		opts.ui.UploadingChangesetSpecsProgress(i+1, len(specs))
+		ui.UploadingChangesetSpecsProgress(i+1, len(specs))
 	}
-	opts.ui.UploadingChangesetSpecsSuccess(ids)
+	ui.UploadingChangesetSpecsSuccess(ids)
 
 	return nil
 }

--- a/cmd/src/batch_exec.go
+++ b/cmd/src/batch_exec.go
@@ -151,6 +151,7 @@ func executeBatchSpecInWorkspaces(ctx context.Context, opts executeBatchSpecOpts
 	coord := svc.NewCoordinator(executor.NewCoordinatorOpts{
 		Creator:       workspaceCreator,
 		CacheDir:      opts.flags.cacheDir,
+		Cache:         &ui.JSONLinesCache{},
 		ClearCache:    opts.flags.clearCache,
 		SkipErrors:    opts.flags.skipErrors,
 		CleanArchives: opts.flags.cleanArchives,

--- a/cmd/src/batch_preview.go
+++ b/cmd/src/batch_preview.go
@@ -49,14 +49,12 @@ Examples:
 			execUI = &ui.TUI{Out: out}
 		}
 
-		err := executeBatchSpec(ctx, executeBatchSpecOpts{
+		err := executeBatchSpec(ctx, execUI, executeBatchSpecOpts{
 			flags:  flags,
 			client: cfg.apiClient(flags.api, flagSet.Output()),
 
 			// Do not apply the uploaded batch spec
 			applyBatchSpec: false,
-
-			ui: execUI,
 		})
 		if err != nil {
 			return cmderrors.ExitCode(1, nil)

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4
 	github.com/sourcegraph/go-diff v0.6.1
 	github.com/sourcegraph/jsonx v0.0.0-20200629203448-1a936bd500cf
-	github.com/sourcegraph/sourcegraph/lib v0.0.0-20211104104606-255e002650dc
+	github.com/sourcegraph/sourcegraph/lib v0.0.0-20211104124831-032ed4e5b75d
 	github.com/ssor/bom v0.0.0-20170718123548-6386211fdfcf // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	golang.org/x/net v0.0.0-20210614182718-04defd469f4e

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4
 	github.com/sourcegraph/go-diff v0.6.1
 	github.com/sourcegraph/jsonx v0.0.0-20200629203448-1a936bd500cf
-	github.com/sourcegraph/sourcegraph/lib v0.0.0-20211104093537-2b2516676fec
+	github.com/sourcegraph/sourcegraph/lib v0.0.0-20211104104606-255e002650dc
 	github.com/ssor/bom v0.0.0-20170718123548-6386211fdfcf // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	golang.org/x/net v0.0.0-20210614182718-04defd469f4e

--- a/go.sum
+++ b/go.sum
@@ -262,6 +262,8 @@ github.com/sourcegraph/sourcegraph/lib v0.0.0-20211104093537-2b2516676fec h1:SvE
 github.com/sourcegraph/sourcegraph/lib v0.0.0-20211104093537-2b2516676fec/go.mod h1:oriyPo0GiQg2oIAjaKAuaNwxiuSmscMVJGfV38ONvqQ=
 github.com/sourcegraph/sourcegraph/lib v0.0.0-20211104104606-255e002650dc h1:r+zAUTmiHxyOfPX3HC6D5qjvfIYHlFUSdSiOmp6avYk=
 github.com/sourcegraph/sourcegraph/lib v0.0.0-20211104104606-255e002650dc/go.mod h1:oriyPo0GiQg2oIAjaKAuaNwxiuSmscMVJGfV38ONvqQ=
+github.com/sourcegraph/sourcegraph/lib v0.0.0-20211104124831-032ed4e5b75d h1:12YQbS5LU5ltOFLzxJW/sbiVIzosvdkdf8kQMLfOc74=
+github.com/sourcegraph/sourcegraph/lib v0.0.0-20211104124831-032ed4e5b75d/go.mod h1:oriyPo0GiQg2oIAjaKAuaNwxiuSmscMVJGfV38ONvqQ=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=

--- a/go.sum
+++ b/go.sum
@@ -260,6 +260,8 @@ github.com/sourcegraph/jsonx v0.0.0-20200629203448-1a936bd500cf h1:oAdWFqhStsWii
 github.com/sourcegraph/jsonx v0.0.0-20200629203448-1a936bd500cf/go.mod h1:ppFaPm6kpcHnZGqQTFhUIAQRIEhdQDWP1PCv4/ON354=
 github.com/sourcegraph/sourcegraph/lib v0.0.0-20211104093537-2b2516676fec h1:SvEo7YwpY2nRGGizAOWlvpitO3qM/NdyhVzR+mkD/a4=
 github.com/sourcegraph/sourcegraph/lib v0.0.0-20211104093537-2b2516676fec/go.mod h1:oriyPo0GiQg2oIAjaKAuaNwxiuSmscMVJGfV38ONvqQ=
+github.com/sourcegraph/sourcegraph/lib v0.0.0-20211104104606-255e002650dc h1:r+zAUTmiHxyOfPX3HC6D5qjvfIYHlFUSdSiOmp6avYk=
+github.com/sourcegraph/sourcegraph/lib v0.0.0-20211104104606-255e002650dc/go.mod h1:oriyPo0GiQg2oIAjaKAuaNwxiuSmscMVJGfV38ONvqQ=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=

--- a/internal/batches/executor/coordinator.go
+++ b/internal/batches/executor/coordinator.go
@@ -44,6 +44,7 @@ type NewCoordinatorOpts struct {
 	EnsureImage     imageEnsurer
 	Creator         workspace.Creator
 	Client          api.Client
+	Cache           ExecutionCache
 
 	// Everything that follows are either command-line flags or features.
 
@@ -68,7 +69,6 @@ type NewCoordinatorOpts struct {
 }
 
 func NewCoordinator(opts NewCoordinatorOpts) *Coordinator {
-	cache := NewCache(opts.CacheDir)
 	logManager := log.NewManager(opts.TempDir, opts.KeepLogs)
 
 	exec := newExecutor(newExecutorOpts{
@@ -83,9 +83,8 @@ func NewCoordinator(opts NewCoordinatorOpts) *Coordinator {
 	})
 
 	return &Coordinator{
-		opts: opts,
-
-		cache:      cache,
+		opts:       opts,
+		cache:      opts.Cache,
 		exec:       exec,
 		logManager: logManager,
 	}

--- a/internal/batches/executor/execution_cache.go
+++ b/internal/batches/executor/execution_cache.go
@@ -291,3 +291,49 @@ func (ExecutionNoOpCache) SetStepResult(ctx context.Context, key CacheKeyer, res
 func (ExecutionNoOpCache) GetStepResult(ctx context.Context, key CacheKeyer) (execution.AfterStepResult, bool, error) {
 	return execution.AfterStepResult{}, false, nil
 }
+
+type JSONCacheWriter interface {
+	WriteExecutionResult(key string, value execution.Result)
+	WriteAfterStepResult(key string, value execution.AfterStepResult)
+}
+
+type JSONLinesCache struct {
+	Writer JSONCacheWriter
+}
+
+func (c *JSONLinesCache) Get(ctx context.Context, key CacheKeyer) (result execution.Result, found bool, err error) {
+	// noop
+	return execution.Result{}, false, nil
+}
+
+func (c *JSONLinesCache) Set(ctx context.Context, key CacheKeyer, result execution.Result) error {
+	k, err := key.Key()
+	if err != nil {
+		return err
+	}
+
+	c.Writer.WriteExecutionResult(k, result)
+
+	return nil
+}
+
+func (c *JSONLinesCache) SetStepResult(ctx context.Context, key CacheKeyer, result execution.AfterStepResult) error {
+	k, err := key.Key()
+	if err != nil {
+		return err
+	}
+
+	c.Writer.WriteAfterStepResult(k, result)
+
+	return nil
+}
+
+func (c *JSONLinesCache) GetStepResult(ctx context.Context, key CacheKeyer) (result execution.AfterStepResult, found bool, err error) {
+	// noop
+	return execution.AfterStepResult{}, false, nil
+}
+
+func (c *JSONLinesCache) Clear(ctx context.Context, key CacheKeyer) error {
+	// noop
+	return nil
+}

--- a/internal/batches/executor/execution_cache.go
+++ b/internal/batches/executor/execution_cache.go
@@ -152,7 +152,7 @@ type ExecutionCache interface {
 	Clear(ctx context.Context, key CacheKeyer) error
 }
 
-func NewCache(dir string) ExecutionCache {
+func NewDiskCache(dir string) ExecutionCache {
 	if dir == "" {
 		return &ExecutionNoOpCache{}
 	}

--- a/internal/batches/ui/json_lines.go
+++ b/internal/batches/ui/json_lines.go
@@ -172,6 +172,22 @@ func (ui *JSONLines) ExecutionError(err error) {
 	logOperationFailure(batcheslib.LogEventOperationBatchSpecExecution, &batcheslib.BatchSpecExecutionMetadata{Error: err.Error()})
 }
 
+var _ executor.JSONCacheWriter = &JSONLines{}
+
+func (ui *JSONLines) WriteExecutionResult(key string, value execution.Result) {
+	logOperationSuccess(batcheslib.LogEventOperationCacheResult, &batcheslib.CacheResultMetadata{
+		Key:   key,
+		Value: value,
+	})
+}
+
+func (ui *JSONLines) WriteAfterStepResult(key string, value execution.AfterStepResult) {
+	logOperationSuccess(batcheslib.LogEventOperationCacheAfterStepResult, &batcheslib.CacheAfterStepResultMetadata{
+		Key:   key,
+		Value: value,
+	})
+}
+
 type taskExecutionJSONLines struct {
 	verbose     bool
 	parallelism int
@@ -376,49 +392,4 @@ func logEvent(e batcheslib.LogEvent) {
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 	}
-}
-
-type JSONLinesCache struct{}
-
-func (c *JSONLinesCache) Get(ctx context.Context, key executor.CacheKeyer) (result execution.Result, found bool, err error) {
-	// noop
-	return execution.Result{}, false, nil
-}
-
-func (c *JSONLinesCache) Set(ctx context.Context, key executor.CacheKeyer, result execution.Result) error {
-	k, err := key.Key()
-	if err != nil {
-		return err
-	}
-
-	logOperationSuccess(batcheslib.LogEventOperationCacheResult, &batcheslib.CacheResultMetadata{
-		Key:   k,
-		Value: result,
-	})
-
-	return nil
-}
-
-func (c *JSONLinesCache) SetStepResult(ctx context.Context, key executor.CacheKeyer, result execution.AfterStepResult) error {
-	k, err := key.Key()
-	if err != nil {
-		return err
-	}
-
-	logOperationSuccess(batcheslib.LogEventOperationCacheAfterStepResult, &batcheslib.CacheAfterStepResultMetadata{
-		Key:   k,
-		Value: result,
-	})
-
-	return nil
-}
-
-func (c *JSONLinesCache) GetStepResult(ctx context.Context, key executor.CacheKeyer) (result execution.AfterStepResult, found bool, err error) {
-	// noop
-	return execution.AfterStepResult{}, false, nil
-}
-
-func (c *JSONLinesCache) Clear(ctx context.Context, key executor.CacheKeyer) error {
-	// noop
-	return nil
 }

--- a/internal/batches/ui/json_lines.go
+++ b/internal/batches/ui/json_lines.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sourcegraph/src-cli/internal/batches/workspace"
 
 	batcheslib "github.com/sourcegraph/sourcegraph/lib/batches"
+	"github.com/sourcegraph/sourcegraph/lib/batches/execution"
 	"github.com/sourcegraph/sourcegraph/lib/batches/git"
 )
 
@@ -375,4 +376,49 @@ func logEvent(e batcheslib.LogEvent) {
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 	}
+}
+
+type JSONLinesCache struct{}
+
+func (c *JSONLinesCache) Get(ctx context.Context, key executor.CacheKeyer) (result execution.Result, found bool, err error) {
+	// noop
+	return execution.Result{}, false, nil
+}
+
+func (c *JSONLinesCache) Set(ctx context.Context, key executor.CacheKeyer, result execution.Result) error {
+	k, err := key.Key()
+	if err != nil {
+		return err
+	}
+
+	logOperationSuccess(batcheslib.LogEventOperationCacheResult, &batcheslib.CacheResultMetadata{
+		Key:   k,
+		Value: result,
+	})
+
+	return nil
+}
+
+func (c *JSONLinesCache) SetStepResult(ctx context.Context, key executor.CacheKeyer, result execution.AfterStepResult) error {
+	k, err := key.Key()
+	if err != nil {
+		return err
+	}
+
+	logOperationSuccess(batcheslib.LogEventOperationCacheAfterStepResult, &batcheslib.CacheAfterStepResultMetadata{
+		Key:   k,
+		Value: result,
+	})
+
+	return nil
+}
+
+func (c *JSONLinesCache) GetStepResult(ctx context.Context, key executor.CacheKeyer) (result execution.AfterStepResult, found bool, err error) {
+	// noop
+	return execution.AfterStepResult{}, false, nil
+}
+
+func (c *JSONLinesCache) Clear(ctx context.Context, key executor.CacheKeyer) error {
+	// noop
+	return nil
 }


### PR DESCRIPTION
This is part of https://github.com/sourcegraph/sourcegraph/issues/26929
and requires https://github.com/sourcegraph/sourcegraph/pull/27061 on
the `sourcegraph/sourcegraph` side.

It adds a `JSONLinesCache` that writes cache entries to stdout. It's
used when executing `src batch exec`, which results in cache entries
being transfered to the Sourcegraph server via the executor.