### PR TITLE
lsif upload: Make better unauthorized error messages

### DIFF
--- a/cmd/src/lsif_upload.go
+++ b/cmd/src/lsif_upload.go
@@ -246,7 +246,7 @@ func handleLSIFUploadError(out *output.Output, err error) error {
 		err = errorWithHint{err: err, hint: strings.Join(mergeStringSlices(
 			[]string{"This Sourcegraph instance has enforced auth for LSIF uploads."},
 			actionableHints,
-			[]string{"See https://docs.sourcegraph.com/cli/references/lsif/upload."},
+			[]string{"For more details, see https://docs.sourcegraph.com/cli/references/lsif/upload."},
 		), "\n")}
 	}
 


### PR DESCRIPTION
Fixes #727.

### Test plan

Ran by hand:

```
$ src lsif upload
💡 Inferred arguments
   repo: github.com/sourcegraph/lsif-go
   commit: cde8136abd91c0a3bce9f5d2755bc006a2caaafb
   root:
   file: ./dump.lsif
   indexer: lsif-go
   indexerVersion: dev

✅ Index compressed
💡 Indexed compressed (6.65MB -> 1.06MB).
❌ Failed to upload index file
unauthorized upload

This Sourcegraph instance has enforced auth for LSIF uploads.
BLAH BLAH TEXT CHANGED SINCE I OPENED THE PR
See https://docs.sourcegraph.com/cli/references/lsif/upload.
```
