### PR TITLE
Simplify caching logic in 'src batch exec'

### DIFF
--- a/cmd/src/batch_exec.go
+++ b/cmd/src/batch_exec.go
@@ -164,14 +164,14 @@ func executeBatchSpecInWorkspaces(ctx context.Context, ui *ui.JSONLines, opts ex
 	// are loaded and set on the tasks.
 	ui.CheckingCache()
 	tasks := svc.BuildTasks(ctx, batchSpec, repoWorkspaces)
-	_, _, err = coord.CheckCache(ctx, tasks)
+	uncachedTasks, cachedSpecs, err := coord.CheckCache(ctx, tasks)
 	if err != nil {
 		return err
 	}
-	ui.CheckingCacheSuccess(0, len(tasks))
+	ui.CheckingCacheSuccess(len(cachedSpecs), len(uncachedTasks))
 
 	taskExecUI := ui.ExecutingTasks(*verbose, opts.flags.parallelism)
-	specs, _, err := coord.Execute(ctx, tasks, batchSpec, taskExecUI)
+	specs, _, err := coord.Execute(ctx, uncachedTasks, batchSpec, taskExecUI)
 	if err == nil || opts.flags.skipErrors {
 		if err == nil {
 			taskExecUI.Success()
@@ -184,6 +184,7 @@ func executeBatchSpecInWorkspaces(ctx context.Context, ui *ui.JSONLines, opts ex
 			return err
 		}
 	}
+	specs = append(specs, cachedSpecs...)
 
 	ids := make([]graphql.ChangesetSpecID, len(specs))
 

--- a/internal/batches/executor/coordinator.go
+++ b/internal/batches/executor/coordinator.go
@@ -103,6 +103,17 @@ func (c *Coordinator) CheckCache(ctx context.Context, tasks []*Task) (uncached [
 	return uncached, specs, nil
 }
 
+// CheckStepResultsCache checks the cache for each Task, but only for cached
+// step results. This is used by `src batch exec` when executing server-side.
+func (c *Coordinator) CheckStepResultsCache(ctx context.Context, tasks []*Task) error {
+	for _, t := range tasks {
+		if err := c.loadCachedStepResults(ctx, t); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (c *Coordinator) ClearCache(ctx context.Context, tasks []*Task) error {
 	for _, task := range tasks {
 		cacheKey := task.cacheKey()


### PR DESCRIPTION
This is part of https://github.com/sourcegraph/sourcegraph/issues/26929
and simplifies the caching-related logic in `src batch exec` to only
what's needed: checking for per-step cache results.

Since server-side batch changes use server-side caching for changeset
specs we don't need to check for changeset specs.