### PR TITLE
search: use .api/search/stream

### DIFF
--- a/internal/streaming/search.go
+++ b/internal/streaming/search.go
@@ -21,7 +21,7 @@ type Opts struct {
 // response body.
 func Search(query string, opts Opts, client api.Client, decoder Decoder) error {
 	// Create request.
-	req, err := client.NewHTTPRequest(context.Background(), "GET", "search/stream?q="+url.QueryEscape(query), nil)
+	req, err := client.NewHTTPRequest(context.Background(), "GET", ".api/search/stream?q="+url.QueryEscape(query), nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Relates to https://github.com/sourcegraph/sourcegraph/issues/29399

This updates stream search to call .api/search/stream instead of
/search/stream. We plan to retire /search/stream as soon as all clients
have been migrated.

