### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/cmd/src/main_test.go
+++ b/cmd/src/main_test.go
@@ -153,12 +153,8 @@ func TestReadConfig(t *testing.T) {
 			setEnv("SRC_ACCESS_TOKEN", test.envToken)
 			setEnv("SRC_ENDPOINT", test.envEndpoint)
 
-			tmpDir, err := os.MkdirTemp("", "")
-			if err != nil {
-				t.Fatal(err)
-			}
+			tmpDir := t.TempDir()
 			testHomeDir = tmpDir
-			t.Cleanup(func() { os.RemoveAll(tmpDir) })
 
 			if test.flagEndpoint != "" {
 				val := test.flagEndpoint

--- a/internal/batches/executor/execution_cache_test.go
+++ b/internal/batches/executor/execution_cache_test.go
@@ -2,7 +2,6 @@ package executor
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -44,16 +43,6 @@ index 0000000..3363c39
 func TestExecutionDiskCache_GetSet(t *testing.T) {
 	ctx := context.Background()
 
-	cacheTmpDir := func(t *testing.T) string {
-		testTempDir, err := os.MkdirTemp("", "execution-disk-cache-test-*")
-		if err != nil {
-			t.Fatal(err)
-		}
-		t.Cleanup(func() { os.Remove(testTempDir) })
-
-		return testTempDir
-	}
-
 	cacheKey1 := &cache.ExecutionKey{
 		Repository: cacheRepo1,
 		Steps: []batcheslib.Step{
@@ -76,7 +65,7 @@ func TestExecutionDiskCache_GetSet(t *testing.T) {
 		Outputs: map[string]interface{}{},
 	}
 
-	cache := ExecutionDiskCache{Dir: cacheTmpDir(t)}
+	cache := ExecutionDiskCache{Dir: t.TempDir()}
 
 	// Empty cache, no hits
 	assertCacheMiss(t, cache, cacheKey1)

--- a/internal/batches/executor/executor_test.go
+++ b/internal/batches/executor/executor_test.go
@@ -335,11 +335,7 @@ func TestExecutor_Integration(t *testing.T) {
 			client := api.NewClient(api.ClientOpts{Endpoint: ts.URL, Out: &clientBuffer})
 
 			// Temp dir for log files and downloaded archives
-			testTempDir, err := os.MkdirTemp("", "executor-integration-test-*")
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer os.Remove(testTempDir)
+			testTempDir := t.TempDir()
 
 			// Setup executor
 			opts := newExecutorOpts{
@@ -667,11 +663,7 @@ func testExecuteTasks(t *testing.T, tasks []*Task, archives ...mock.RepoArchive)
 		t.Skip("Test doesn't work on Windows because dummydocker is written in bash")
 	}
 
-	testTempDir, err := os.MkdirTemp("", "executor-integration-test-*")
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { os.Remove(testTempDir) })
+	testTempDir := t.TempDir()
 
 	// Setup dummydocker
 	addToPath(t, "testdata/dummydocker")

--- a/internal/batches/repozip/fetcher_test.go
+++ b/internal/batches/repozip/fetcher_test.go
@@ -21,16 +21,6 @@ import (
 )
 
 func TestArchive_Ensure(t *testing.T) {
-	workspaceTmpDir := func(t *testing.T) string {
-		testTempDir, err := os.MkdirTemp("", "executor-integration-test-*")
-		if err != nil {
-			t.Fatal(err)
-		}
-		t.Cleanup(func() { os.Remove(testTempDir) })
-
-		return testTempDir
-	}
-
 	repo := RepoRevision{
 		RepoName: "github.com/sourcegraph/src-cli",
 		Commit:   "d34db33f",
@@ -58,7 +48,7 @@ func TestArchive_Ensure(t *testing.T) {
 
 		rf := &archiveRegistry{
 			client:     client,
-			dir:        workspaceTmpDir(t),
+			dir:        t.TempDir(),
 			deleteZips: false,
 		}
 
@@ -103,7 +93,7 @@ func TestArchive_Ensure(t *testing.T) {
 
 		rf := &archiveRegistry{
 			client:     client,
-			dir:        workspaceTmpDir(t),
+			dir:        t.TempDir(),
 			deleteZips: true,
 		}
 
@@ -167,7 +157,7 @@ func TestArchive_Ensure(t *testing.T) {
 
 		rf := &archiveRegistry{
 			client:     client,
-			dir:        workspaceTmpDir(t),
+			dir:        t.TempDir(),
 			deleteZips: false,
 		}
 
@@ -207,7 +197,7 @@ func TestArchive_Ensure(t *testing.T) {
 
 		rf := &archiveRegistry{
 			client:     client,
-			dir:        workspaceTmpDir(t),
+			dir:        t.TempDir(),
 			deleteZips: false,
 		}
 		zip := rf.Checkout(repo, "")
@@ -276,7 +266,7 @@ func TestArchive_Ensure(t *testing.T) {
 
 		rf := &archiveRegistry{
 			client:     client,
-			dir:        workspaceTmpDir(t),
+			dir:        t.TempDir(),
 			deleteZips: false,
 		}
 		zip := rf.Checkout(repo, path)

--- a/internal/batches/workspace/bind_workspace_nonwin_test.go
+++ b/internal/batches/workspace/bind_workspace_nonwin_test.go
@@ -17,7 +17,6 @@ func TestMkdirAllStatError(t *testing.T) {
 
 	// Create a shared workspace.
 	base := mustCreateWorkspace(t)
-	defer os.RemoveAll(base)
 
 	// We'll create a directory and a file within it, remove the execute bit on
 	// the directory, and then stat() the file to cause a failure.
@@ -34,6 +33,12 @@ func TestMkdirAllStatError(t *testing.T) {
 	if err := os.Chmod(filepath.Join(base, "locked"), 0600); err != nil {
 		t.Fatal(err)
 	}
+	// Add the execute bit back to the directory so "base" can be cleaned up
+	t.Cleanup(func() {
+		if err := os.Chmod(filepath.Join(base, "locked"), 0700); err != nil {
+			t.Fatal(err)
+		}
+	})
 
 	err = mkdirAll(base, "locked/file", 0750)
 	if err == nil {
@@ -41,7 +46,6 @@ func TestMkdirAllStatError(t *testing.T) {
 	} else if _, ok := err.(errPathExistsAsFile); ok {
 		t.Errorf("unexpected error of type %T: %v", err, err)
 	}
-
 }
 
 func mustHavePerm(t *testing.T, path string, want os.FileMode) error {

--- a/internal/servegit/serve_test.go
+++ b/internal/servegit/serve_test.go
@@ -87,11 +87,7 @@ func TestReposHandler(t *testing.T) {
 
 			// This is the difference, we create a symlink for root
 			{
-				tmp, err := os.MkdirTemp("", "")
-				if err != nil {
-					t.Fatal(err)
-				}
-				t.Cleanup(func() { os.RemoveAll(tmp) })
+				tmp := t.TempDir()
 
 				symlink := filepath.Join(tmp, "symlink-root")
 				if err := os.Symlink(root, symlink); err != nil {
@@ -178,11 +174,7 @@ func gitInitBare(t *testing.T, path string) {
 }
 
 func gitInitRepos(t *testing.T, names ...string) string {
-	root, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { os.RemoveAll(root) })
+	root := t.TempDir()
 	root = filepath.Join(root, "repos-root")
 
 	for _, name := range names {
@@ -201,11 +193,7 @@ func gitInitRepos(t *testing.T, names ...string) string {
 }
 
 func TestIgnoreGitSubmodules(t *testing.T) {
-	root, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { os.RemoveAll(root) })
+	root := t.TempDir()
 
 	if err := os.MkdirAll(filepath.Join(root, "dir"), os.ModePerm); err != nil {
 		t.Fatal(err)
@@ -229,11 +217,7 @@ func TestIgnoreGitSubmodules(t *testing.T) {
 }
 
 func TestIsBareRepo(t *testing.T) {
-	dir, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { os.RemoveAll(dir) })
+	dir := t.TempDir()
 
 	gitInitBare(t, dir)
 
@@ -243,11 +227,7 @@ func TestIsBareRepo(t *testing.T) {
 }
 
 func TestEmptyDirIsNotBareRepo(t *testing.T) {
-	dir, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { os.RemoveAll(dir) })
+	dir := t.TempDir()
 
 	if isBareRepo(dir) {
 		t.Errorf("Path %s it falsey detected as a bare repository", dir)


### PR DESCRIPTION
### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->

A small testing enhancement.

We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

Reference: https://pkg.go.dev/testing#T.TempDir