### PR TITLE
Handle nil output when writing progress message

### DIFF
--- a/cmd/src/lsif_upload_flags.go
+++ b/cmd/src/lsif_upload_flags.go
@@ -184,7 +184,9 @@ func handleLSIFTyped(out *output.Output) error {
 // Reads the LSIF Typed encoded input file and writes the corresponding LSIF
 // Graph encoded output file.
 func convertLSIFTypedToLSIFGraph(out *output.Output, inputFile, outputFile string) error {
-	out.Writef("%s  Converting %s into %s", output.EmojiInfo, inputFile, outputFile)
+	if out != nil {
+		out.Writef("%s  Converting %s into %s", output.EmojiInfo, inputFile, outputFile)
+	}
 	tmp, err := os.Create(outputFile)
 	if err != nil {
 		return err


### PR DESCRIPTION
Previously, the command `src lsif upload -no-progress` failed with a
nil panic when using LSIF Typed. I was tempted to refactor the code
so that `output` cannot be nil but decided not to in order to keep the
diff small and focused on fixing the panic.

### Test plan

Manually ran `src lsif upload -no-progress` and see it not panic.
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
