### PR TITLE
Add Bitbucket Cloud to the supported list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to `src-cli` are documented in this file.
 ### Added
 
 - `src lsif upload` now supports the `-gitlab-token` flag. [#721](https://github.com/sourcegraph/src-cli/pull/721)
+- Batch Changes can be applied to Bitbucket Cloud when `src` is used with Sourcegraph 3.40 or later. [#725](https://github.com/sourcegraph/src-cli/pull/725)
 
 ### Changed
 

--- a/internal/batches/features.go
+++ b/internal/batches/features.go
@@ -18,6 +18,7 @@ type FeatureFlags struct {
 	AllowConditionalExec     bool
 	AllowOptionalPublished   bool
 	ServerSideBatchChanges   bool
+	BitbucketCloud           bool
 }
 
 func (ff *FeatureFlags) SetFromVersion(version string) error {
@@ -42,6 +43,7 @@ func (ff *FeatureFlags) SetFromVersion(version string) error {
 		{&ff.AllowConditionalExec, ">= 3.28.0-0", "2021-05-05"},
 		{&ff.AllowOptionalPublished, ">= 3.30.0-0", "2021-06-21"},
 		{&ff.ServerSideBatchChanges, ">= 3.37.0-0", "2022-02-08"},
+		{&ff.BitbucketCloud, ">= 3.40.0-0", "2022-04-20"},
 	} {
 		value, err := api.CheckSourcegraphVersion(version, feature.constraint, feature.minDate)
 		if err != nil {

--- a/internal/batches/service/service.go
+++ b/internal/batches/service/service.go
@@ -554,7 +554,12 @@ func (svc *Service) ResolveRepositories(ctx context.Context, spec *batcheslib.Ba
 			result.AddRepoRevision(repo.ID, repo)
 
 			switch st := strings.ToLower(repo.ExternalRepository.ServiceType); st {
-			case "github", "gitlab", "bitbucketserver", "bitbucketcloud":
+			case "github", "gitlab", "bitbucketserver":
+			case "bitbucketcloud":
+				if svc.features.BitbucketCloud {
+					break
+				}
+				fallthrough
 			default:
 				if !svc.allowUnsupported {
 					unsupported.Append(repo)

--- a/internal/batches/service/service.go
+++ b/internal/batches/service/service.go
@@ -554,7 +554,7 @@ func (svc *Service) ResolveRepositories(ctx context.Context, spec *batcheslib.Ba
 			result.AddRepoRevision(repo.ID, repo)
 
 			switch st := strings.ToLower(repo.ExternalRepository.ServiceType); st {
-			case "github", "gitlab", "bitbucketserver":
+			case "github", "gitlab", "bitbucketserver", "bitbucketcloud":
 			default:
 				if !svc.allowUnsupported {
 					unsupported.Append(repo)


### PR DESCRIPTION
Part of sourcegraph/sourcegraph#24199.

### Test plan

Testing against sourcegraph/sourcegraph#32826.