### PR TITLE
batches: make `-f` optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ All notable changes to `src-cli` are documented in this file.
 
 ### Changed
 
+- `src batch` commands no longer require `-f` to read from a file. Additionally, running a `src batch` command that requires a batch spec file without a `-f` option from the terminal will now generate an error instead of waiting indefinitely for a batch spec on standard input; however, piping in a batch spec will still work as expected. [#687](https://github.com/sourcegraph/src-cli/pull/687)
+
 ### Fixed
 
 ### Removed

--- a/cmd/src/batch_apply.go
+++ b/cmd/src/batch_apply.go
@@ -18,13 +18,16 @@ creating or updating the described batch change if necessary.
 
 Usage:
 
-    src batch apply -f FILE [command options]
+    src batch apply [command options] [-f FILE]
+    src batch apply [command options] FILE
 
 Examples:
 
     $ src batch apply -f batch.spec.yaml
-  
+
     $ src batch apply -f batch.spec.yaml -namespace myorg
+
+    $ src batch apply batch.spec.yaml
 
 `
 

--- a/cmd/src/batch_exec.go
+++ b/cmd/src/batch_exec.go
@@ -170,7 +170,7 @@ func executeBatchSpecInWorkspaces(ctx context.Context, ui *ui.JSONLines, opts ex
 func loadWorkspaceExecutionInput(file string) (batcheslib.WorkspacesExecutionInput, error) {
 	var input batcheslib.WorkspacesExecutionInput
 
-	f, err := batchOpenFileFlag(&file)
+	f, err := batchOpenFileFlag(file)
 	if err != nil {
 		return input, err
 	}

--- a/cmd/src/batch_preview.go
+++ b/cmd/src/batch_preview.go
@@ -18,11 +18,14 @@ Sourcegraph instance, ready to be previewed and applied.
 
 Usage:
 
-    src batch preview -f FILE [command options]
+    src batch preview [command options] [-f FILE]
+    src batch preview [command options] FILE
 
 Examples:
 
     $ src batch preview -f batch.spec.yaml
+
+    $ src batch preview batch.spec.yaml
 
 `
 
@@ -34,8 +37,9 @@ Examples:
 			return err
 		}
 
-		if len(flagSet.Args()) != 0 {
-			return cmderrors.Usage("additional arguments not allowed")
+		file, err := getBatchSpecFile(flagSet, &flags.file)
+		if err != nil {
+			return err
 		}
 
 		ctx, cancel := contextCancelOnInterrupt(context.Background())
@@ -49,14 +53,14 @@ Examples:
 			execUI = &ui.TUI{Out: out}
 		}
 
-		err := executeBatchSpec(ctx, execUI, executeBatchSpecOpts{
+		if err = executeBatchSpec(ctx, execUI, executeBatchSpecOpts{
 			flags:  flags,
 			client: cfg.apiClient(flags.api, flagSet.Output()),
+			file:   file,
 
 			// Do not apply the uploaded batch spec
 			applyBatchSpec: false,
-		})
-		if err != nil {
+		}); err != nil {
 			return cmderrors.ExitCode(1, nil)
 		}
 

--- a/cmd/src/batch_repositories.go
+++ b/cmd/src/batch_repositories.go
@@ -67,8 +67,13 @@ Examples:
 			return err
 		}
 
+		var file string
+		if fileFlag != nil {
+			file = *fileFlag
+		}
+
 		out := output.NewOutput(flagSet.Output(), output.OutputOpts{Verbose: *verbose})
