### PR TITLE
batches: fix incorrect help text

### DIFF
--- a/cmd/src/batch_remote.go
+++ b/cmd/src/batch_remote.go
@@ -130,7 +130,7 @@ Examples:
 		aliases: []string{},
 		handler: handler,
 		usageFunc: func() {
-			fmt.Fprintf(flag.CommandLine.Output(), "Usage of 'src batch remote %s':\n", flagSet.Name())
+			fmt.Fprintf(flag.CommandLine.Output(), "Usage of 'src batch %s':\n", flagSet.Name())
 			flagSet.PrintDefaults()
 			fmt.Println(usage)
 		},


### PR DESCRIPTION
I obviously missed this when I removed the extra level of commands in the new command structure.