### PR TITLE
Remove TODO from flag docs

### DIFF
--- a/cmd/src/lsif_upload_flags.go
+++ b/cmd/src/lsif_upload_flags.go
@@ -71,7 +71,7 @@ func init() {
 
 	// Codehost authorization secrets
 	lsifUploadFlagSet.StringVar(&lsifUploadFlags.gitHubToken, "github-token", "", `A GitHub access token with 'public_repo' scope that Sourcegraph uses to verify you have access to the repository.`)
-	lsifUploadFlagSet.StringVar(&lsifUploadFlags.gitLabToken, "gitlab-token", "", `A GitLab access token with 'read_repository' and 'write_repository' scopes that Sourcegraph uses to verify you have access to the repository.`)
+	lsifUploadFlagSet.StringVar(&lsifUploadFlags.gitLabToken, "gitlab-token", "", `A GitLab access token with 'read_api' scope that Sourcegraph uses to verify you have access to the repository.`)
 
 	// Output and error behavior
 	lsifUploadFlagSet.BoolVar(&lsifUploadFlags.ignoreUploadFailures, "ignore-upload-failure", false, `Exit with status code zero on upload failure.`)

--- a/cmd/src/lsif_upload_flags.go
+++ b/cmd/src/lsif_upload_flags.go
@@ -71,7 +71,7 @@ func init() {
 
 	// Codehost authorization secrets
 	lsifUploadFlagSet.StringVar(&lsifUploadFlags.gitHubToken, "github-token", "", `A GitHub access token with 'public_repo' scope that Sourcegraph uses to verify you have access to the repository.`)
-	lsifUploadFlagSet.StringVar(&lsifUploadFlags.gitLabToken, "gitlab-token", "", `A GitLab access token with TODO that Sourcegraph uses to verify you have access to the repository.`)
+	lsifUploadFlagSet.StringVar(&lsifUploadFlags.gitLabToken, "gitlab-token", "", `A GitLab access token with 'read_repository' and 'write_repository' scopes that Sourcegraph uses to verify you have access to the repository.`)
 
 	// Output and error behavior
 	lsifUploadFlagSet.BoolVar(&lsifUploadFlags.ignoreUploadFailures, "ignore-upload-failure", false, `Exit with status code zero on upload failure.`)


### PR DESCRIPTION
Otherwise, this TODO will end up in the Sourcegraph docs.

### Test plan

~The text is based on the old help text which mentioned "with read and write repository scope."~

@efritz locally tested this, `read_api` works.