### PR TITLE
Use `setup-node` GitHub Actions step before running `npm publish`.

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -41,6 +41,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          registry-url: 'https://registry.npmjs.org'
       - run: npm publish --access public
         working-directory: npm-distribution
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ All notable changes to `src-cli` are documented in this file.
 
 ### Removed
 
-## 3.40.3
+## 3.40.4
 
 ### Added
 

--- a/npm-distribution/package.json
+++ b/npm-distribution/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sourcegraph/src",
-  "version": "3.40.3",
+  "version": "3.40.4",
   "description": "Sourcegraph CLI",
   "repository": "git@github.com:sourcegraph/src-cli.git",
   "author": "Code Intelligence at Sourcegraph",


### PR DESCRIPTION
The last `npm publish` step failed with an authorization error
https://github.com/sourcegraph/src-cli/runs/6707002077?check_suite_focus=true
```
npm ERR! need auth This command requires you to be logged in to https://registry.npmjs.org/
29
```

Our current hypothesis is that this change fixes the issue.

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
