### PR TITLE
search: add a tip about negated searches

### DIFF
--- a/cmd/src/search.go
+++ b/cmd/src/search.go
@@ -49,6 +49,12 @@ Other tips:
   Force color output on (not on by default when piped to other programs) by setting COLOR=t
 
   Query syntax: https://about.sourcegraph.com/docs/search/query-syntax/
+
+  Be careful with search strings including negation: a search with an initial
+  negated term may be parsed as a flag rather than as a search string. You can
+  use -- to ensure that src parses this correctly, eg:
+
+    	$ src search -- '-repo:github.com/foo/bar error'
 `
 
 	flagSet := flag.NewFlagSet("search", flag.ExitOnError)


### PR DESCRIPTION
This came out of https://sourcegraph.slack.com/archives/C022SPMNR0W/p1648748082874949.

### Test plan

N/A; help change only.