### PR TITLE
batches: Don't let stderr clutter git output

### DIFF
--- a/internal/batches/workspace/git.go
+++ b/internal/batches/workspace/git.go
@@ -25,9 +25,12 @@ func runGitCmd(ctx context.Context, dir string, args ...string) ([]byte, error) 
 		"GIT_COMMITTER_EMAIL=batch-changes@sourcegraph.com",
 	}
 	cmd.Dir = dir
-	out, err := cmd.CombinedOutput()
+	out, err := cmd.Output()
 	if err != nil {
-		return out, errors.Wrapf(err, "'git %s' failed: %s", strings.Join(args, " "), out)
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return out, errors.Wrapf(err, "'git %s' failed: %s", strings.Join(args, " "), string(exitErr.Stderr))
+		}
+		return out, errors.Wrapf(err, "'git %s' failed: %s", strings.Join(args, " "), string(out))
 	}
 	return out, nil
 }


### PR DESCRIPTION
We parse lots of the things that git outputs, so having stderr randonly interfere with the output breaks that parsing. Since we can still get stderr from the exiterror, I don't think this is a regression at all in debuggability. This was found on k8s where parsing the patch would fail on a particular repo. Turns out git logged a warning.

### Test plan

Verified the patch can now be parsed.