### PR TITLE
Fix log lines being intertwined by newlines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ All notable changes to `src-cli` are documented in this file.
 
 ### Fixed
 
+- Excess newlines in between outputs in logfiles written when `--keep-logs` is used have been fixed. [#665](https://github.com/sourcegraph/src-cli/pull/665)
+
 ### Removed
 
 ## 3.34.1

--- a/internal/batches/log/task_logger.go
+++ b/internal/batches/log/task_logger.go
@@ -82,7 +82,19 @@ type prefixWriter struct {
 }
 
 func (pw *prefixWriter) Write(p []byte) (int, error) {
-	for _, line := range bytes.Split(p, []byte("\n")) {
+	// Don't split on the final newline in this writer, split
+	// content into separate lines anyways, so lines without \n
+	// at the end wouldn't print properly regardless. This fixes
+	// output being separated by constant newlines.
+	// Otherwise:
+	// > echo Hello world; echo Hello Sourcegraph
+	//
+	// Hello world
+	//
+	// Hello Sourcegraph
+	//
+	t := bytes.TrimSuffix(p, []byte("\n"))
+	for _, line := range bytes.Split(t, []byte("\n")) {
 		pw.logger.Logf("%s | %s", pw.prefix, string(line))
 	}
 	return len(p), nil


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/27860

Output after this change:

```
2021-11-26T15:13:58.653891+01:00 [Step 1] run: "echo \"I am the real Doctor Doom!\";\necho \"Doom?\";\ni=1\nwhile [ $i -le 3 ]\ndo\n  echo \"Doom!\"\n  i=$(($i+1))\ndone\necho \"I am the one true doom!\";\necho \"Doom was here!\" >> message.txt && cat message.txt;\n", container: "alpine:3"
2021-11-26T15:13:58.654013+01:00 [Step 1] full command: "docker run --rm --init --cidfile /tmp/github.com-sourcegraph-src-cli-e1b02cba1a569231092d19edae4701aca205091a-container-id3858813705 --workdir /work --mount type=bind,source=/tmp/3671410092,target=/tmp/tmp.AGjGdD,ro --user 0:0 --mount type=volume,source=1b39a55789ee5b072a7014e132d8bc9b410049d7b5ceb83e1a0b43c49b5e882e,target=/work --entrypoint /bin/sh -- sha256:d6e46aa2470df1d32034c6707c8041158b652f38d2a9ae3d7ad7e7532d22ebe0 /tmp/tmp.AGjGdD"
2021-11-26T15:13:59.152889+01:00 stdout | I am the real Doctor Doom!
2021-11-26T15:13:59.152936+01:00 stdout | Doom?
2021-11-26T15:13:59.152947+01:00 stdout | Doom!
2021-11-26T15:13:59.152956+01:00 stdout | Doom!
2021-11-26T15:13:59.152964+01:00 stdout | Doom!
2021-11-26T15:13:59.152974+01:00 stdout | I am the one true doom!
2021-11-26T15:13:59.153936+01:00 stdout | Doom was here!
2021-11-26T15:13:59.263706+01:00 [Step 1] complete in 610ms
2021-11-26T15:14:01.957952+01:00 [Step 2] run: "echo \"${{ outputs.stepOneOutput }}\"", container: "alpine:3"
2021-11-26T15:14:01.957977+01:00 [Step 2] full command: "docker run --rm --init --cidfile /tmp/github.com-sourcegraph-src-cli-e1b02cba1a569231092d19edae4701aca205091a-container-id2611694238 --workdir /work --mount type=bind,source=/tmp/2595855663,target=/tmp/tmp.EOkIOC,ro --user 0:0 --mount type=volume,source=1b39a55789ee5b072a7014e132d8bc9b410049d7b5ceb83e1a0b43c49b5e882e,target=/work --entrypoint /bin/sh -- sha256:d6e46aa2470df1d32034c6707c8041158b652f38d2a9ae3d7ad7e7532d22ebe0 /tmp/tmp.EOkIOC"
2021-11-26T15:14:02.484039+01:00 stdout | Doom says: I am the real Doctor Doom!
2021-11-26T15:14:02.484112+01:00 stdout | Doom?
2021-11-26T15:14:02.48413+01:00 stdout | Doom!
2021-11-26T15:14:02.484145+01:00 stdout | Doom!
2021-11-26T15:14:02.484156+01:00 stdout | Doom!
2021-11-26T15:14:02.484193+01:00 stdout | I am the one true doom!
2021-11-26T15:14:02.484242+01:00 stdout | Doom was here!
2021-11-26T15:14:02.48426+01:00 stdout | 
2021-11-26T15:14:02.612467+01:00 [Step 2] complete in 654ms
```