### PR TITLE
Don't wait on stdin by default for batch commands

### DIFF
--- a/cmd/src/batch_common.go
+++ b/cmd/src/batch_common.go
@@ -96,8 +96,8 @@ func newBatchExecuteFlags(flagSet *flag.FlagSet, workspaceExecution bool, cacheD
 	)
 
 	flagSet.StringVar(
-		&caf.file, "f", "",
-		"The batch spec file to read.",
+		&caf.file, "f", "batch.yaml",
+		"The batch spec file to read. Set to - for stdin.",
 	)
 
 	flagSet.IntVar(

--- a/cmd/src/batch_repositories.go
+++ b/cmd/src/batch_repositories.go
@@ -32,7 +32,7 @@ Examples:
 	flagSet := flag.NewFlagSet("repositories", flag.ExitOnError)
 
 	var (
-		fileFlag = flagSet.String("f", "", "The batch spec file to read.")
+		fileFlag = flagSet.String("f", "batch.yaml", "The batch spec file to read. Set to - for stdin.")
 		apiFlags = api.NewFlags(flagSet)
 	)
 

--- a/cmd/src/batch_validate.go
+++ b/cmd/src/batch_validate.go
@@ -29,7 +29,7 @@ Examples:
 
 	flagSet := flag.NewFlagSet("validate", flag.ExitOnError)
 	apiFlags := api.NewFlags(flagSet)
-	fileFlag := flagSet.String("f", "", "The batch spec file to read.")
+	fileFlag := flagSet.String("f", "batch.yaml", "The batch spec file to read. Set to - for stdin.")
 
 	var (
 		allowUnsupported bool


### PR DESCRIPTION
So I've been on a several month long goose chase.
I have been unable to create sourcegraph batches due to it hanging when running things like `src batch preview` in the folder that has a batch spec file.
It would hang forever on the message `⠋  Parsing batch spec`
Maybe the issue is already obvious here, but I was in contact with Sourcegraph staff about this and did show them my invocation, and they also asked me to try some invocations with the same issue.

I tried this on windows, on wsl2, and even created a virtual box ubuntu vm, all had the same issue. Then finally I dusted off an old mac pro and tried it there, the same issue. So it obviously wasn't a hardware problem.
At that point I realized the cli is open source so I just tried to reproduce it with a debugger attached, and it was easily reproducible.

The problem is that it seems that `src` requires you to specify `-f` when you want to use a file, and it does not by default find the `batch.yaml` in the current folder.
Instead it defaults to reading from stdin and expects the batch file from there. This is not printed however so an end user is completely stumped as to what is going on.
The help text for the commands does not mention this either, so for the casual user it would not be obvious that you cannot ommit `-f` and instead are expected to add it or do something like `cat batch.yaml | src batch preview`.

This PR serves as one example how to solve this.

I set the default value to if `-f` is missing to be `batch.yaml`, which is what `src batch new` creates by default.
So to me it seems obvious that by default the batch commands looks for the file that is created when a new batch is created with the default name.

This is obviously a breaking change, but I cannot speak to how much of an issue this is. If you know that a lot of tooling exists that rely on this, then you likely would not want this approach.

Another approach would be to simply print "waiting for stdin" when stdin has been indicated, so the user is actually made aware that something is wrong here.

Personally I prefer to default to looking for `batch.yaml` for the reason mentioned above. But it's your tool so please do advise here. Thanks