### PR TITLE
Bump golang in asdf to 1.18

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-golang 1.17.5
+golang 1.18.1
 shfmt 3.2.0
 shellcheck 0.7.1


### PR DESCRIPTION
### Test plan

Tested `go` compilation and test running works locally again. Not a change to the shipped binary.
