### PR TITLE
go.mod: pull in sourcegraph/sourcegraph#28240 fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to `src-cli` are documented in this file.
 ### Fixed
 
 - Excess newlines in between outputs in logfiles written when `--keep-logs` is used have been fixed. [#665](https://github.com/sourcegraph/src-cli/pull/665)
+- `src` would sometimes panic when Ctrl-C was pressed while executing batch change steps due to a bug in the library used to render the execution progress bars. This has been fixed. [🤘 #666](https://github.com/sourcegraph/src-cli/pull/666)
 
 ### Removed
 

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4
 	github.com/sourcegraph/go-diff v0.6.1
 	github.com/sourcegraph/jsonx v0.0.0-20200629203448-1a936bd500cf
-	github.com/sourcegraph/sourcegraph/lib v0.0.0-20211115102128-3c8c7a9499a3
+	github.com/sourcegraph/sourcegraph/lib v0.0.0-20211126224101-2ada4911722e
 	github.com/ssor/bom v0.0.0-20170718123548-6386211fdfcf // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d

--- a/go.sum
+++ b/go.sum
@@ -258,8 +258,8 @@ github.com/sourcegraph/go-diff v0.6.1 h1:hmA1LzxW0n1c3Q4YbrFgg4P99GSnebYa3x8gr0H
 github.com/sourcegraph/go-diff v0.6.1/go.mod h1:iBszgVvyxdc8SFZ7gm69go2KDdt3ag071iBaWPF6cjs=
 github.com/sourcegraph/jsonx v0.0.0-20200629203448-1a936bd500cf h1:oAdWFqhStsWiiMP/vkkHiMXqFXzl1XfUNOdxKJbd6bI=
 github.com/sourcegraph/jsonx v0.0.0-20200629203448-1a936bd500cf/go.mod h1:ppFaPm6kpcHnZGqQTFhUIAQRIEhdQDWP1PCv4/ON354=
-github.com/sourcegraph/sourcegraph/lib v0.0.0-20211115102128-3c8c7a9499a3 h1:vaflMp94dFzfdgb2MIxGEVQKo1O1o3uH9w0sYds/ZBU=
-github.com/sourcegraph/sourcegraph/lib v0.0.0-20211115102128-3c8c7a9499a3/go.mod h1:4WdX5odo9YL0GD0Wg9OZJJtIJIn1jIsh+UWrQ4MEcaw=
+github.com/sourcegraph/sourcegraph/lib v0.0.0-20211126224101-2ada4911722e h1:BZpmejyF9KR5h7U9U/lfg4PfcPQZc29fuNGn0c1kT+c=
+github.com/sourcegraph/sourcegraph/lib v0.0.0-20211126224101-2ada4911722e/go.mod h1:4WdX5odo9YL0GD0Wg9OZJJtIJIn1jIsh+UWrQ4MEcaw=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=


### PR DESCRIPTION
As promised, this includes a changelog entry.