### PR TITLE
add login into command list & alphabetize 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to `src-cli` are documented in this file.
 
 ### Added
 
+- Added `login` text to command text menu and ordered alphabetically [#713](https://github.com/sourcegraph/src-cli/pull/713)
+
 ### Changed
 
 ### Fixed

--- a/cmd/src/main.go
+++ b/cmd/src/main.go
@@ -32,18 +32,18 @@ The options are:
 
 The commands are:
 
-	search          search for results on Sourcegraph
 	api             interacts with the Sourcegraph GraphQL API
-	repos,repo      manages repositories
-	users,user      manages users
-	orgs,org        manages organizations
-	config          manages global, org, and user settings
-	extsvc          manages external services
-	extensions,ext  manages extensions (experimental)
 	batch           manages batch changes
+	config          manages global, org, and user settings
+	extensions,ext  manages extensions (experimental)
+	extsvc          manages external services
+	login           authenticate to a Sourcegraph instance with your user credentials
 	lsif            manages LSIF data
-	login		authenticate to a Sourcegraph instance with your user credentials
+	orgs,org        manages organizations
+	repos,repo      manages repositories
+	search          search for results on Sourcegraph
 	serve-git       serves your local git repositories over HTTP for Sourcegraph to pull
+	users,user      manages users
 	version         display and compare the src-cli version against the recommended version for your instance
 
 Use "src [command] -h" for more information about a command.

--- a/cmd/src/main.go
+++ b/cmd/src/main.go
@@ -42,6 +42,7 @@ The commands are:
 	extensions,ext  manages extensions (experimental)
 	batch           manages batch changes
 	lsif            manages LSIF data
+	login		authenticate to a Sourcegraph instance with your user credentials
 	serve-git       serves your local git repositories over HTTP for Sourcegraph to pull
 	version         display and compare the src-cli version against the recommended version for your instance
 


### PR DESCRIPTION

Fixes https://github.com/sourcegraph/sourcegraph/issues/32450 and adds a bit more!

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->

* Added `login` command to the list
* Noticed list was not alphabetized so went a step further and re-ordered the commands
* Confirmed changes in src-cli dev environment look visually correct (use spaces versus tabs 🙃 )

<img width="823" alt="image" src="https://user-images.githubusercontent.com/27694443/158906679-d64cf011-9c0a-4cf6-986c-784265b0665d.png">

