### PR TITLE
Add support for LSIF Typed

### DIFF
--- a/cmd/src/lsif_upload.go
+++ b/cmd/src/lsif_upload.go
@@ -57,8 +57,8 @@ Examples:
 func handleLSIFUpload(args []string) error {
 	ctx := context.Background()
 
-	err := parseAndValidateLSIFUploadFlags(args)
 	out := lsifUploadOutput()
+	err := parseAndValidateLSIFUploadFlags(args, out)
 	if !lsifUploadFlags.json {
 		if out != nil {
 			printInferredArguments(out)

--- a/cmd/src/lsif_upload.go
+++ b/cmd/src/lsif_upload.go
@@ -57,8 +57,7 @@ Examples:
 func handleLSIFUpload(args []string) error {
 	ctx := context.Background()
 
-	out := lsifUploadOutput()
-	err := parseAndValidateLSIFUploadFlags(args, out)
+	out, err := parseAndValidateLSIFUploadFlags(args)
 	if !lsifUploadFlags.json {
 		if out != nil {
 			printInferredArguments(out)
@@ -117,22 +116,6 @@ func handleLSIFUpload(args []string) error {
 	}
 
 	return nil
-}
-
-// lsifUploadOutput returns an output object that should be used to print the progres
-// of requests made during this upload. If -json, -no-progress, or -trace>0 is given,
-// then no output object is defined.
-//
-// For -no-progress and -trace>0 conditions, emergency loggers will be used to display
-// inferred arguments and the URL at which processing status is shown.
-func lsifUploadOutput() (out *output.Output) {
-	if lsifUploadFlags.json || lsifUploadFlags.noProgress || lsifUploadFlags.verbosity > 0 {
-		return nil
-	}
-
-	return output.NewOutput(flag.CommandLine.Output(), output.OutputOpts{
-		Verbose: true,
-	})
 }
 
 // lsifUploadOptions creates a set of upload options given the values in the flags.

--- a/cmd/src/lsif_upload_flags_test.go
+++ b/cmd/src/lsif_upload_flags_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/sourcegraph/sourcegraph/lib/codeintel/lsiftyped"
+	"google.golang.org/protobuf/proto"
+)
+
+var exampleLsifTypedIndex = lsiftyped.Index{
+	Metadata: &lsiftyped.Metadata{
+		TextDocumentEncoding: lsiftyped.TextEncoding_UTF8,
+		ToolInfo: &lsiftyped.ToolInfo{
+			Name:    "hello",
+			Version: "1.0.0",
+		},
+	},
+}
+
+var exampleLsifGraphString = `{"id":1,"version":"0.4.3","positionEncoding":"utf-8","toolInfo":{"name":"hello","version":"1.0.0"},"type":"vertex","label":"metaData"}
+`
+
+func exampleLsifTypedBytes(t *testing.T) []byte {
+	bytes, err := proto.Marshal(&exampleLsifTypedIndex)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return bytes
+}
+
+func createTempLsifTypedFile(t *testing.T) (string, string) {
+	tmp, err := os.CreateTemp("", "*.lsif-typed")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmp.Write(exampleLsifTypedBytes(t))
+	tmp.Close()
+	tmpGraph := strings.TrimSuffix(tmp.Name(), "-typed")
+	t.Cleanup(func() {
+		os.Remove(tmp.Name())
+		os.Remove(tmpGraph)
+	})
+
+	return tmp.Name(), tmpGraph
+}
+
+func assertLsifGraphOutput(t *testing.T, lsifGraphFile, expectedGraphString string) {
+	out := lsifUploadOutput()
+	handleLSIFTyped(out)
+	lsifGraph, err := os.ReadFile(lsifGraphFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	obtained := string(lsifGraph)
+	if obtained != expectedGraphString {
+		t.Fatalf("unexpected LSIF output %s", obtained)
+	}
+	if lsifGraphFile != lsifUploadFlags.file {
+		t.Fatalf("unexpected lsifUploadFlag.file value %s, expected %s", lsifUploadFlags.file, lsifGraphFile)
+	}
+}
+
+func TestImplicitlyConvertLsifTypedIntoGraph(t *testing.T) {
+	_, graphFile := createTempLsifTypedFile(t)
+	lsifUploadFlags.file = graphFile
+	assertLsifGraphOutput(t, graphFile, exampleLsifGraphString)
+}
+
+func TestImplicitlyIgnoreLsifTyped(t *testing.T) {
+	_, graphFile := createTempLsifTypedFile(t)
+	lsifUploadFlags.file = graphFile
+	os.WriteFile(graphFile, []byte("hello world"), 0755)
+	assertLsifGraphOutput(t, graphFile, "hello world")
+}
+
+func TestExplicitlyConvertLsifTypedIntoGraph(t *testing.T) {
+	typedFile, graphFile := createTempLsifTypedFile(t)
+	lsifUploadFlags.file = typedFile
+	assertLsifGraphOutput(t, graphFile, exampleLsifGraphString)
+}

--- a/cmd/src/lsif_upload_flags_test.go
+++ b/cmd/src/lsif_upload_flags_test.go
@@ -42,7 +42,6 @@ func createTempLsifTypedFile(t *testing.T) (string, string) {
 		os.Remove(tmp.Name())
 		os.Remove(tmpGraph)
 	})
-
 	return tmp.Name(), tmpGraph
 }
 

--- a/cmd/src/lsif_upload_flags_test.go
+++ b/cmd/src/lsif_upload_flags_test.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"os"
-	"strings"
+	"path/filepath"
 	"testing"
 
 	"github.com/sourcegraph/sourcegraph/lib/codeintel/lsiftyped"
@@ -30,19 +30,15 @@ func exampleLsifTypedBytes(t *testing.T) []byte {
 	return bytes
 }
 
-func createTempLsifTypedFile(t *testing.T) (string, string) {
-	tmp, err := os.CreateTemp("", "*.lsif-typed")
+func createTempLsifTypedFile(t *testing.T) (typedFile, graphFile string) {
+	dir := t.TempDir()
+	typedFile = filepath.Join(dir, "dump.lsif-typed")
+	graphFile = filepath.Join(dir, "dump.lsif")
+	err := os.WriteFile(typedFile, exampleLsifTypedBytes(t), 0755)
 	if err != nil {
 		t.Fatal(err)
 	}
-	tmp.Write(exampleLsifTypedBytes(t))
-	tmp.Close()
-	tmpGraph := strings.TrimSuffix(tmp.Name(), "-typed")
-	t.Cleanup(func() {
-		os.Remove(tmp.Name())
-		os.Remove(tmpGraph)
-	})
-	return tmp.Name(), tmpGraph
+	return typedFile, graphFile
 }
 
 func assertLsifGraphOutput(t *testing.T, lsifGraphFile, expectedGraphString string) {

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/sourcegraph/sourcegraph/lib v0.0.0-20220414150621-eeb00fcedd88
 	github.com/stretchr/testify v1.7.1
 	golang.org/x/net v0.0.0-20220325170049-de3da57026de
+	google.golang.org/protobuf v1.27.1
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 	jaytaylor.com/html2text v0.0.0-20200412013138-3577fbdbcff7
 )

--- a/go.sum
+++ b/go.sum
@@ -491,6 +491,7 @@ google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpAD
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
+google.golang.org/protobuf v1.27.1 h1:SnqbnDw1V7RiZcXPx5MEeqPv2s79L9i7BJUlG/+RurQ=
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
Running `src lsif upload` now converts LSIF Typed into LSIF Graph in the
following scenarios:

- When the provided `-file` flag matches the file extension ".lsif-typed"
- When the provided `-file` flag points to a non-existent file, while
  the sibling `*.lsif-typed` file exists.

Fixes https://github.com/sourcegraph/sourcegraph/issues/27405

### Test plan

Manually tested the command locally.

```
❯ ~/dev/sourcegraph/src-cli/src lsif upload
ℹ️  Converting ./dump.lsif-typed into ./dump.lsif
💡 Inferred arguments
   repo: github.com/sourcegraph/sourcegraph
   commit: 91976dc8c72ce24876c10fa9fa1bd40a5f00e557
   root:
   file: dump.lsif
...
❯ ~/dev/sourcegraph/src-cli/src lsif upload -file dump.lsif-typed
ℹ️  Converting dump.lsif-typed into dump.lsif
💡 Inferred arguments
   repo: github.com/sourcegraph/sourcegraph
   commit: 91976dc8c72ce24876c10fa9fa1bd40a5f00e557
   root:
   file: dump.lsif
...
```
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
