### PR TITLE
batches: use the minimum possible goroutines to fetch images

### DIFF
--- a/internal/batches/service/service.go
+++ b/internal/batches/service/service.go
@@ -198,6 +198,9 @@ func (svc *Service) EnsureDockerImages(
 	if parallelism < 1 {
 		parallelism = 1
 	}
+	if parallelism > total {
+		parallelism = total
+	}
 	var wg sync.WaitGroup
 	for i := 0; i < parallelism; i++ {
 		wg.Add(1)


### PR DESCRIPTION
This was spotted by @eseliger in the review for #647 — if `total < parallelism`, there's no real need to spawn extra goroutines, so let's not.