### PR TITLE
batches: clarify on.repository error message when for incorrect repo path

### DIFF
--- a/internal/batches/service/service.go
+++ b/internal/batches/service/service.go
@@ -671,7 +671,9 @@ func (svc *Service) resolveRepositoryName(ctx context.Context, name string) (*gr
 		return nil, err
 	}
 	if result.Repository == nil {
-		return nil, errors.New("no repository found")
+
+		// no repository found: double-check your spelling and make sure to specify the repository in the format <>
+		return nil, errors.New("no repository found: did you check spelling and specify the repository in the format \"codehost.com/owner/repo-name\"? ")
 	}
 	return result.Repository, nil
 }


### PR DESCRIPTION
Closes #33778

going back and fourth between this error message:
`no repository found: double-check your spelling and make sure to specify the repository in the format "codehost.com/owner/repo-name"` 
&
 `no repository found: did you check spelling and specify the repository in the format "codehost.com/owner/repo-name"? 
`

Thoughts?

Also, I believe the SSBC error for this operation may also not be clear enough and could benefit from being changed to whatever we decide above. It reads:
`Resolving "r:sourcegraph": repo not found: name="sourcegraph"
`

### Test plan
observed visual change in error text in src cli
