### PR TITLE
Fix Execution URL when using `src batch remote`

### DIFF
--- a/cmd/src/batch_common.go
+++ b/cmd/src/batch_common.go
@@ -298,7 +298,7 @@ func executeBatchSpec(ctx context.Context, ui ui.ExecUI, opts executeBatchSpecOp
 	if err != nil {
 		return err
 	}
-	ui.ResolvingNamespaceSuccess(namespace)
+	ui.ResolvingNamespaceSuccess(namespace.ID)
 
 	var workspaceCreator workspace.Creator
 
@@ -441,7 +441,7 @@ func executeBatchSpec(ctx context.Context, ui ui.ExecUI, opts executeBatchSpecOp
 	}
 
 	ui.CreatingBatchSpec()
-	id, url, err := svc.CreateBatchSpec(ctx, namespace, rawSpec, ids)
+	id, url, err := svc.CreateBatchSpec(ctx, namespace.ID, rawSpec, ids)
 	if err != nil {
 		return ui.CreatingBatchSpecError(err)
 	}

--- a/cmd/src/batch_remote.go
+++ b/cmd/src/batch_remote.go
@@ -63,7 +63,7 @@ Examples:
 		// may as well validate it at the same time so we don't even have to go to
 		// the backend if it's invalid.
 		ui.ParsingBatchSpec()
-		_, raw, err := parseBatchSpec(file, svc)
+		spec, raw, err := parseBatchSpec(file, svc)
 		if err != nil {
 			ui.ParsingBatchSpecFailure(err)
 			return err
@@ -121,15 +121,13 @@ Examples:
 		}
 		ui.ExecutingBatchSpecSuccess()
 
-		var batchChangeName string = "comby-fmt"
 		executionURL := fmt.Sprintf(
 			"%s/%s/batch-changes/%s/executions/%s",
 			strings.TrimSuffix(cfg.Endpoint, "/"),
 			strings.TrimPrefix(namespace.URL, "/"),
-			batchChangeName,
+			spec.Name,
 			batchSpecID,
 		)
-		// ui.RemoteSuccess(strings.TrimSuffix(cfg.Endpoint, "/") + "/batch-changes/executions/" + batchSpecID)
 		ui.RemoteSuccess(executionURL)
 
 		return nil

--- a/cmd/src/batch_remote.go
+++ b/cmd/src/batch_remote.go
@@ -72,17 +72,17 @@ Examples:
 
 		// We're going to need the namespace ID, so let's figure that out.
 		ui.ResolvingNamespace()
-		namespaceID, err := svc.ResolveNamespace(ctx, flags.namespace)
+		namespace, err := svc.ResolveNamespace(ctx, flags.namespace)
 		if err != nil {
 			return err
 		}
-		ui.ResolvingNamespaceSuccess(namespaceID)
+		ui.ResolvingNamespaceSuccess(namespace.ID)
 
 		ui.SendingBatchSpec()
 		batchSpecID, err := svc.UpsertBatchSpecInput(
 			ctx,
 			raw,
-			namespaceID,
+			namespace.ID,
 			flags.allowIgnored,
 			flags.allowUnsupported,
 			flags.clearCache,
@@ -125,7 +125,7 @@ Examples:
 		executionURL := fmt.Sprintf(
 			"%s/%s/batch-changes/%s/executions/%s",
 			strings.TrimSuffix(cfg.Endpoint, "/"),
-			strings.TrimPrefix(namespaceDetails.URL, "/"),
+			strings.TrimPrefix(namespace.URL, "/"),
 			batchChangeName,
 			batchSpecID,
 		)

--- a/cmd/src/batch_remote.go
+++ b/cmd/src/batch_remote.go
@@ -121,7 +121,16 @@ Examples:
 		}
 		ui.ExecutingBatchSpecSuccess()
 
-		ui.RemoteSuccess(strings.TrimSuffix(cfg.Endpoint, "/") + "/batch-changes/executions/" + batchSpecID)
+		var batchChangeName string = "comby-fmt"
+		executionURL := fmt.Sprintf(
+			"%s/%s/batch-changes/%s/executions/%s",
+			strings.TrimSuffix(cfg.Endpoint, "/"),
+			strings.TrimPrefix(namespaceDetails.URL, "/"),
+			batchChangeName,
+			batchSpecID,
+		)
+		// ui.RemoteSuccess(strings.TrimSuffix(cfg.Endpoint, "/") + "/batch-changes/executions/" + batchSpecID)
+		ui.RemoteSuccess(executionURL)
 
 		return nil
 	}

