### PR TITLE
Only apply cache result progress if resulted in diff

### DIFF
--- a/internal/batches/executor/run_steps.go
+++ b/internal/batches/executor/run_steps.go
@@ -121,8 +121,12 @@ func runSteps(ctx context.Context, opts *executionOpts) (result execution.Result
 			stepContext.Steps.Changes = previousStepResult.Files
 			stepContext.Outputs = opts.task.CachedResult.Outputs
 
-			if err := ws.ApplyDiff(ctx, []byte(opts.task.CachedResult.Diff)); err != nil {
-				return execResult, nil, errors.Wrap(err, "getting changed files in step")
+			// If the previous steps made any modifications in the workspace yet,
+			// apply them.
+			if opts.task.CachedResult.Diff != "" {
+				if err := ws.ApplyDiff(ctx, []byte(opts.task.CachedResult.Diff)); err != nil {
+					return execResult, nil, errors.Wrap(err, "getting changed files in step")
+				}
 			}
 		}
 

--- a/internal/batches/workspace/bind_workspace.go
+++ b/internal/batches/workspace/bind_workspace.go
@@ -172,8 +172,8 @@ func (w *dockerBindWorkspace) ApplyDiff(ctx context.Context, diff []byte) error 
 	}
 
 	// Apply diff
-	if _, err = runGitCmd(ctx, w.dir, "apply", "-p0", tmp.Name()); err != nil {
-		return errors.Wrap(err, "applying cached diff")
+	if out, err := runGitCmd(ctx, w.dir, "apply", "-p0", tmp.Name()); err != nil {
+		return errors.Wrapf(err, "applying cached diff: %s", string(out))
 	}
 
 	// Add all files to index

--- a/internal/batches/workspace/git.go
+++ b/internal/batches/workspace/git.go
@@ -27,7 +27,7 @@ func runGitCmd(ctx context.Context, dir string, args ...string) ([]byte, error) 
 	cmd.Dir = dir
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return nil, errors.Wrapf(err, "'git %s' failed: %s", strings.Join(args, " "), out)
+		return out, errors.Wrapf(err, "'git %s' failed: %s", strings.Join(args, " "), out)
 	}
 	return out, nil
 }


### PR DESCRIPTION
A user reported this, we store execution step results in the cache also when no diff was generated (rightfully), but then we should only apply the patch when there is actually anything to do.

Also, I initially couldn't reproduce this locally because we swallowed this error in volume mode. It would only happen in bind mode.

Closes https://github.com/sourcegraph/src-cli/issues/755

### Test plan

Verified this does properly fail in volume mode now, too and don't fail anymore at all.