### PR TITLE
Add src code-intel alias for src lsif

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to `src-cli` are documented in this file.
 ## Unreleased
 
 ### Added
+- `src code-intel` is a new alias for `src lsif`. [#745](https://github.com/sourcegraph/src-cli/pull/745)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to `src-cli` are documented in this file.
 ## Unreleased
 
 ### Added
-- `src code-intel` is a new alias for `src lsif`. [#745](https://github.com/sourcegraph/src-cli/pull/745)
+- `src code-intel` is a new alias for `src lsif`. [#748](https://github.com/sourcegraph/src-cli/pull/748)
 
 ### Changed
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN go build ./cmd/src
 # This stage should be kept in sync with Dockerfile.release.
 FROM sourcegraph/alpine:3.12@sha256:ce099fbcd3cf70b338fc4cb2a4e1fa9ae847de21afdb0a849a393b87d94fb174
 
-# needed for `src lsif upload` and `src actions exec`
+# needed for `src code-intel upload` and `src actions exec`
 RUN apk add --no-cache git
 
 COPY --from=builder /src/src /usr/bin/

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -4,7 +4,7 @@
 # the main Dockerfile, which should have an identical second stage.
 FROM sourcegraph/alpine:3.12@sha256:ce099fbcd3cf70b338fc4cb2a4e1fa9ae847de21afdb0a849a393b87d94fb174
 
-# needed for `src lsif upload` and `src actions exec`
+# needed for `src code-intel upload` and `src actions exec`
 RUN apk add --no-cache git
 
 COPY src /usr/bin/

--- a/README.markdown
+++ b/README.markdown
@@ -111,7 +111,8 @@ Is your Sourcegraph instance behind a custom auth proxy? See [auth proxy configu
  - `src config` - manage global, org, and user settings
  - `src extsvc` - manage external services (repository configuration)
  - `src extensions` - manage extensions
- - `src lsif` - manages LSIF data
+ - `src code-intel` - manages Code Intelligence data
+ - `src lsif` - manages LSIF data (DEPRECATED: use `src code-intel` instead)
  - `src serve-git` - serves your local git repositories over HTTP for Sourcegraph to pull
  - `src version` - check version and guaranteed-compatible version for your Sourcegraph instance
 

--- a/cmd/src/code_intel.go
+++ b/cmd/src/code_intel.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+)
+
+var codeintelCommands commander
+
+func init() {
+	usage := `'src code-intel' manages code intelligence data on a Sourcegraph instance.
+
+Usage:
+
+    src code-intel command [command options]
+
+The commands are:
+
+    upload     uploads an LSIF dump file
+
+Use "src code-intel [command] -h" for more information about a command.
+`
+	flagSet := flag.NewFlagSet("code-intel", flag.ExitOnError)
+	handler := func(args []string) error {
+		lsifCommands.run(flagSet, "src code-intel", usage, args)
+		return nil
+	}
+
+	// Register the command.
+	commands = append(commands, &command{
+		flagSet: flagSet,
+		aliases: []string{"code-intel"},
+		handler: handler,
+		usageFunc: func() {
+			fmt.Println(usage)
+		},
+	})
+}

--- a/cmd/src/code_intel_upload_flags.go
+++ b/cmd/src/code_intel_upload_flags.go
@@ -20,7 +20,7 @@ import (
 	"github.com/sourcegraph/src-cli/internal/codeintel"
 )
 
-var lsifUploadFlags struct {
+var codeintelUploadFlags struct {
 	file string
 
 	// UploadRecordOptions
@@ -49,53 +49,53 @@ var lsifUploadFlags struct {
 }
 
 var (
-	lsifUploadFlagSet = flag.NewFlagSet("upload", flag.ExitOnError)
-	apiClientFlagSet  = flag.NewFlagSet("upload client", flag.ExitOnError)
+	codeintelUploadFlagSet = flag.NewFlagSet("upload", flag.ExitOnError)
+	apiClientFlagSet       = flag.NewFlagSet("upload client", flag.ExitOnError)
 	// Used to include the insecure-skip-verify flag in the help output, as we don't use any of the
 	// other api.Client methods, so only the insecureSkipVerify flag is relevant here.
 	dummyflag bool
 )
 
 func init() {
-	lsifUploadFlagSet.StringVar(&lsifUploadFlags.file, "file", "./dump.lsif", `The path to the LSIF dump file.`)
+	codeintelUploadFlagSet.StringVar(&codeintelUploadFlags.file, "file", "./dump.lsif", `The path to the LSIF dump file.`)
 
 	// UploadRecordOptions
-	lsifUploadFlagSet.StringVar(&lsifUploadFlags.repo, "repo", "", `The name of the repository (e.g. github.com/gorilla/mux). By default, derived from the origin remote.`)
-	lsifUploadFlagSet.StringVar(&lsifUploadFlags.commit, "commit", "", `The 40-character hash of the commit. Defaults to the currently checked-out commit.`)
-	lsifUploadFlagSet.StringVar(&lsifUploadFlags.root, "root", "", `The path in the repository that matches the LSIF projectRoot (e.g. cmd/project1). Defaults to the directory where the dump file is located.`)
-	lsifUploadFlagSet.StringVar(&lsifUploadFlags.indexer, "indexer", "", `The name of the indexer that generated the dump. This will override the 'toolInfo.name' field in the metadata vertex of the LSIF dump file. This must be supplied if the indexer does not set this field (in which case the upload will fail with an explicit message).`)
-	lsifUploadFlagSet.StringVar(&lsifUploadFlags.indexerVersion, "indexerVersion", "", `The version of the indexer that generated the dump. This will override the 'toolInfo.version' field in the metadata vertex of the LSIF dump file. This must be supplied if the indexer does not set this field (in which case the upload will fail with an explicit message).`)
-	lsifUploadFlagSet.IntVar(&lsifUploadFlags.associatedIndexID, "associated-index-id", -1, "ID of the associated index record for this upload. For internal use only.")
+	codeintelUploadFlagSet.StringVar(&codeintelUploadFlags.repo, "repo", "", `The name of the repository (e.g. github.com/gorilla/mux). By default, derived from the origin remote.`)
+	codeintelUploadFlagSet.StringVar(&codeintelUploadFlags.commit, "commit", "", `The 40-character hash of the commit. Defaults to the currently checked-out commit.`)
+	codeintelUploadFlagSet.StringVar(&codeintelUploadFlags.root, "root", "", `The path in the repository that matches the LSIF projectRoot (e.g. cmd/project1). Defaults to the directory where the dump file is located.`)
+	codeintelUploadFlagSet.StringVar(&codeintelUploadFlags.indexer, "indexer", "", `The name of the indexer that generated the dump. This will override the 'toolInfo.name' field in the metadata vertex of the LSIF dump file. This must be supplied if the indexer does not set this field (in which case the upload will fail with an explicit message).`)
+	codeintelUploadFlagSet.StringVar(&codeintelUploadFlags.indexerVersion, "indexerVersion", "", `The version of the indexer that generated the dump. This will override the 'toolInfo.version' field in the metadata vertex of the LSIF dump file. This must be supplied if the indexer does not set this field (in which case the upload will fail with an explicit message).`)
+	codeintelUploadFlagSet.IntVar(&codeintelUploadFlags.associatedIndexID, "associated-index-id", -1, "ID of the associated index record for this upload. For internal use only.")
 
 	// SourcegraphInstanceOptions
-	lsifUploadFlagSet.StringVar(&lsifUploadFlags.uploadRoute, "upload-route", "/.api/lsif/upload", "The path of the upload route. For internal use only.")
-	lsifUploadFlagSet.Int64Var(&lsifUploadFlags.maxPayloadSizeMb, "max-payload-size", 100, `The maximum upload size (in megabytes). Indexes exceeding this limit will be uploaded over multiple HTTP requests.`)
+	codeintelUploadFlagSet.StringVar(&codeintelUploadFlags.uploadRoute, "upload-route", "/.api/lsif/upload", "The path of the upload route. For internal use only.")
+	codeintelUploadFlagSet.Int64Var(&codeintelUploadFlags.maxPayloadSizeMb, "max-payload-size", 100, `The maximum upload size (in megabytes). Indexes exceeding this limit will be uploaded over multiple HTTP requests.`)
 
 	// Codehost authorization secrets
-	lsifUploadFlagSet.StringVar(&lsifUploadFlags.gitHubToken, "github-token", "", `A GitHub access token with 'public_repo' scope that Sourcegraph uses to verify you have access to the repository.`)
-	lsifUploadFlagSet.StringVar(&lsifUploadFlags.gitLabToken, "gitlab-token", "", `A GitLab access token with 'read_api' scope that Sourcegraph uses to verify you have access to the repository.`)
+	codeintelUploadFlagSet.StringVar(&codeintelUploadFlags.gitHubToken, "github-token", "", `A GitHub access token with 'public_repo' scope that Sourcegraph uses to verify you have access to the repository.`)
+	codeintelUploadFlagSet.StringVar(&codeintelUploadFlags.gitLabToken, "gitlab-token", "", `A GitLab access token with 'read_api' scope that Sourcegraph uses to verify you have access to the repository.`)
 
 	// Output and error behavior
-	lsifUploadFlagSet.BoolVar(&lsifUploadFlags.ignoreUploadFailures, "ignore-upload-failure", false, `Exit with status code zero on upload failure.`)
-	lsifUploadFlagSet.BoolVar(&lsifUploadFlags.noProgress, "no-progress", false, `Do not display progress updates.`)
-	lsifUploadFlagSet.IntVar(&lsifUploadFlags.verbosity, "trace", 0, "-trace=0 shows no logs; -trace=1 shows requests and response metadata; -trace=2 shows headers, -trace=3 shows response body")
-	lsifUploadFlagSet.BoolVar(&lsifUploadFlags.json, "json", false, `Output relevant state in JSON on success.`)
-	lsifUploadFlagSet.BoolVar(&lsifUploadFlags.open, "open", false, `Open the LSIF upload page in your browser.`)
-	lsifUploadFlagSet.BoolVar(&dummyflag, "insecure-skip-verify", false, "Skip validation of TLS certificates against trusted chains")
+	codeintelUploadFlagSet.BoolVar(&codeintelUploadFlags.ignoreUploadFailures, "ignore-upload-failure", false, `Exit with status code zero on upload failure.`)
+	codeintelUploadFlagSet.BoolVar(&codeintelUploadFlags.noProgress, "no-progress", false, `Do not display progress updates.`)
+	codeintelUploadFlagSet.IntVar(&codeintelUploadFlags.verbosity, "trace", 0, "-trace=0 shows no logs; -trace=1 shows requests and response metadata; -trace=2 shows headers, -trace=3 shows response body")
+	codeintelUploadFlagSet.BoolVar(&codeintelUploadFlags.json, "json", false, `Output relevant state in JSON on success.`)
+	codeintelUploadFlagSet.BoolVar(&codeintelUploadFlags.open, "open", false, `Open the LSIF upload page in your browser.`)
+	codeintelUploadFlagSet.BoolVar(&dummyflag, "insecure-skip-verify", false, "Skip validation of TLS certificates against trusted chains")
 }
 
-// parseAndValidateLSIFUploadFlags calls lsifUploadFlagSet.Parse, then infers values for
-// missing flags, normalizes supplied values, and validates the state of the lsifUploadFlags
+// parseAndValidateCodeIntelUploadFlags calls codeintelUploadFlagset.Parse, then infers values for
+// missing flags, normalizes supplied values, and validates the state of the codeintelUploadFlags
 // object.
 //
-// On success, the global lsifUploadFlags object will be populated with valid values. An
+// On success, the global codeintelUploadFlags object will be populated with valid values. An
 // error is returned on failure.
-func parseAndValidateLSIFUploadFlags(args []string) (*output.Output, error) {
-	if err := lsifUploadFlagSet.Parse(args); err != nil {
+func parseAndValidateCodeIntelUploadFlags(args []string) (*output.Output, error) {
+	if err := codeintelUploadFlagSet.Parse(args); err != nil {
 		return nil, err
 	}
 
-	out := lsifUploadOutput()
+	out := codeintelUploadOutput()
 
 	// extract only the -insecure-skip-verify flag so we dont get 'flag provided but not defined'
 	var insecureSkipVerifyFlag []string
@@ -105,10 +105,10 @@ func parseAndValidateLSIFUploadFlags(args []string) (*output.Output, error) {
 		}
 	}
 
-	// parse the api client flags separately and then populate the lsifUploadFlags struct with the result
+	// parse the api client flags separately and then populate the codeintelUploadFlags struct with the result
 	// we could just use insecureSkipVerify but I'm including everything here because it costs nothing
 	// and maybe we'll use some in the future
-	lsifUploadFlags.apiFlags = api.NewFlags(apiClientFlagSet)
+	codeintelUploadFlags.apiFlags = api.NewFlags(apiClientFlagSet)
 	if err := apiClientFlagSet.Parse(insecureSkipVerifyFlag); err != nil {
 		return nil, err
 	}
@@ -117,7 +117,7 @@ func parseAndValidateLSIFUploadFlags(args []string) (*output.Output, error) {
 		return nil, err
 	}
 
-	if inferenceErrors := inferMissingLSIFUploadFlags(); len(inferenceErrors) > 0 {
+	if inferenceErrors := inferMissingCodeIntelUploadFlags(); len(inferenceErrors) > 0 {
 		return nil, errorWithHint{
 			err: inferenceErrors[0].err, hint: strings.Join([]string{
 				fmt.Sprintf(
@@ -129,21 +129,21 @@ func parseAndValidateLSIFUploadFlags(args []string) (*output.Output, error) {
 		}
 	}
 
-	if err := validateLSIFUploadFlags(); err != nil {
+	if err := validateCodeIntelUploadFlags(); err != nil {
 		return nil, err
 	}
 
 	return out, nil
 }
 
-// lsifUploadOutput returns an output object that should be used to print the progres
+// codeintelUploadOutput returns an output object that should be used to print the progres
 // of requests made during this upload. If -json, -no-progress, or -trace>0 is given,
 // then no output object is defined.
 //
 // For -no-progress and -trace>0 conditions, emergency loggers will be used to display
 // inferred arguments and the URL at which processing status is shown.
-func lsifUploadOutput() (out *output.Output) {
-	if lsifUploadFlags.json || lsifUploadFlags.noProgress || lsifUploadFlags.verbosity > 0 {
+func codeintelUploadOutput() (out *output.Output) {
+	if codeintelUploadFlags.json || codeintelUploadFlags.noProgress || codeintelUploadFlags.verbosity > 0 {
 		return nil
 	}
 
@@ -173,11 +173,11 @@ func replaceBaseName(oldPath string, newBaseName string) string {
 }
 
 func handleSCIP(out *output.Output) error {
-	fileExt := path.Ext(lsifUploadFlags.file)
+	fileExt := path.Ext(codeintelUploadFlags.file)
 	if len(fileExt) == 0 {
-		return errors.Newf("missing file extension for %s; expected .scip", lsifUploadFlags.file)
+		return errors.Newf("missing file extension for %s; expected .scip", codeintelUploadFlags.file)
 	}
-	inputFile := lsifUploadFlags.file
+	inputFile := codeintelUploadFlags.file
 	if fileExt == ".scip" || fileExt == ".lsif-typed" {
 		// The user explicitly passed in a -file flag that points to an SCIP index.
 		outputFile := replaceExtension(inputFile, ".lsif")
@@ -186,7 +186,7 @@ func handleSCIP(out *output.Output) error {
 		}
 		// HACK: Modify the flags to point to the output file, because
 		// that field of the flags is read when performing the upload.
-		lsifUploadFlags.file = outputFile
+		codeintelUploadFlags.file = outputFile
 		return convertSCIPToLSIFGraph(out, inputFile, outputFile)
 	}
 
@@ -213,7 +213,7 @@ func handleSCIP(out *output.Output) error {
 
 	// The provided -file flag points to an `*.lsif` file that doesn't exist
 	// so we convert the sibling file (which we confirmed exists).
-	return convertSCIPToLSIFGraph(out, scipFile, lsifUploadFlags.file)
+	return convertSCIPToLSIFGraph(out, scipFile, codeintelUploadFlags.file)
 }
 
 // Reads the SCIP encoded input file and writes the corresponding LSIF
@@ -252,13 +252,13 @@ func convertSCIPToLSIFGraph(out *output.Output, inputFile, outputFile string) er
 	return nil
 }
 
-// inferMissingLSIFUploadFlags updates the flags values which were not explicitly
+// inferMissingCodeIntelUploadFlags updates the flags values which were not explicitly
 // supplied by the user with default values inferred from the current git state and
 // filesystem.
 //
-// Note: This function must not be called before lsifUploadFlagSet.Parse.
-func inferMissingLSIFUploadFlags() (inferErrors []argumentInferenceError) {
-	if _, err := os.Stat(lsifUploadFlags.file); os.IsNotExist(err) {
+// Note: This function must not be called before codeintelUploadFlagset.Parse.
+func inferMissingCodeIntelUploadFlags() (inferErrors []argumentInferenceError) {
+	if _, err := os.Stat(codeintelUploadFlags.file); os.IsNotExist(err) {
 		inferErrors = append(inferErrors, argumentInferenceError{"file", err})
 	}
 
@@ -266,19 +266,19 @@ func inferMissingLSIFUploadFlags() (inferErrors []argumentInferenceError) {
 	getIndexerName := func() (string, error) { return indexerName, readIndexerNameAndVersionErr }
 	getIndexerVersion := func() (string, error) { return indexerVersion, readIndexerNameAndVersionErr }
 
-	if err := inferUnsetFlag("repo", &lsifUploadFlags.repo, codeintel.InferRepo); err != nil {
+	if err := inferUnsetFlag("repo", &codeintelUploadFlags.repo, codeintel.InferRepo); err != nil {
 		inferErrors = append(inferErrors, *err)
 	}
-	if err := inferUnsetFlag("commit", &lsifUploadFlags.commit, codeintel.InferCommit); err != nil {
+	if err := inferUnsetFlag("commit", &codeintelUploadFlags.commit, codeintel.InferCommit); err != nil {
 		inferErrors = append(inferErrors, *err)
 	}
-	if err := inferUnsetFlag("root", &lsifUploadFlags.root, inferIndexRoot); err != nil {
+	if err := inferUnsetFlag("root", &codeintelUploadFlags.root, inferIndexRoot); err != nil {
 		inferErrors = append(inferErrors, *err)
 	}
-	if err := inferUnsetFlag("indexer", &lsifUploadFlags.indexer, getIndexerName); err != nil {
+	if err := inferUnsetFlag("indexer", &codeintelUploadFlags.indexer, getIndexerName); err != nil {
 		inferErrors = append(inferErrors, *err)
 	}
-	if err := inferUnsetFlag("indexerVersion", &lsifUploadFlags.indexerVersion, getIndexerVersion); err != nil {
+	if err := inferUnsetFlag("indexerVersion", &codeintelUploadFlags.indexerVersion, getIndexerVersion); err != nil {
 		inferErrors = append(inferErrors, *err)
 	}
 
@@ -290,9 +290,9 @@ func inferMissingLSIFUploadFlags() (inferErrors []argumentInferenceError) {
 // by the user, then this function no-ops. An argumentInferenceError is returned if
 // the given function returns an error.
 //
-// Note: This function must not be called before lsifUploadFlagSet.Parse.
+// Note: This function must not be called before codeintelUploadFlagset.Parse.
 func inferUnsetFlag(name string, target *string, f func() (string, error)) *argumentInferenceError {
-	if isFlagSet(lsifUploadFlagSet, name) {
+	if isFlagSet(codeintelUploadFlagSet, name) {
 		return nil
 	}
 
@@ -320,17 +320,17 @@ func isFlagSet(fs *flag.FlagSet, name string) (found bool) {
 
 // inferIndexRoot returns the root directory based on the configured index file path.
 //
-// Note: This function must not be called before lsifUploadFlagSet.Parse.
+// Note: This function must not be called before codeintelUploadFlagset.Parse.
 func inferIndexRoot() (string, error) {
-	return codeintel.InferRoot(lsifUploadFlags.file)
+	return codeintel.InferRoot(codeintelUploadFlags.file)
 }
 
 // readIndexerNameAndVersion returns the indexer name and version values read from the
 // toolInfo value in the configured index file.
 //
-// Note: This function must not be called before lsifUploadFlagSet.Parse.
+// Note: This function must not be called before codeintelUploadFlagset.Parse.
 func readIndexerNameAndVersion() (string, string, error) {
-	file, err := os.Open(lsifUploadFlags.file)
+	file, err := os.Open(codeintelUploadFlags.file)
 	if err != nil {
 		return "", "", err
 	}
@@ -339,17 +339,17 @@ func readIndexerNameAndVersion() (string, string, error) {
 	return upload.ReadIndexerNameAndVersion(file)
 }
 
-// validateLSIFUploadFlags returns an error if any of the parsed flag values are illegal.
+// validateCodeIntelUploadFlags returns an error if any of the parsed flag values are illegal.
 //
-// Note: This function must not be called before lsifUploadFlagSet.Parse.
-func validateLSIFUploadFlags() error {
-	lsifUploadFlags.root = codeintel.SanitizeRoot(lsifUploadFlags.root)
+// Note: This function must not be called before codeintelUploadFlagset.Parse.
+func validateCodeIntelUploadFlags() error {
+	codeintelUploadFlags.root = codeintel.SanitizeRoot(codeintelUploadFlags.root)
 
-	if strings.HasPrefix(lsifUploadFlags.root, "..") {
+	if strings.HasPrefix(codeintelUploadFlags.root, "..") {
 		return errors.New("root must not be outside of repository")
 	}
 
-	if lsifUploadFlags.maxPayloadSizeMb < 25 {
+	if codeintelUploadFlags.maxPayloadSizeMb < 25 {
 		return errors.New("max-payload-size must be at least 25 (MB)")
 	}
 

--- a/cmd/src/code_intel_upload_flags_test.go
+++ b/cmd/src/code_intel_upload_flags_test.go
@@ -45,7 +45,7 @@ func createTempSCIPFile(t *testing.T, scipFileName string) (scipFilePath string,
 }
 
 func assertLSIFOutput(t *testing.T, lsifFile, expectedLSIFString string) {
-	out := lsifUploadOutput()
+	out := codeintelUploadOutput()
 	handleSCIP(out)
 	lsif, err := os.ReadFile(lsifFile)
 	if err != nil {
@@ -55,15 +55,15 @@ func assertLSIFOutput(t *testing.T, lsifFile, expectedLSIFString string) {
 	if obtained != expectedLSIFString {
 		t.Fatalf("unexpected LSIF output %s", obtained)
 	}
-	if lsifFile != lsifUploadFlags.file {
-		t.Fatalf("unexpected lsifUploadFlag.file value %s, expected %s", lsifUploadFlags.file, lsifFile)
+	if lsifFile != codeintelUploadFlags.file {
+		t.Fatalf("unexpected codeintelUploadFlag.file value %s, expected %s", codeintelUploadFlags.file, lsifFile)
 	}
 }
 
 func TestImplicitlyConvertSCIPIntoLSIF(t *testing.T) {
 	for _, filename := range []string{"index.scip", "dump.scip", "dump.lsif-typed"} {
 		_, lsifFile := createTempSCIPFile(t, filename)
-		lsifUploadFlags.file = lsifFile
+		codeintelUploadFlags.file = lsifFile
 		assertLSIFOutput(t, lsifFile, exampleLSIFString)
 	}
 }
@@ -71,7 +71,7 @@ func TestImplicitlyConvertSCIPIntoLSIF(t *testing.T) {
 func TestImplicitlyIgnoreSCIP(t *testing.T) {
 	for _, filename := range []string{"index.scip", "dump.scip", "dump.lsif-typed"} {
 		_, lsifFile := createTempSCIPFile(t, filename)
-		lsifUploadFlags.file = lsifFile
+		codeintelUploadFlags.file = lsifFile
 		os.WriteFile(lsifFile, []byte("hello world"), 0755)
 		assertLSIFOutput(t, lsifFile, "hello world")
 	}
@@ -80,7 +80,7 @@ func TestImplicitlyIgnoreSCIP(t *testing.T) {
 func TestExplicitlyConvertSCIPIntoGraph(t *testing.T) {
 	for _, filename := range []string{"index.scip", "dump.scip", "dump.lsif-typed"} {
 		scipFile, lsifFile := createTempSCIPFile(t, filename)
-		lsifUploadFlags.file = scipFile
+		codeintelUploadFlags.file = scipFile
 		assertLSIFOutput(t, lsifFile, exampleLSIFString)
 	}
 }

--- a/cmd/src/lsif.go
+++ b/cmd/src/lsif.go
@@ -8,19 +8,10 @@ import (
 var lsifCommands commander
 
 func init() {
-	usage := `'src lsif' is a tool that manages LSIF data on a Sourcegraph instance.
+	usage := `[DEPRECATED] 'src lsif' is a tool that manages LSIF data on a Sourcegraph instance.
 
-Usage:
-
-	src lsif command [command options]
-
-The commands are:
-
-	upload     uploads an LSIF dump file
-
-Use "src lsif [command] -h" for more information about a command.
+Use 'src code-intel' instead.
 `
-
 	flagSet := flag.NewFlagSet("lsif", flag.ExitOnError)
 	handler := func(args []string) error {
 		lsifCommands.run(flagSet, "src lsif", usage, args)

--- a/cmd/src/main.go
+++ b/cmd/src/main.go
@@ -34,15 +34,17 @@ The commands are:
 
 	api             interacts with the Sourcegraph GraphQL API
 	batch           manages batch changes
+	code-intel      manages code intelligence data
 	config          manages global, org, and user settings
 	extensions,ext  manages extensions (experimental)
 	extsvc          manages external services
 	login           authenticate to a Sourcegraph instance with your user credentials
-	lsif            manages LSIF data
+	lsif            manages LSIF data (deprecated: use 'code-intel')
 	orgs,org        manages organizations
 	repos,repo      manages repositories
 	search          search for results on Sourcegraph
 	serve-git       serves your local git repositories over HTTP for Sourcegraph to pull
+	upload          upload an index to a Sourcegraph instance
 	users,user      manages users
 	version         display and compare the src-cli version against the recommended version for your instance
 


### PR DESCRIPTION
Replaces #745. After discussing with Olaf and TJ, it was decided that
adding other commands would be easier if we had the in-between
command. We will add another alias depending on what Code Intel
is rebranded to. 😐

### Test Plan

Updated existing tests. Ran `src -h`, `src code-intel -h` and `src code-intel upload -h` manually.