--- a/internal/batches/service/service.go
+++ b/internal/batches/service/service.go
@@ -480,12 +480,12 @@ query GetCurrentUserID {
 }
 `
 
-type NamespaceDetails struct {
+type Namespace struct {
 	ID  string
 	URL string
 }
 
-func (svc *Service) ResolveNamespace(ctx context.Context, namespace string) (NamespaceDetails, error) {
+func (svc *Service) ResolveNamespace(ctx context.Context, namespace string) (Namespace, error) {
 	if namespace == "" {
 		// if no namespace is provided, default to logged in user as namespace
 		var resp struct {
@@ -497,13 +497,13 @@ func (svc *Service) ResolveNamespace(ctx context.Context, namespace string) (Nam
 			} `json:"data"`
 		}
 		if ok, err := svc.client.NewRequest(usernameQuery, nil).DoRaw(ctx, &resp); err != nil || !ok {
-			return NamespaceDetails{}, errors.WithMessage(err, "failed to resolve namespace: no user logged in")
+			return Namespace{}, errors.WithMessage(err, "failed to resolve namespace: no user logged in")
 		}
 
 		if resp.Data.CurrentUser.ID == "" {
-			return NamespaceDetails{}, errors.New("cannot resolve current user")
+			return Namespace{}, errors.New("cannot resolve current user")
 		}
-		return NamespaceDetails{
+		return Namespace{
 			ID:  resp.Data.CurrentUser.ID,
 			URL: resp.Data.CurrentUser.URL,
 		}, nil
@@ -525,22 +525,22 @@ func (svc *Service) ResolveNamespace(ctx context.Context, namespace string) (Nam
 	if ok, err := svc.client.NewRequest(namespaceQuery, map[string]interface{}{
 		"name": namespace,
 	}).DoRaw(ctx, &result); err != nil || !ok {
-		return NamespaceDetails{}, err
+		return Namespace{}, err
 	}
 
 	if result.Data.User != nil {
-		return NamespaceDetails{
+		return Namespace{
 			ID:  result.Data.User.ID,
 			URL: result.Data.User.URL,
 		}, nil
 	}
 	if result.Data.Organization != nil {
-		return NamespaceDetails{
+		return Namespace{
 			ID:  result.Data.Organization.ID,
 			URL: result.Data.Organization.URL,
 		}, nil
 	}
-	return NamespaceDetails{}, fmt.Errorf("failed to resolve namespace %q: no user or organization found", namespace)
+	return Namespace{}, fmt.Errorf("failed to resolve namespace %q: no user or organization found", namespace)
 }
 
 func (svc *Service) ResolveRepositories(ctx context.Context, spec *batcheslib.BatchSpec) ([]*graphql.Repository, error) {

--- a/internal/batches/service/service.go
+++ b/internal/batches/service/service.go
@@ -475,50 +475,72 @@ const usernameQuery = `
 query GetCurrentUserID {
     currentUser {
         id
+		url
     }
 }
 `
 
-func (svc *Service) ResolveNamespace(ctx context.Context, namespace string) (string, error) {
+type NamespaceDetails struct {
+	ID  string
+	URL string
+}
+
+func (svc *Service) ResolveNamespace(ctx context.Context, namespace string) (NamespaceDetails, error) {
 	if namespace == "" {
 		// if no namespace is provided, default to logged in user as namespace
 		var resp struct {
 			Data struct {
 				CurrentUser struct {
-					ID string `json:"id"`
+					ID  string `json:"id"`
+					URL string `json:"url"`
 				} `json:"currentUser"`
 			} `json:"data"`
 		}
 		if ok, err := svc.client.NewRequest(usernameQuery, nil).DoRaw(ctx, &resp); err != nil || !ok {
-			return "", errors.WithMessage(err, "failed to resolve namespace: no user logged in")
+			return NamespaceDetails{}, errors.WithMessage(err, "failed to resolve namespace: no user logged in")
 		}
 
 		if resp.Data.CurrentUser.ID == "" {
-			return "", errors.New("cannot resolve current user")
+			return NamespaceDetails{}, errors.New("cannot resolve current user")
 		}
-		return resp.Data.CurrentUser.ID, nil
+		return NamespaceDetails{
+			ID:  resp.Data.CurrentUser.ID,
+			URL: resp.Data.CurrentUser.URL,
+		}, nil
 	}
 
 	var result struct {
 		Data struct {
-			User         *struct{ ID string }
-			Organization *struct{ ID string }
+			User *struct {
+				ID  string
+				URL string
+			}
+			Organization *struct {
+				ID  string
+				URL string
+			}
 		}
 		Errors []interface{}
 	}
 	if ok, err := svc.client.NewRequest(namespaceQuery, map[string]interface{}{
 		"name": namespace,
 	}).DoRaw(ctx, &result); err != nil || !ok {
-		return "", err
+		return NamespaceDetails{}, err
 	}
 
 	if result.Data.User != nil {
-		return result.Data.User.ID, nil
+		return NamespaceDetails{
+			ID:  result.Data.User.ID,
+			URL: result.Data.User.URL,
+		}, nil
 	}
 	if result.Data.Organization != nil {
-		return result.Data.Organization.ID, nil
+		return NamespaceDetails{
+			ID:  result.Data.Organization.ID,
+			URL: result.Data.Organization.URL,
+		}, nil
 	}
-	return "", fmt.Errorf("failed to resolve namespace %q: no user or organization found", namespace)
+	return NamespaceDetails{}, fmt.Errorf("failed to resolve namespace %q: no user or organization found", namespace)
 }
 
 func (svc *Service) ResolveRepositories(ctx context.Context, spec *batcheslib.BatchSpec) ([]*graphql.Repository, error) {

--- a/internal/batches/service/service.go
+++ b/internal/batches/service/service.go
@@ -463,10 +463,12 @@ const namespaceQuery = `
 query NamespaceQuery($name: String!) {
     user(username: $name) {
         id
+        url
     }
 
     organization(name: $name) {
         id
+        url
     }
 }
 `
@@ -475,7 +477,7 @@ const usernameQuery = `
 query GetCurrentUserID {
     currentUser {
         id
-		url
+        url
     }
 }
 `


### PR DESCRIPTION
### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->

Run `src batch remote -f comby-go-refactor.batch.yml`

comby-go-refactor.batch.yml
```yaml
name: comby-go-fmt
description: Run `comby` and `go fmt`

# Find all repositories that contain a README.md file.
on:
  - repositoriesMatchingQuery: lang:go fmt.Sprintf("%d", :[v]) patterntype:structural

steps:
  - run: comby -in-place 'fmt.Sprintf("%d", :[v])' 'strconv.Itoa(:[v])' ${{ join repository.search_result_paths " " }}
    container: comby/comby
  - run: goimports -w ${{ join previous_step.modified_files " " }}
    container: unibeautify/goimports

# Describe the changeset (e.g., GitHub pull request) you want for each repository.
changesetTemplate:
  title: Replacing fmt.Sprintf with strconv.Itoa
  body: This campiagn replaces `fmt.Sprintf` with `strconv.Itoa`
  branch: batch-changes/comby-go-fmt # Push the commit to this branch.
  commit:
    message: Replacing fmt.Sprintf with strconv.Iota
```

The result is an execution URL that doesn't 404.
![Screenshot 2022-04-20 at 15 46 36](https://user-images.githubusercontent.com/25608335/164257786-0ccffd97-e6e7-4971-993a-cb6981b328b9.png)

Closes [#33696](https://github.com/sourcegraph/sourcegraph/issues/33696)