### PR TITLE
batches: support volume mode on Apple Silicon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ All notable changes to `src-cli` are documented in this file.
 
 ### Changed
 
+- `src batch [preview|apply]` will now use the faster volume workspace by default for macOS systems using arm64 processors (aka "Apple Silicon")
+
 ### Fixed
 
 ### Removed

--- a/internal/batches/workspace/workspace.go
+++ b/internal/batches/workspace/workspace.go
@@ -95,9 +95,9 @@ func BestCreatorType(ctx context.Context, images map[string]docker.Image) Creato
 	// if you have a batch change with steps that run as UID 1000 and then UID
 	// 2000, you'll get errors when the second step tries to write.
 
-	// For the time being, we're only going to consider volume mode on Intel
-	// macOS.
-	if runtime.GOOS != "darwin" || runtime.GOARCH != "amd64" {
+	// For the time being, we're only going to consider volume mode on Intel or
+	// M1 macOS.
+	if runtime.GOOS != "darwin" || (runtime.GOARCH != "amd64" && runtime.GOARCH != "arm64") {
 		return CreatorTypeBind
 	}
 

--- a/internal/batches/workspace/workspace.go
+++ b/internal/batches/workspace/workspace.go
@@ -95,8 +95,11 @@ func BestCreatorType(ctx context.Context, images map[string]docker.Image) Creato
 	// if you have a batch change with steps that run as UID 1000 and then UID
 	// 2000, you'll get errors when the second step tries to write.
 
-	// For the time being, we're only going to consider volume mode on Intel or
-	// M1 macOS.
+	// NOTE: For the time being, we're only going to consider volume mode on Intel or M1
+	// macOS. As we've generally not observed many issues from users using volume mode, and
+	// it is the faster of the options on non-Linux platforms (and only a touch slower on
+	// Linux itself), we should consider making it the default in the future for the sake of
+	// consistency.
 	if runtime.GOOS != "darwin" || (runtime.GOARCH != "amd64" && runtime.GOARCH != "arm64") {
 		return CreatorTypeBind
 	}
@@ -106,7 +109,7 @@ func BestCreatorType(ctx context.Context, images map[string]docker.Image) Creato
 
 func detectBestCreatorType(ctx context.Context, images map[string]docker.Image) CreatorType {
 	// OK, so we're interested in volume mode, but we need to take its
-	// shortcomings around mixed user environments into account.
+	// shortcomings around mixed user environments on Linux into account.
 	//
 	// To do that, let's iterate over the Docker images that are going to be
 	// used and get their default UID. This admittedly only gets us so far —


### PR DESCRIPTION
Tested basic "hello world" batch spec with volume mount mode (both setting the workspace flag and on auto with the new default condition) and didn't see any issues with the execution or the diffs produced. The new condition will default to volume mode for Intel and M1 Macs and keep bind mode as the default for anything else. I updated some comments in the area to capture the discussion @LawnGnome and I had about eventually moving to volume mode as the default for everyone.

Closes https://github.com/sourcegraph/sourcegraph/issues/27549