### PR TITLE
Fix the regexp to extract the version from git refs

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           node-version: 16
           registry-url: 'https://registry.npmjs.org'
-      - run: echo "VERSION=${GITHUB_REF/refs\/tags\/v/}" >> $GITHUB_ENV
+      - run: echo "VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
       - run: echo "Releasing version ${{ env.version }}"
       - run: yarn version --no-git-tag-version --new-version "${{ env.VERSION }}"
         working-directory: npm-distribution


### PR DESCRIPTION
The last npm release job failed with "error Invalid version supplied."
because the inferred version was "refs/tags/3.40.6".

### Test plan

Run the release job and see it succeed.
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
