### PR TITLE
lsif upload: Add -gitlab-token to help text

### DIFF
--- a/cmd/src/lsif_upload.go
+++ b/cmd/src/lsif_upload.go
@@ -35,6 +35,7 @@ Examples:
   Upload an LSIF dump when lsifEnforceAuth is enabled:
 
     	$ src lsif upload -github-token=BAZ
+    	$ src lsif upload -gitlab-token=BAZ
 
   Upload an LSIF dump when the LSIF indexer does not not declare a tool name.
 

--- a/cmd/src/lsif_upload.go
+++ b/cmd/src/lsif_upload.go
@@ -34,7 +34,7 @@ Examples:
 
   Upload an LSIF dump when lsifEnforceAuth is enabled:
 
-    	$ src lsif upload -github-token=BAZ
+    	$ src lsif upload -github-token=BAZ, or
     	$ src lsif upload -gitlab-token=BAZ
 
   Upload an LSIF dump when the LSIF indexer does not not declare a tool name.


### PR DESCRIPTION
Was missing this new option in help text.

### Test plan

N/A.