### PR TITLE
workspaces: Don't run in workspace path

### DIFF
--- a/internal/batches/executor/run_steps.go
+++ b/internal/batches/executor/run_steps.go
@@ -289,9 +289,10 @@ func executeSingleStep(
 
 	// Where should we execute the steps.run script?
 	scriptWorkDir := workDir
-	if opts.task.Path != "" {
-		scriptWorkDir = workDir + "/" + opts.task.Path
-	}
+	// TODO: This breaks scripts that use `search_result_paths`
+	// if opts.task.Path != "" {
+	// 	scriptWorkDir = workDir + "/" + opts.task.Path
+	// }
 
 	args := append([]string{
 		"run",


### PR DESCRIPTION
This messes with scripts and renders search_result_paths pretty much useless.

I propose we do this change to fix it, although breaking.
Also, we should introduce a "workingDirectory" option on `Step`, that allows to restore this using templating with `${{ workspace.path }}`.

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
