### PR TITLE
Simplify npm package release by setting the version

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -45,6 +45,10 @@ jobs:
         with:
           node-version: 16
           registry-url: 'https://registry.npmjs.org'
+      - run: echo "VERSION=${GITHUB_REF/refs\/tags\/v/}" >> $GITHUB_ENV
+      - run: echo "Releasing version ${{ env.version }}""
+      - run: yarn version --no-git-tag-version --new-version "${{ env.VERSION }}"
+        working-directory: npm-distribution
       - run: npm publish --access public
         working-directory: npm-distribution
         env:

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -56,15 +56,13 @@ We adhere to the [general Sourcegraph principles for testing](https://docs.sourc
 
 ## Releasing
 
-1.  If this is a non-patch release, update the changelog. Add a new section `## $MAJOR.MINOR` to [`CHANGELOG.md`](https://github.com/sourcegraph/src-cli/blob/main/CHANGELOG.md#unreleased) immediately under `## Unreleased changes`. Add new empty `Added`, `Changed`, `Fixed`, and `Removed` sections under `## Unreleased changes`.
-2.  Find the latest version (either via the releases tab on GitHub or via git tags) to determine which version you are releasing.
-3.  Update the `"version"` field in the file `npm-distribution/package.json` to match the version you are releasing.
-4.  Open a pull request with the new changelog and updated `npm-distribution/package.json` version. Get the pull request merged before completing the next step.
-5.  `VERSION=9.9.9 ./release.sh` (replace `9.9.9` with the version you are releasing)
-6.  GitHub will automatically perform the release via the [goreleaser action](https://github.com/sourcegraph/src-cli/actions?query=workflow%3AGoreleaser). Once it has finished, **you need to confirm**:
+1.  Find the latest version (either via the releases tab on GitHub or via git tags) to determine which version you are releasing.
+2.  (optional) If this is a non-patch release, update the changelog. Add a new section `## $MAJOR.MINOR` to [`CHANGELOG.md`](https://github.com/sourcegraph/src-cli/blob/main/CHANGELOG.md#unreleased) immediately under `## Unreleased changes`. Add new empty `Added`, `Changed`, `Fixed`, and `Removed` sections under `## Unreleased changes`. Open a pull request with the new changelog. Get the pull request merged before completing the next step.
+3.  `VERSION=9.9.9 ./release.sh` (replace `9.9.9` with the version you are releasing)
+4.  GitHub will automatically perform the release via the [goreleaser action](https://github.com/sourcegraph/src-cli/actions?query=workflow%3AGoreleaser). Once it has finished, **you need to confirm**:
     1. The [curl commands in the README](README.markdown#installation) fetch the latest version above.
     2. The [releases section of the repo sidebar](https://github.com/sourcegraph/src-cli) shows the correct version.
-7.  Make the necessary updates to the main Sourcegraph repo:
+5.  Make the necessary updates to the main Sourcegraph repo:
     1. Update the `MinimumVersion` constant in the [src-cli package](https://github.com/sourcegraph/sourcegraph/tree/main/internal/src-cli/consts.go).
     2. Update the reference documentation by running `go generate ./doc/cli/references`.
     3. Commit the changes, and open a PR.

--- a/npm-distribution/package.json
+++ b/npm-distribution/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sourcegraph/src",
-  "version": "3.40.4",
+  "version": "0.0.0-dev",
   "description": "Sourcegraph CLI",
   "repository": "git@github.com:sourcegraph/src-cli.git",
   "author": "Code Intelligence at Sourcegraph",

--- a/release.sh
+++ b/release.sh
@@ -5,21 +5,17 @@ set -euf -o pipefail
 read -p 'Have you read DEVELOPMENT.md? [y/N] ' -n 1 -r
 echo
 case "$REPLY" in
-    Y|y) ;;
-    *)
-        echo 'Please read the Releasing section of DEVELOPMENT.md before running this script.'
-        exit 1
-        ;;
+  Y | y) ;;
+  *)
+    echo 'Please read the Releasing section of DEVELOPMENT.md before running this script.'
+    exit 1
+    ;;
 esac
 
 if ! echo "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
   echo "\$VERSION is not in MAJOR.MINOR.PATCH format"
   exit 1
 fi
-
-echo "Verifying that npm-distribution/package.json has the correct version"
-yarn --cwd="$PWD/npm-distribution" version --no-git-tag-version --new-version "$VERSION"
-git diff --exit-code
 
 # Create a new tag and push it, this will trigger the goreleaser workflow in .github/workflows/goreleaser.yml
 git tag "${VERSION}" -a -m "release v${VERSION}"


### PR DESCRIPTION
Previously, you had to manually open a PR to bump up the version in package.json.
Now, the version is automatically bumped during the release pipeline.

### Test plan

Cut a new release and see if it works.
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
