### PR TITLE
extensions: remove url from copied manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ All notable changes to `src-cli` are documented in this file.
 
 ### Fixed
 
+- `src extensions copy` now removes the `url` property from extension manifests that points to the sourcegraph.com extension bundle, enabling use for air-gapped instances.
+
 ### Removed
 
 ## 3.38.0

--- a/cmd/src/extensions_copy.go
+++ b/cmd/src/extensions_copy.go
@@ -100,6 +100,11 @@ Copy an extension from Sourcegraph.com to your private registry.
 		if err != nil {
 			return err
 		}
+		// Remove sourcegraph.com bundle URL.
+		manifest, err = updatePropertyInManifest(manifest, "url", "")
+		if err != nil {
+			return err
+		}
 
 		response, err := http.Get(extensionResult.ExtensionRegistry.Extension.Manifest.BundleURL)
 		if err != nil {

--- a/cmd/src/extensions_publish.go
+++ b/cmd/src/extensions_publish.go
@@ -247,7 +247,11 @@ func updatePropertyInManifest(manifest []byte, property, value string) (updatedM
 	if o == nil {
 		o = map[string]interface{}{}
 	}
-	o[property] = value
+	if value == "" {
+		delete(o, property)
+	} else {
+		o[property] = value
+	}
 	return json.MarshalIndent(o, "", "  ")
 }
 

--- a/cmd/src/extensions_publish_test.go
+++ b/cmd/src/extensions_publish_test.go
@@ -54,6 +54,18 @@ func TestUpdatePropertyInManifest(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("remove property", func(t *testing.T) {
+		manifest := `{"extensionID":"sourcegraph/typescript", "url":"https://sourcegraph.com"}`
+		want := `{"extensionID": "sourcegraph/typescript"}`
+		got, err := updatePropertyInManifest([]byte(manifest), "url", "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !jsonDeepEqual(string(got), want) {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
 }
 
 func jsonDeepEqual(a, b string) bool {


### PR DESCRIPTION
Closes #717. 
- Update `updatePropertyInManifest` to remove property when value is an empty string.
- Remove `url` property from manifest before publishing to private registry.

This is a backwards-compatible change, so can it be part of a [patch release](https://github.com/sourcegraph/src-cli/blob/main/DEVELOPMENT.md#releasing)? And is the changelog entry unnecessary in this case then?

### Test plan

- Added a test case for removing properties from an extension manifest.
- Built with `go install` and tested `src ext copy` to confirm that the command still works and that `url ` is no longer included in the manifest.