### PR TITLE
batches: fail earlier on dotcom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ All notable changes to `src-cli` are documented in this file.
 
 ### Fixed
 
+- `src batch [preview|apply]` will now check that the target Sourcegraph instance supports batch changes before doing any other work and exit early in the case that it does not.
+
 ### Removed
 
 ## 3.36.2

--- a/internal/batches/service/service.go
+++ b/internal/batches/service/service.go
@@ -763,7 +763,7 @@ func (svc *Service) FindDirectoriesInRepos(ctx context.Context, fileName string,
 
 var defaultQueryCountRegex = regexp.MustCompile(`\bcount:(\d+|all)\b`)
 
-const hardCodedCount = " count:99999"
+const hardCodedCount = " count:999999"
 
 func setDefaultQueryCount(query string) string {
 	if defaultQueryCountRegex.MatchString(query) {

--- a/internal/batches/service/service.go
+++ b/internal/batches/service/service.go
@@ -57,15 +57,15 @@ func New(opts *Opts) *Service {
 // first thing we do.
 const sourcegraphVersionQuery = `query SourcegraphVersion {
 	site {
-	  productVersion
+		productVersion
 	}
 	batchChanges(first: 1) {
-    nodes {
-      id
-    }
-  }
+		nodes {
+			id
+		}
+	}
 }
-  `
+`
 
 // getSourcegraphVersion queries the Sourcegraph GraphQL API to get the
 // current version of the Sourcegraph instance.

--- a/internal/batches/service/service.go
+++ b/internal/batches/service/service.go
@@ -52,6 +52,9 @@ func New(opts *Opts) *Service {
 	}
 }
 
+// The reason we ask for batchChanges here is to surface errors about trying to use batch
+// changes in an unsupported environment sooner, since the version check is typically the
+// first thing we do.
 const sourcegraphVersionQuery = `query SourcegraphVersion {
 	site {
 	  productVersion

--- a/internal/batches/service/service.go
+++ b/internal/batches/service/service.go
@@ -760,7 +760,7 @@ func (svc *Service) FindDirectoriesInRepos(ctx context.Context, fileName string,
 
 var defaultQueryCountRegex = regexp.MustCompile(`\bcount:(\d+|all)\b`)
 
-const hardCodedCount = " count:999999"
+const hardCodedCount = " count:99999"
 
 func setDefaultQueryCount(query string) string {
 	if defaultQueryCountRegex.MatchString(query) {

--- a/internal/batches/service/service.go
+++ b/internal/batches/service/service.go
@@ -56,7 +56,12 @@ const sourcegraphVersionQuery = `query SourcegraphVersion {
 	site {
 	  productVersion
 	}
+	batchChanges(first: 1) {
+    nodes {
+      id
+    }
   }
+}
   `
 
 // getSourcegraphVersion queries the Sourcegraph GraphQL API to get the


### PR DESCRIPTION
This PR is in response to https://github.com/sourcegraph/sourcegraph/issues/28252 and does two things:
- ~Lessens the arbitrarily large default count applied to the batch spec `repositoriesMatchingQuery` from 999999 to 99999, which is less likely to cause timeouts.~ Decided not to proceed with this change since we haven't heard of actual enterprise customers running into timeouts yet and this is expected to become a non-issue once we actually use `count: all`.
- Requests BC-specific information from the version GraphQL query so that it produces an error on dotcom or in an environment where batch changes is not available. This has the effect that `src preview|apply` will fail right away on the first thing it does, which is the version check, as opposed to much later after execution finishes and we go to upload changesets:
```
failed to query Sourcegraph version to check for available features: GraphQL errors: 1 error occurred:
   	* {
     "message": "access to batch changes on Sourcegraph.com is currently not available",
     "path": [
       "batchChanges"
     ]
   }
```