### PR TITLE
Remove CSRF tokens fetching code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ All notable changes to `src-cli` are documented in this file.
 
 ### Removed
 
+## 3.35.1
+
+### Changed
+
+- `src validate` has been updated to work with Sourcegraph 3.35's changed CSRF behaviour. [#673](https://github.com/sourcegraph/src-cli/pull/673)
+
 ## 3.35.0
 
 ### Added

--- a/cmd/src/validate.go
+++ b/cmd/src/validate.go
@@ -454,22 +454,6 @@ func (vd *validator) signIn(baseURL string, email, password string) (*vdClient, 
 	return client, nil
 }
 
-// extractCSRFToken extracts CSRF token from HTML response body.
-func (vd *validator) extractCSRFToken(body string) string {
-	anchor := `X-Csrf-Token":"`
-	i := strings.Index(body, anchor)
-	if i == -1 {
-		return ""
-	}
-
-	j := strings.Index(body[i+len(anchor):], `","`)
-	if j == -1 {
-		return ""
-	}
-
-	return body[i+len(anchor) : i+len(anchor)+j]
-}
-
 // Client is an authenticated client for a Sourcegraph user for doing e2e testing.
 // The user may or may not be a site admin depends on how the client is instantiated.
 // It works by simulating how the browser would send HTTP requests to the server.

--- a/cmd/src/validate.go
+++ b/cmd/src/validate.go
@@ -415,10 +415,7 @@ func (vd *validator) createAccessToken(username string) (string, error) {
 // SiteAdminInit initializes the instance with given admin account.
 // It returns an authenticated client as the admin for doing e2e testing.
 func (vd *validator) siteAdminInit(baseURL, email, username, password string) (*vdClient, error) {
-	client, err := vd.newClient(baseURL)
-	if err != nil {
-		return nil, err
-	}
+	client := vd.newClient(baseURL)
 
 	var request = struct {
 		Email    string `json:"email"`
@@ -429,7 +426,7 @@ func (vd *validator) siteAdminInit(baseURL, email, username, password string) (*
 		Username: username,
 		Password: password,
 	}
-	err = client.authenticate("/-/site-init", request)
+	err := client.authenticate("/-/site-init", request)
 	if err != nil {
 		return nil, err
 	}
@@ -440,10 +437,7 @@ func (vd *validator) siteAdminInit(baseURL, email, username, password string) (*
 // SignIn performs the sign in with given user credentials.
 // It returns an authenticated client as the user for doing e2e testing.
 func (vd *validator) signIn(baseURL string, email, password string) (*vdClient, error) {
-	client, err := vd.newClient(baseURL)
-	if err != nil {
-		return nil, err
-	}
+	client := vd.newClient(baseURL)
 
 	var request = struct {
 		Email    string `json:"email"`
@@ -452,7 +446,7 @@ func (vd *validator) signIn(baseURL string, email, password string) (*vdClient, 
 		Email:    email,
 		Password: password,
 	}
-	err = client.authenticate("/-/sign-in", request)
+	err := client.authenticate("/-/sign-in", request)
 	if err != nil {
 		return nil, err
 	}
@@ -481,47 +475,16 @@ func (vd *validator) extractCSRFToken(body string) string {
 // It works by simulating how the browser would send HTTP requests to the server.
 type vdClient struct {
 	baseURL       string
-	csrfToken     string
-	csrfCookie    *http.Cookie
 	sessionCookie *http.Cookie
 
 	userID string
 }
 
-// newClient instantiates a new client by performing a GET request then obtains the
-// CSRF token and cookie from its response.
-func (vd *validator) newClient(baseURL string) (*vdClient, error) {
-	resp, err := http.Get(baseURL)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	p, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	csrfToken := vd.extractCSRFToken(string(p))
-	if csrfToken == "" {
-		return nil, err
-	}
-	var csrfCookie *http.Cookie
-	for _, cookie := range resp.Cookies() {
-		if cookie.Name == "sg_csrf_token" {
-			csrfCookie = cookie
-			break
-		}
-	}
-	if csrfCookie == nil {
-		return nil, errors.New(`"sg_csrf_token" cookie not found`)
-	}
-
+// newClient instantiates a new client.
+func (vd *validator) newClient(baseURL string) *vdClient {
 	return &vdClient{
-		baseURL:    baseURL,
-		csrfToken:  csrfToken,
-		csrfCookie: csrfCookie,
-	}, nil
+		baseURL: baseURL,
+	}
 }
 
 // authenticate is used to send a HTTP POST request to an URL that is able to authenticate
@@ -538,8 +501,6 @@ func (c *vdClient) authenticate(path string, body interface{}) error {
 		return err
 	}
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("X-Csrf-Token", c.csrfToken)
-	req.AddCookie(c.csrfCookie)
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -643,7 +604,6 @@ func (c *vdClient) graphQL(token, query string, variables map[string]interface{}
 		// NOTE: We use this header to protect from CSRF attacks of HTTP API,
 		// see https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/cmd/frontend/internal/cli/http.go#L41-42
 		req.Header.Set("X-Requested-With", "Sourcegraph")
-		req.AddCookie(c.csrfCookie)
 		req.AddCookie(c.sessionCookie)
 	}
 


### PR DESCRIPTION
Follow-up to this problem reported on [Slack](https://sourcegraph.slack.com/archives/C01N83PS4TU/p1640031669019000).

Due to https://github.com/sourcegraph/sourcegraph/pull/28572, the CSRF headers were removed and due to a bug in the error checking code, [triggers a panic](https://buildkite.com/sourcegraph/deploy-sourcegraph/builds/24470).