### PR TITLE
batches: use Docker CPU count as default parallelism, not GOMAXPROCS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ All notable changes to `src-cli` are documented in this file.
 
 ### Changed
 
+- The default parallelism of `src batch preview` and `src batch apply` are now based on the number of CPU cores available to Docker, rather than the host system running `src`. This can be overridden [with the `-j` flag](https://docs.sourcegraph.com/cli/references/batch/preview). [#786](https://github.com/sourcegraph/src-cli/pull/786)
+
 ### Fixed
 
 ### Removed

--- a/cmd/src/batch_common.go
+++ b/cmd/src/batch_common.go
@@ -123,7 +123,7 @@ func newBatchExecuteFlags(flagSet *flag.FlagSet, workspaceExecution bool, cacheD
 
 	flagSet.IntVar(
 		&caf.parallelism, "j", 0,
-		"The maximum number of parallel jobs. Default (or 0) is the number of CPU cores available to Docker, or GOMAXPROCS if Docker cannot report its number of cores.",
+		"The maximum number of parallel jobs. Default (or 0) is the number of CPU cores available to Docker.",
 	)
 	flagSet.DurationVar(
 		&caf.timeout, "timeout", 60*time.Minute,
@@ -544,19 +544,5 @@ func getBatchParallelism(ctx context.Context, flag int) (int, error) {
 		return flag, nil
 	}
 
-	ncpu, err := docker.NCPU(ctx)
-	var terr docker.TimeoutError
-	if errors.As(err, &terr) {
-		return 0, err
-	} else if err != nil {
-		// In the case of errors from Docker itself, we want to fall back to
-		// GOMAXPROCS, since it's possible Docker just doesn't have access to
-		// the CPU core count (either due to permissions, or being too old).
-		//
-		// It would obviously be better if we had a global logger available to
-		// log this.
-		return runtime.GOMAXPROCS(0), nil
-	}
-
-	return ncpu, nil
+	return docker.NCPU(ctx)
 }

--- a/cmd/src/batch_exec.go
+++ b/cmd/src/batch_exec.go
@@ -172,6 +172,9 @@ func executeBatchSpecInWorkspaces(ctx context.Context, flags *executorModeFlags)
 	if err := checkExecutable("git", "version"); err != nil {
 		return err
 	}
+	if err := checkExecutable("docker", "version"); err != nil {
+		return err
+	}
 
 	// Read the input file that contains the raw spec and the workspaces in
 	// which to execute it.

--- a/internal/batches/docker/context.go
+++ b/internal/batches/docker/context.go
@@ -37,6 +37,12 @@ type fastCommandTimeoutError struct {
 	timeout time.Duration
 }
 
+type TimeoutError interface {
+	Timeout() bool
+}
+
+var _ TimeoutError = &fastCommandTimeoutError{}
+
 func newFastCommandTimeoutError(ctx context.Context, args ...string) error {
 	// Attempt to extract the timeout from the context.
 	timeout, ok := ctx.Value(fastCommandTimeoutEnv).(time.Duration)
@@ -63,6 +69,8 @@ func (e *fastCommandTimeoutError) Error() string {
 		shellquote.Join(e.args...), e.timeout,
 	)
 }
+
+func (*fastCommandTimeoutError) Timeout() bool { return true }
 
 const (
 	fastCommandTimeoutDefault = 5 * time.Second

--- a/internal/batches/docker/context.go
+++ b/internal/batches/docker/context.go
@@ -37,12 +37,6 @@ type fastCommandTimeoutError struct {
 	timeout time.Duration
 }
 
-type TimeoutError interface {
-	Timeout() bool
-}
-
-var _ TimeoutError = &fastCommandTimeoutError{}
-
 func newFastCommandTimeoutError(ctx context.Context, args ...string) error {
 	// Attempt to extract the timeout from the context.
 	timeout, ok := ctx.Value(fastCommandTimeoutEnv).(time.Duration)

--- a/internal/batches/docker/context.go
+++ b/internal/batches/docker/context.go
@@ -1,0 +1,94 @@
+package docker
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/kballard/go-shellquote"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+// withFastCommandContext wraps the given context with a timeout appropriate for
+// invoking Docker commands that are expected to be fast, such as `docker info`
+// and `docker image inspect`. This defaults to 5 seconds, but can be overridden
+// by the undocumented $SRC_DOCKER_FAST_COMMAND_TIMEOUT environment variable.
+//
+// If the context deadline is exceeded, the code using the context can pass the
+// context and Docker arguments to newFastCommandTimeoutError to get a nicely
+// formatted error for the user.
+func withFastCommandContext(ctx context.Context) (context.Context, context.CancelFunc, error) {
+	timeout, err := fastCommandTimeout()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	fctx, cancel := context.WithTimeout(
+		context.WithValue(ctx, fastCommandTimeoutEnv, timeout),
+		timeout,
+	)
+	return fctx, cancel, nil
+}
+
+type fastCommandTimeoutError struct {
+	args    []string
+	timeout time.Duration
+}
+
+func newFastCommandTimeoutError(ctx context.Context, args ...string) error {
+	// Attempt to extract the timeout from the context.
+	timeout, ok := ctx.Value(fastCommandTimeoutEnv).(time.Duration)
+	if !ok {
+		return errors.Newf(
+			"additional error found when attempting to create fastCommandTimeoutError: "+
+				"no timeout was set within the context, so the context probably wasn't wrapped "+
+				"with withFastCommandContext (please file a bug report on src-cli!): "+
+				"the original error involved invoking docker with these args: %q",
+			args,
+		)
+	}
+
+	return &fastCommandTimeoutError{
+		args:    args,
+		timeout: timeout,
+	}
+}
+
+func (e *fastCommandTimeoutError) Error() string {
+	return fmt.Sprintf(
+		"`docker %s` failed to respond within %s; "+
+			"please verify that Docker has been started and is responding normally",
+		shellquote.Join(e.args...), e.timeout,
+	)
+}
+
+const (
+	fastCommandTimeoutDefault = 5 * time.Second
+	fastCommandTimeoutEnv     = "SRC_DOCKER_FAST_COMMAND_TIMEOUT"
+)
+
+var fastCommandTimeoutData = struct {
+	once    sync.Once
+	timeout time.Duration
+	err     error
+}{
+	timeout: fastCommandTimeoutDefault,
+	err:     nil,
+}
+
+func fastCommandTimeout() (time.Duration, error) {
+	fastCommandTimeoutData.once.Do(func() {
+		if userTimeout, ok := os.LookupEnv(fastCommandTimeoutEnv); ok {
+			parsed, err := time.ParseDuration(userTimeout)
+			if err != nil {
+				fastCommandTimeoutData.err = errors.Wrapf(err, "parsing timeout duration from environment variable %s", fastCommandTimeoutEnv)
+			} else {
+				fastCommandTimeoutData.timeout = parsed
+			}
+		}
+	})
+
+	return fastCommandTimeoutData.timeout, fastCommandTimeoutData.err
+}

--- a/internal/batches/docker/image.go
+++ b/internal/batches/docker/image.go
@@ -4,10 +4,8 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"os"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 
@@ -82,21 +80,18 @@ func (image *image) Ensure(ctx context.Context) error {
 				// Desktop VMs running out of memory, whereupon the Linux
 				// kernel's OOM killer sometimes chooses to kill components of
 				// Docker instead of processes within containers.
-				timeout, err := dockerImageInspectTimeout()
+				dctx, cancel, err := withFastCommandContext(ctx)
 				if err != nil {
 					return "", err
 				}
-				dctx, cancel := context.WithTimeout(ctx, timeout)
 				defer cancel()
 
-				out, err := exec.CommandContext(dctx, "docker", "image", "inspect", "--format", "{{ .Id }}", image.name).CombinedOutput()
+				args := []string{"image", "inspect", "--format", "{{ .Id }}", image.name}
+				out, err := exec.CommandContext(dctx, "docker", args...).CombinedOutput()
 				id := string(bytes.TrimSpace(out))
 
 				if errors.Is(errors.Cause(err), context.DeadlineExceeded) {
-					return "", &dockerImageInspectTimeoutError{
-						image:   image.name,
-						timeout: timeout,
-					}
+					return "", newFastCommandTimeoutError(dctx, args...)
 				} else if err != nil {
 					return "", err
 				}
@@ -107,7 +102,7 @@ func (image *image) Ensure(ctx context.Context) error {
 			// docker image inspect will return a non-zero exit code if the image and
 			// tag don't exist locally, regardless of the format.
 			var digest string
-			if digest, err = inspectDigest(); errors.HasType(err, &dockerImageInspectTimeoutError{}) {
+			if digest, err = inspectDigest(); errors.HasType(err, &fastCommandTimeoutError{}) {
 				// Ensure we immediately propagate a timeout up, rather than
 				// trying to tell an unresponsive Docker to pull.
 				return err
@@ -175,51 +170,4 @@ func (image *image) UIDGID(ctx context.Context) (UIDGID, error) {
 	})
 
 	return image.uidGid, image.uidGidErr
-}
-
-const (
-	dockerImageInspectTimeoutDefault = 5 * time.Second
-	dockerImageInspectTimeoutEnv     = "SRC_DOCKER_IMAGE_INSPECT_TIMEOUT"
-)
-
-var dockerImageInspectTimeoutData = struct {
-	once    sync.Once
-	timeout time.Duration
-	err     error
-}{
-	timeout: dockerImageInspectTimeoutDefault,
-	err:     nil,
-}
-
-// dockerImageInspectTimeout returns a timeout appropriate for invoking `docker
-// image inspect`. This defaults to 5 seconds, but can be overridden by the
-// undocumented $SRC_DOCKER_IMAGE_INSPECT_TIMEOUT environment variable.
-func dockerImageInspectTimeout() (time.Duration, error) {
-	dockerImageInspectTimeoutData.once.Do(func() {
-		if userTimeout, ok := os.LookupEnv(dockerImageInspectTimeoutEnv); ok {
-			parsed, err := time.ParseDuration(userTimeout)
-			if err != nil {
-				dockerImageInspectTimeoutData.err = errors.Wrapf(err, "parsing timeout duration from environment variable %s", dockerImageInspectTimeoutEnv)
-			} else {
-				dockerImageInspectTimeoutData.timeout = parsed
-			}
-		}
-	})
-
-	return dockerImageInspectTimeoutData.timeout, dockerImageInspectTimeoutData.err
-}
-
-type dockerImageInspectTimeoutError struct {
-	image   string
-	timeout time.Duration
-}
-
-var _ error = &dockerImageInspectTimeoutError{}
-
-func (e *dockerImageInspectTimeoutError) Error() string {
-	return fmt.Sprintf(
-		"`docker image inspect --format '{{ .Id }}' %s` failed to respond within %s; "+
-			"please verify that Docker has been started and is responding normally",
-		e.image, e.timeout,
-	)
 }

--- a/internal/batches/docker/image.go
+++ b/internal/batches/docker/image.go
@@ -90,7 +90,7 @@ func (image *image) Ensure(ctx context.Context) error {
 				out, err := exec.CommandContext(dctx, "docker", args...).CombinedOutput()
 				id := string(bytes.TrimSpace(out))
 
-				if errors.Is(err, context.DeadlineExceeded) {
+				if errors.IsDeadlineExceeded(err) || errors.IsDeadlineExceeded(dctx.Err()) {
 					return "", newFastCommandTimeoutError(dctx, args...)
 				} else if err != nil {
 					return "", err

--- a/internal/batches/docker/image.go
+++ b/internal/batches/docker/image.go
@@ -90,7 +90,7 @@ func (image *image) Ensure(ctx context.Context) error {
 				out, err := exec.CommandContext(dctx, "docker", args...).CombinedOutput()
 				id := string(bytes.TrimSpace(out))
 
-				if errors.Is(errors.Cause(err), context.DeadlineExceeded) {
+				if errors.Is(err, context.DeadlineExceeded) {
 					return "", newFastCommandTimeoutError(dctx, args...)
 				} else if err != nil {
 					return "", err

--- a/internal/batches/docker/image_test.go
+++ b/internal/batches/docker/image_test.go
@@ -94,10 +94,10 @@ func TestImage_Digest(t *testing.T) {
 		digest, err := image.Digest(ctx)
 		assert.Empty(t, digest)
 
-		as := &dockerImageInspectTimeoutError{}
+		as := &fastCommandTimeoutError{}
 		assert.ErrorAs(t, err, &as)
-		assert.Equal(t, "foo", as.image)
-		assert.Equal(t, dockerImageInspectTimeoutDefault, as.timeout)
+		assert.Equal(t, "foo", as.args[len(as.args)-1])
+		assert.Equal(t, fastCommandTimeoutDefault, as.timeout)
 	})
 }
 

--- a/internal/batches/docker/info.go
+++ b/internal/batches/docker/info.go
@@ -23,7 +23,7 @@ func NCPU(ctx context.Context) (int, error) {
 
 	args := []string{"info", "--format", "{{ .NCPU }}"}
 	out, err := exec.CommandContext(dctx, "docker", args...).CombinedOutput()
-	if errors.Is(errors.Cause(err), context.DeadlineExceeded) {
+	if errors.IsDeadlineExceeded(err) || errors.IsDeadlineExceeded(dctx.Err()) {
 		return ncpu, newFastCommandTimeoutError(dctx, args...)
 	} else if err != nil {
 		return ncpu, err

--- a/internal/batches/docker/info.go
+++ b/internal/batches/docker/info.go
@@ -28,7 +28,7 @@ func NCPU(ctx context.Context) (int, error) {
 
 	dcpu, err := strconv.Atoi(string(bytes.TrimSpace(out)))
 	if err != nil {
-		return 0, err
+		return 0, errors.Wrap(err, "parsing docker cpu count")
 	}
 
 	return dcpu, nil

--- a/internal/batches/docker/info.go
+++ b/internal/batches/docker/info.go
@@ -3,7 +3,6 @@ package docker
 import (
 	"bytes"
 	"context"
-	"runtime"
 	"strconv"
 
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -13,25 +12,23 @@ import (
 
 // NCPU returns the number of CPU cores available to Docker.
 func NCPU(ctx context.Context) (int, error) {
-	ncpu := runtime.GOMAXPROCS(0)
-
 	dctx, cancel, err := withFastCommandContext(ctx)
 	if err != nil {
-		return ncpu, err
+		return 0, err
 	}
 	defer cancel()
 
 	args := []string{"info", "--format", "{{ .NCPU }}"}
 	out, err := exec.CommandContext(dctx, "docker", args...).CombinedOutput()
 	if errors.IsDeadlineExceeded(err) || errors.IsDeadlineExceeded(dctx.Err()) {
-		return ncpu, newFastCommandTimeoutError(dctx, args...)
+		return 0, newFastCommandTimeoutError(dctx, args...)
 	} else if err != nil {
-		return ncpu, err
+		return 0, err
 	}
 
 	dcpu, err := strconv.Atoi(string(bytes.TrimSpace(out)))
 	if err != nil {
-		return ncpu, err
+		return 0, err
 	}
 
 	return dcpu, nil

--- a/internal/batches/docker/info.go
+++ b/internal/batches/docker/info.go
@@ -1,0 +1,38 @@
+package docker
+
+import (
+	"bytes"
+	"context"
+	"runtime"
+	"strconv"
+
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+
+	"github.com/sourcegraph/src-cli/internal/exec"
+)
+
+// NCPU returns the number of CPU cores available to Docker.
+func NCPU(ctx context.Context) (int, error) {
+	ncpu := runtime.GOMAXPROCS(0)
+
+	dctx, cancel, err := withFastCommandContext(ctx)
+	if err != nil {
+		return ncpu, err
+	}
+	defer cancel()
+
+	args := []string{"info", "--format", "{{ .NCPU }}"}
+	out, err := exec.CommandContext(dctx, "docker", args...).CombinedOutput()
+	if errors.Is(errors.Cause(err), context.DeadlineExceeded) {
+		return ncpu, newFastCommandTimeoutError(dctx, args...)
+	} else if err != nil {
+		return ncpu, err
+	}
+
+	dcpu, err := strconv.Atoi(string(bytes.TrimSpace(out)))
+	if err != nil {
+		return ncpu, err
+	}
+
+	return dcpu, nil
+}

--- a/internal/batches/docker/info_test.go
+++ b/internal/batches/docker/info_test.go
@@ -1,0 +1,76 @@
+package docker
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/sourcegraph/src-cli/internal/exec/expect"
+)
+
+func Test_NCPU(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("docker fails", func(t *testing.T) {
+		expect.Commands(t, infoFailure())
+
+		ncpu, err := NCPU(ctx)
+		assert.Zero(t, ncpu)
+		assert.Error(t, err)
+	})
+
+	t.Run("docker times out", func(t *testing.T) {
+		tctx, cancel := context.WithTimeout(ctx, -1*time.Second)
+		t.Cleanup(cancel)
+
+		expect.Commands(t, infoSuccess("4"))
+
+		ncpu, err := NCPU(tctx)
+		assert.Zero(t, ncpu)
+		var terr *fastCommandTimeoutError
+		assert.ErrorAs(t, err, &terr)
+		assert.Equal(t, []string{"info", "--format", "{{ .NCPU }}"}, terr.args)
+		assert.Equal(t, fastCommandTimeoutDefault, terr.timeout)
+	})
+
+	t.Run("docker succeeds, but returns nothing", func(t *testing.T) {
+		expect.Commands(t, infoSuccess(""))
+
+		ncpu, err := NCPU(ctx)
+		assert.Zero(t, ncpu)
+		assert.Error(t, err)
+	})
+
+	t.Run("docker succeeds, but returns something invalid", func(t *testing.T) {
+		expect.Commands(t, infoSuccess("foo"))
+
+		ncpu, err := NCPU(ctx)
+		assert.Zero(t, ncpu)
+		assert.Error(t, err)
+	})
+
+	t.Run("docker succeeds", func(t *testing.T) {
+		expect.Commands(t, infoSuccess("4"))
+
+		ncpu, err := NCPU(ctx)
+		assert.Equal(t, 4, ncpu)
+		assert.NoError(t, err)
+	})
+}
+
+func infoSuccess(ncpu string) *expect.Expectation {
+	return expect.NewLiteral(
+		expect.Behaviour{Stdout: []byte(fmt.Sprintf("%s\n", ncpu))},
+		"docker", "info", "--format", "{{ .NCPU }}",
+	)
+}
+
+func infoFailure() *expect.Expectation {
+	return expect.NewLiteral(
+		expect.Behaviour{ExitCode: 1},
+		"docker", "info", "--format", "{{ .NCPU }}",
+	)
+}

--- a/internal/exec/expect/expect.go
+++ b/internal/exec/expect/expect.go
@@ -212,3 +212,27 @@ func NewGlobValidator(wantName string, wantArg ...string) CommandValidator {
 		return errs
 	}
 }
+
+// NewLiteral is a convenience function that creates an Expectation that
+// validates commands literally.
+//
+// You don't need to use this, but it tends to make Commands() calls more
+// readable.
+func NewLiteral(behaviour Behaviour, wantName string, wantArg ...string) *Expectation {
+	return &Expectation{
+		Behaviour: behaviour,
+		Validator: func(haveName string, haveArg ...string) error {
+			var errs errors.MultiError
+
+			if wantName != haveName {
+				errs = errors.Append(errs, errors.Errorf("name does not match: have=%q want=%q", haveName, wantName))
+			}
+
+			if diff := cmp.Diff(haveArg, wantArg); diff != "" {
+				errs = errors.Append(errs, errors.Errorf("arguments do not match (-have +want):\n%s", diff))
+			}
+
+			return errs
+		},
+	}
+}


### PR DESCRIPTION
This PR changes the default parallelism of `src batch preview|apply` runs to be based on the CPU cores reported by `docker info`.

Practically, this means that Docker Desktop users will now have their parallelism based on the VM Docker runs within, not their host machine. The trade off here is that Docker Desktop users will likely have their default parallelism cut significantly, but this is also likely to make issues caused by the Docker VM having its resources exhausted considerably less likely.

### Implementation notes

* I've migrated the previous `docker version` preflight to use `docker info` instead, which means we can get the CPU count and preflight Docker at the same time.
* Since `docker info` should always be quick, this reuses the same timeout behaviour as #783, which has been renamed from being `image inspect` specific to being used for any "fast commands" issued to Docker. The behaviour is otherwise unchanged.
* In testing this, I found an issue where `os/exec` is inconsistent in terms of the error returned when a deadline is exceeded; I've updated both places we use the fast command context to look both at the returned error and the context error.

### Screenshot of the timeout

<img width="724" alt="image" src="https://user-images.githubusercontent.com/229984/173941814-ea5cef8f-0f9c-42f5-ad1e-bb296bfbd257.png">

### Test plan

Added unit tests, and tested this in various scenarios locally (Docker not running; Docker running but unresponsive; Docker running normally).