### PR TITLE
batches: encourage semver that prerelease versions are newer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ All notable changes to `src-cli` are documented in this file.
 
 ### Fixed
 
+- Certain Batch Changes features that previously would not work on prerelease versions of Sourcegraph will now work as expected again.
+
 ### Removed
 
 ## 3.35.2

--- a/internal/api/version_check.go
+++ b/internal/api/version_check.go
@@ -6,6 +6,17 @@ import (
 	"github.com/Masterminds/semver"
 )
 
+// NOTE: A version with a prerelease suffix (e.g. the "-rc.3" of "3.35.1-rc.3") is not
+// considered by semver to satisfy a constraint without a prerelease suffix, regardless of
+// whether or not the major/minor/patch version is greater than or equal to that of the
+// constraint.
+//
+// For example, the version "3.35.1-rc.3" is not considered to satisfy the constraint ">=
+// 3.23.0". This is likely not the expected outcome. However, the same version IS
+// considered to satisfy the constraint "3.23.0-0". Thus, it is recommended to pass a
+// constraint with a minimum prerelease version suffix attached if comparisons to
+// prerelease versions are ever expected. See
+// https://github.com/Masterminds/semver#working-with-prerelease-versions for more.
 func CheckSourcegraphVersion(version, constraint, minDate string) (bool, error) {
 	if version == "dev" || version == "0.0.0+dev" {
 		return true, nil
@@ -26,5 +37,6 @@ func CheckSourcegraphVersion(version, constraint, minDate string) (bool, error) 
 	if err != nil {
 		return false, err
 	}
+
 	return c.Check(v), nil
 }

--- a/internal/batches/features.go
+++ b/internal/batches/features.go
@@ -25,14 +25,21 @@ func (ff *FeatureFlags) SetFromVersion(version string) error {
 		constraint string
 		minDate    string
 	}{
-		{&ff.AllowArrayEnvironments, ">= 3.23.0", "2020-11-24"},
-		{&ff.IncludeAutoAuthorDetails, ">= 3.20.0", "2020-09-10"},
-		{&ff.UseGzipCompression, ">= 3.21.0", "2020-10-12"},
-		{&ff.AllowTransformChanges, ">= 3.23.0", "2020-12-11"},
-		{&ff.AllowWorkspaces, ">= 3.25.0", "2021-01-29"},
-		{&ff.BatchChanges, ">= 3.26.0", "2021-03-07"},
-		{&ff.AllowConditionalExec, ">= 3.28.0", "2021-05-05"},
-		{&ff.AllowOptionalPublished, ">= 3.30.0", "2021-06-21"},
+		// NOTE: It's necessary to include a "-0" prerelease suffix on each constraint so that
+		// prereleases of future versions are still considered to satisfy the constraint.
+		//
+		// For example, the version "3.35.1-rc.3" is not considered to satisfy the constraint
+		// ">= 3.23.0". However, the same version IS considered to satisfy the constraint
+		// "3.23.0-0". See
+		// https://github.com/Masterminds/semver#working-with-prerelease-versions for more.
+		{&ff.AllowArrayEnvironments, ">= 3.23.0-0", "2020-11-24"},
+		{&ff.IncludeAutoAuthorDetails, ">= 3.20.0-0", "2020-09-10"},
+		{&ff.UseGzipCompression, ">= 3.21.0-0", "2020-10-12"},
+		{&ff.AllowTransformChanges, ">= 3.23.0-0", "2020-12-11"},
+		{&ff.AllowWorkspaces, ">= 3.25.0-0", "2021-01-29"},
+		{&ff.BatchChanges, ">= 3.26.0-0", "2021-03-07"},
+		{&ff.AllowConditionalExec, ">= 3.28.0-0", "2021-05-05"},
+		{&ff.AllowOptionalPublished, ">= 3.30.0-0", "2021-06-21"},
 	} {
 		value, err := api.CheckSourcegraphVersion(version, feature.constraint, feature.minDate)
 		if err != nil {


### PR DESCRIPTION
This is a partial fix for the issue Malo was running into when trying to execute a batch spec with src-cli on demo.sourcegraph.com despite having `user.name` and `user.email` set in his git config:

```
❌ Error:
   {
     "message": "3 errors occurred:\n\t* Must validate one and only one schema (oneOf)\n\t* commits.0: authorName is required\n\t* commits.0: authorEmail is required\n\n",
     "path": [
       "createChangesetSpec"
     ]
   }
```

I thought, and we say in the docs, that

> The commits created from your spec will use the git config values for `user.name` and `user.email` from your local environment

but I couldn't actually find if/how this happening in the code. In `BuildChangesetSpecs`, we explicitly [only check the changeset template from the input spec](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/lib/batches/changeset_specs.go?#L64:2-80:2), and the closest I could find to us actually looking at the git config is where we [pull from these values](https://sourcegraph.com/github.com/sourcegraph/src-cli/-/blob/internal/batches/service/service.go#L363:2-365:52) to pre-populate them in the batch spec file for `src batch new`. So maybe this isn't actually correct. 😬

Regardless of whether or not we do pull from the local git config, the point still remains that we should be [falling back on batch-changes@sourcegraph.com and "Sourcegraph"](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/lib/batches/changeset_specs.go?#L65:2-69:2), so the error Malo ran into is still out of place.

In a strange turn of events, I was able to trace this to the [feature flag](https://sourcegraph.com/github.com/sourcegraph/src-cli/-/blob/internal/batches/executor/coordinator.go#L196:2-199:4) `IncludeAutoAuthorDetails`. It turns out that the version currently on demo (3.35.1-rc.3) is not considered by semver to pass the [constraint](https://sourcegraph.com/github.com/sourcegraph/src-cli/-/blob/internal/batches/features.go#L29:3-29:63) we have for this feature flag (">= 3.20.0") due to the prerelease part (-rc.3), so the lack of author and email specified in the batch spec would actually fail the schema validation since the feature to use the fallbacks is not turned on.

The "fix" in this case is to reassure semver that 3.35.1-rc.3 does, in fact, satisfy the constraint ">= 3.20.0", by telling it to actually evaluate and consider prerelease versions by including the minimum possible prerelease version suffix on the constraint: ">= 3.20.0-0", as it suggests [in their docs](https://github.com/Masterminds/semver#working-with-prerelease-versions).

I tested and ensured that the constraint is still satisfied by versions without a prerelease, as before (e.g. 3.35.1 also still passes the check).