### PR TITLE
batches: fix `src batch apply -f`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ All notable changes to `src-cli` are documented in this file.
 
 ### Fixed
 
+- A bug in 3.36.3 caused `src batch apply` to no longer accept a file provided with `-f`. This has been fixed. [#695](https://github.com/sourcegraph/src-cli/pull/695)
+
 ### Removed
 
 ## 3.36.3

--- a/cmd/src/batch_apply.go
+++ b/cmd/src/batch_apply.go
@@ -39,8 +39,9 @@ Examples:
 			return err
 		}
 
-		if len(flagSet.Args()) != 0 {
-			return cmderrors.Usage("additional arguments not allowed")
+		file, err := getBatchSpecFile(flagSet, &flags.file)
+		if err != nil {
+			return err
 		}
 
 		ctx, cancel := contextCancelOnInterrupt(context.Background())
@@ -54,13 +55,13 @@ Examples:
 			execUI = &ui.TUI{Out: out}
 		}
 
-		err := executeBatchSpec(ctx, execUI, executeBatchSpecOpts{
+		if err = executeBatchSpec(ctx, execUI, executeBatchSpecOpts{
 			flags:  flags,
 			client: cfg.apiClient(flags.api, flagSet.Output()),
+			file:   file,
 
 			applyBatchSpec: true,
-		})
-		if err != nil {
+		}); err != nil {
 			return cmderrors.ExitCode(1, nil)
 		}
 


### PR DESCRIPTION
This code should have been the same in `src batch preview` and `src batch apply`, but apparently wasn't. My bad, sorry.