### PR TITLE
changelog: update for 3.40.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,15 +17,27 @@ All notable changes to `src-cli` are documented in this file.
 
 ### Fixed
 
+### Removed
+
+## 3.40.8
+
+### Fixed
+
 - Output variables created from batch spec steps will no longer have an extra newline added if the output doesn't end with a newline. [sourcegraph/sourcegraph#36562](https://github.com/sourcegraph/sourcegraph/issues/36562)
 
-### Removed
+## 3.40.5 to 3.40.7
+
+- No substantive changes; these releases were related solely to improving our release machinery.
 
 ## 3.40.4
 
 ### Added
 
 - It's now possible to install src-cli via `npm install -g @sourcegraph/src`. [sourcegraph/src-cli#760](https://github.com/sourcegraph/src-cli/pull/760)
+
+## 3.40.3
+
+- No substantive changes; this release was related solely to improving our release machinery.
 
 ## 3.40.2
 


### PR DESCRIPTION
I added sections for the other patch releases just so nobody is confused.

I miss being able to just push changes to `CHANGELOG.md`.

### Test plan

N/A