### PR TITLE
batches: match on abbreviated commit hash in version

### DIFF
--- a/internal/api/version_check.go
+++ b/internal/api/version_check.go
@@ -22,7 +22,10 @@ func CheckSourcegraphVersion(version, constraint, minDate string) (bool, error) 
 		return true, nil
 	}
 
-	buildDate := regexp.MustCompile(`^\d+_(\d{4}-\d{2}-\d{2})_[a-z0-9]{7}$`)
+	// This should match the version format returned by Sourcegraph, which uses the 12
+	// character abbreviated commit hash:
+	// https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/enterprise/dev/ci/internal/ci/config.go?L96.
+	buildDate := regexp.MustCompile(`^\d+_(\d{4}-\d{2}-\d{2})_[a-z0-9]{12}$`)
 	matches := buildDate.FindStringSubmatch(version)
 	if len(matches) > 1 {
 		return matches[1] >= minDate, nil

--- a/internal/api/version_check.go
+++ b/internal/api/version_check.go
@@ -22,10 +22,11 @@ func CheckSourcegraphVersion(version, constraint, minDate string) (bool, error) 
 		return true, nil
 	}
 
-	// This should match the version format returned by Sourcegraph, which uses the 12
-	// character abbreviated commit hash:
+	// Since we don't actually care about the abbreviated commit hash at the end of the
+	// version string, we match on 7 or more characters. Currently, the Sourcegraph version
+	// is expected to return 12:
 	// https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/enterprise/dev/ci/internal/ci/config.go?L96.
-	buildDate := regexp.MustCompile(`^\d+_(\d{4}-\d{2}-\d{2})_[a-z0-9]{12}$`)
+	buildDate := regexp.MustCompile(`^\d+_(\d{4}-\d{2}-\d{2})_[a-z0-9]{7,}$`)
 	matches := buildDate.FindStringSubmatch(version)
 	if len(matches) > 1 {
 		return matches[1] >= minDate, nil

--- a/internal/api/version_check_test.go
+++ b/internal/api/version_check_test.go
@@ -93,7 +93,7 @@ func TestCheckSourcegraphVersion(t *testing.T) {
 			minDate:        "2020-01-29",
 			constraint:     ">= 0.0",
 			expected:       true,
-		}
+		},
 	} {
 		actual, err := CheckSourcegraphVersion(tc.currentVersion, tc.constraint, tc.minDate)
 		if err != nil {

--- a/internal/api/version_check_test.go
+++ b/internal/api/version_check_test.go
@@ -20,6 +20,12 @@ func TestCheckSourcegraphVersion(t *testing.T) {
 			expected:       true,
 		},
 		{
+			currentVersion: "3.12.6-rc.3",
+			constraint:     ">= 3.10.6-0",
+			minDate:        "2020-01-19",
+			expected:       true,
+		},
+		{
 			currentVersion: "3.12.6",
 			constraint:     ">= 3.13",
 			minDate:        "2020-01-19",
@@ -44,19 +50,19 @@ func TestCheckSourcegraphVersion(t *testing.T) {
 			expected:       true,
 		},
 		{
-			currentVersion: "54959_2020-01-29_9258595",
+			currentVersion: "54959_2020-01-29_925859585436",
 			minDate:        "2020-01-19",
 			constraint:     ">= 999.13",
 			expected:       true,
 		},
 		{
-			currentVersion: "54959_2020-01-29_9258595",
+			currentVersion: "54959_2020-01-29_925859585436",
 			minDate:        "2020-01-30",
 			constraint:     ">= 999.13",
 			expected:       false,
 		},
 		{
-			currentVersion: "54959_2020-01-29_9258595",
+			currentVersion: "54959_2020-01-29_925859585436",
 			minDate:        "2020-01-29",
 			constraint:     ">= 0.0",
 			expected:       true,

--- a/internal/api/version_check_test.go
+++ b/internal/api/version_check_test.go
@@ -49,6 +49,26 @@ func TestCheckSourcegraphVersion(t *testing.T) {
 			minDate:        "2020-01-19",
 			expected:       true,
 		},
+		// 7-character abbreviated hash
+		{
+			currentVersion: "54959_2020-01-29_9258595",
+			minDate:        "2020-01-19",
+			constraint:     ">= 999.13",
+			expected:       true,
+		},
+		{
+			currentVersion: "54959_2020-01-29_9258595",
+			minDate:        "2020-01-30",
+			constraint:     ">= 999.13",
+			expected:       false,
+		},
+		{
+			currentVersion: "54959_2020-01-29_9258595",
+			minDate:        "2020-01-29",
+			constraint:     ">= 0.0",
+			expected:       true,
+		},
+		// 12-character abbreviated hash
 		{
 			currentVersion: "54959_2020-01-29_925859585436",
 			minDate:        "2020-01-19",
@@ -67,6 +87,13 @@ func TestCheckSourcegraphVersion(t *testing.T) {
 			constraint:     ">= 0.0",
 			expected:       true,
 		},
+		// Full 40-character hash, just for fun
+		{
+			currentVersion: "54959_2020-01-29_7db7d396346284fd0f8f79f130f38b16fb1d3d70",
+			minDate:        "2020-01-29",
+			constraint:     ">= 0.0",
+			expected:       true,
+		}
 	} {
 		actual, err := CheckSourcegraphVersion(tc.currentVersion, tc.constraint, tc.minDate)
 		if err != nil {


### PR DESCRIPTION
Follow up to https://github.com/sourcegraph/sourcegraph/pull/29654, the version string for Sourcegraph in certain pre-release environments now will feature the 12-character abbreviated commit hash at the end.

See https://sourcegraph.slack.com/archives/C01N83PS4TU/p1642013850061100 for more.

Fixes [29618](https://github.com/sourcegraph/sourcegraph/issues/29618).