### PR TITLE
go.mod: use grafana/regexp, matching sourcegraph/sourcegraph#30948

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ All notable changes to `src-cli` are documented in this file.
 
 ### Changed
 
+- Migrated to [`grafana/regexp`](https://github.com/grafana/regexp) to match our usage in Sourcegraph proper. [#694](https://github.com/sourcegraph/src-cli/pull/694)
+
 ### Fixed
 
 ### Removed

--- a/cmd/src/colors.go
+++ b/cmd/src/colors.go
@@ -3,8 +3,9 @@ package main
 import (
 	"fmt"
 	"os"
-	"regexp"
 	"strconv"
+
+	"github.com/grafana/regexp"
 
 	"github.com/mattn/go-isatty"
 )

--- a/cmd/src/search.go
+++ b/cmd/src/search.go
@@ -9,10 +9,11 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"regexp"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/grafana/regexp"
 
 	isatty "github.com/mattn/go-isatty"
 	"jaytaylor.com/html2text"

--- a/cmd/src/search_alert_test.go
+++ b/cmd/src/search_alert_test.go
@@ -2,9 +2,10 @@ package main
 
 import (
 	"fmt"
-	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/grafana/regexp"
 
 	"github.com/google/go-cmp/cmp"
 )

--- a/cmd/src/search_stream.go
+++ b/cmd/src/search_stream.go
@@ -7,10 +7,11 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"regexp"
 	"strconv"
 	"strings"
 	"text/template"
+
+	"github.com/grafana/regexp"
 
 	"github.com/sourcegraph/src-cli/internal/api"
 	"github.com/sourcegraph/src-cli/internal/streaming"

--- a/cmd/src/search_test.go
+++ b/cmd/src/search_test.go
@@ -6,9 +6,10 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/grafana/regexp"
 )
 
 var _ = func() bool {

--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/go-stack/stack v1.8.1 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/grafana/regexp v0.0.0-20220202152315-e74e38789280 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/inconshreveable/log15 v0.0.0-20201112154412-8562bdadbbac // indirect
 	github.com/klauspost/compress v1.14.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -125,6 +125,8 @@ github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
+github.com/grafana/regexp v0.0.0-20220202152315-e74e38789280 h1:MOND6wXrwVXEzmL2bZ+Jcbgycwt1LD5q6NQbqz/Nlic=
+github.com/grafana/regexp v0.0.0-20220202152315-e74e38789280/go.mod h1:M5qHK+eWfAv8VR/265dIuEpL3fNfeC21tXXp9itM24A=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=

--- a/internal/api/version_check.go
+++ b/internal/api/version_check.go
@@ -1,7 +1,7 @@
 package api
 
 import (
-	"regexp"
+	"github.com/grafana/regexp"
 
 	"github.com/Masterminds/semver"
 )

--- a/internal/batches/service/service.go
+++ b/internal/batches/service/service.go
@@ -8,9 +8,10 @@ import (
 	"os"
 	"os/exec"
 	"path"
-	"regexp"
 	"strings"
 	"sync"
+
+	"github.com/grafana/regexp"
 
 	"github.com/cockroachdb/errors"
 	"github.com/hashicorp/go-multierror"


### PR DESCRIPTION
I did a quick `src search`, and everything still looks (a) normal, and (b) garishly coloured, so I think we're good.