-		spec, _, err := parseBatchSpec(fileFlag, svc)
+		spec, _, err := parseBatchSpec(file, svc)
 		if err != nil {
 			ui := &ui.TUI{Out: out}
 			ui.ParsingBatchSpecFailure(err)

--- a/cmd/src/batch_repositories.go
+++ b/cmd/src/batch_repositories.go
@@ -21,9 +21,11 @@ apply to.
 
 Usage:
 
-    src batch repositories -f FILE
+    src batch repositories [-f] FILE
 
 Examples:
+
+    $ src batch repositories batch.spec.yaml
 
     $ src batch repositories -f batch.spec.yaml
 
@@ -32,7 +34,7 @@ Examples:
 	flagSet := flag.NewFlagSet("repositories", flag.ExitOnError)
 
 	var (
-		fileFlag = flagSet.String("f", "", "The batch spec file to read.")
+		fileFlag = flagSet.String("f", "", "The batch spec file to read, or - to read from standard input.")
 		apiFlags = api.NewFlags(flagSet)
 	)
 

--- a/cmd/src/batch_validate.go
+++ b/cmd/src/batch_validate.go
@@ -19,9 +19,11 @@ func init() {
 
 Usage:
 
-    src batch validate -f FILE
+    src batch validate [-f] FILE
 
 Examples:
+
+    $ src batch validate batch.spec.yaml
 
     $ src batch validate -f batch.spec.yaml
 
@@ -29,7 +31,7 @@ Examples:
 
 	flagSet := flag.NewFlagSet("validate", flag.ExitOnError)
 	apiFlags := api.NewFlags(flagSet)
-	fileFlag := flagSet.String("f", "", "The batch spec file to read.")
+	fileFlag := flagSet.String("f", "", "The batch spec file to read, or - to read from standard input.")
 
 	var (
 		allowUnsupported bool

--- a/cmd/src/batch_validate.go
+++ b/cmd/src/batch_validate.go
@@ -68,7 +68,12 @@ Examples:
 			return err
 		}
 
-		if _, _, err := parseBatchSpec(fileFlag, svc); err != nil {
+		file, err := getBatchSpecFile(flagSet, fileFlag)
+		if err != nil {
+			return err
+		}
+
+		if _, _, err := parseBatchSpec(file, svc); err != nil {
 			ui.ParsingBatchSpecFailure(err)
 			return err
 		}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/Masterminds/semver v1.5.0
 	github.com/cockroachdb/errors v1.8.6
 	github.com/cockroachdb/redact v1.1.3 // indirect
+	github.com/creack/goselect v0.1.2
 	github.com/derision-test/glock v0.0.0-20210316032053-f5b74334bb29
 	github.com/dineshappavoo/basex v0.0.0-20170425072625-481a6f6dc663
 	github.com/dustin/go-humanize v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
+github.com/creack/goselect v0.1.2 h1:2DNy14+JPjRBgPzAd1thbQp4BSIihxcBf0IXhQXDRa0=
+github.com/creack/goselect v0.1.2/go.mod h1:a/NhLweNvqIYMuxcMOuWY516Cimucms3DglDzQP3hKY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.11 h1:07n33Z8lZxZ2qwegKbObQohDhXDQxiMMz1NOUGYlesw=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/internal/batches/ui/tty.go
+++ b/internal/batches/ui/tty.go
@@ -7,7 +7,6 @@ import (
 )
 
 func HasInput(fd uintptr, timeout time.Duration) (bool, error) {
-
 	rfds := &goselect.FDSet{}
 	rfds.Zero()
 	rfds.Set(fd)

--- a/internal/batches/ui/tty.go
+++ b/internal/batches/ui/tty.go
@@ -1,0 +1,20 @@
+package ui
+
+import (
+	"time"
+
+	"github.com/creack/goselect"
+)
+
+func HasInput(fd uintptr, timeout time.Duration) (bool, error) {
+
+	rfds := &goselect.FDSet{}
+	rfds.Zero()
+	rfds.Set(fd)
+
+	if err := goselect.Select(1, rfds, nil, nil, timeout); err != nil {
+		return false, err
+	}
+
+	return rfds.IsSet(fd), nil
+}


### PR DESCRIPTION
New behaviour (assuming `COMMAND` is any command that accepted `-f`, including `apply`, `preview`, `repos`, or `validate`):

* `src batch COMMAND` **on a TTY**: will wait for 250ms in case there's input on stdin; otherwise errors
* `src batch COMMAND` with a file redirected in: waits indefinitely for input
* `src batch COMMAND -f -`: waits indefinitely for input
* `src batch COMMAND FILE`: reads from `FILE`; equivalent to `src batch COMMAND -f FILE`
* `src batch COMMAND -f FILE`: works as before

In summary, this shouldn't break backward compatibility in any case except for the user _slowly_ typing in a batch spec on stdin.

Fixes #680.