### PR TITLE
Fixed issue where errors were thrown away

### DIFF
--- a/cmd/src/batch_common.go
+++ b/cmd/src/batch_common.go
@@ -325,10 +325,10 @@ func executeBatchSpec(ctx context.Context, ui ui.ExecUI, opts executeBatchSpecOp
 	importedSpecs, importErr := svc.CreateImportChangesetSpecs(ctx, batchSpec)
 	var errs *multierror.Error
 	if execErr != nil {
-		err = multierror.Append(err, execErr)
+		errs = multierror.Append(errs, execErr)
 	}
 	if importErr != nil {
-		err = multierror.Append(err, importErr)
+		errs = multierror.Append(errs, importErr)
 	}
 	err = errs.ErrorOrNil()
 	if err != nil && !opts.flags.skipErrors {


### PR DESCRIPTION
It's essentially just a typo fixed here.
Without this fix then repo errors when running things like `src batch preview` are just ignored, and the cli returns with exit code 0 without any error messages without uploading changesets for any successful repo (which is intended, you need to set `-skip-errors` for it to do that).

See output below for examples.
Took me a couple of days to figure out what was the problem. I could see that there were errors due to `Executing... (1/1, 1 errored)` but since exit code was 0 and no errors were printed I assumed that src by default ignores repo errors. Which it does not.

Current main branch:
```
$ src batch preview -f batch.yml
✅ Parsing batch spec
✅ Resolving namespace
✅ Preparing container images  ██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████
🚧 Workspace creator: bind
✅ Set workspace type
✅ Resolved 1 repositories
✅ Found 1 workspaces with steps to execute
✅ Found 0 cached changeset specs; 1 task needs to be executed
✅ Executing... (1/1, 1 errored)  ███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████
│
└── redacted  Traceback (most recent call last):                                                                                                                                          9s
✅ Creating batch spec on Sourcegraph

✅ To preview or apply the batch spec, go to:
   https://redacted


Process finished with the exit code 0

```

this branch:
```
$ src batch preview -f batch.yml
✅ Parsing batch spec
✅ Resolving namespace
✅ Preparing container images  ██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████
🚧 Workspace creator: bind
✅ Set workspace type
✅ Resolved 1 repositories
✅ Found 1 workspaces with steps to execute
✅ Found 0 cached changeset specs; 1 task needs to be executed
✅ Executing... (1/1, 1 errored)  ███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████
│
└──redacted  Traceback (most recent call last):                                                                                                                                          6s

❌ Error:
   redacted:
   run: python /tmp/script.py
   container: sourcegraph-batch

   standard error:
        Traceback (most recent call last):
          File "/tmp/script.py", line 74, in <module>
            main()
          File "/tmp/script.py", line 52, in main
            tags = get_module_tags(module, src)
          File "/tmp/script.py", line 12, in get_module_tags
            raise Exception("hello")
        Exception: hello

   Command failed with exit code 1.
   Log: C:/tmp\changeset-redacted



💡 The troubleshooting documentation can help to narrow down the cause of the errors:
   https://docs.sourcegraph.com/batch_changes/references/troubleshooting


Process finished with the exit code 1


```