### PR TITLE
batches: upsert batch change when running `src batch remote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ All notable changes to `src-cli` are documented in this file.
 
 ### Fixed
 
-- Execution URL when running `src batch remote` doesn't result in a 404. [sourcegraph/src-cli](https://github.com/sourcegraph/src-cli/pull/787)
+- The preview link shown when running `src batch remote` to create a new batch change no longer 404s. [sourcegraph/src-cli](https://github.com/sourcegraph/src-cli/pull/787)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ All notable changes to `src-cli` are documented in this file.
 
 ### Fixed
 
+- Execution URL when running `src batch remote` doesn't result in a 404. [sourcegraph/src-cli](https://github.com/sourcegraph/src-cli/pull/787)
+
 ### Removed
 
 ## 3.40.11

--- a/cmd/src/batch_remote.go
+++ b/cmd/src/batch_remote.go
@@ -78,6 +78,13 @@ Examples:
 		}
 		ui.ResolvingNamespaceSuccess(namespace.ID)
 
+		ui.SendingBatchChange()
+		err = svc.UpsertBatchChange(ctx, spec.Name, namespace.ID)
+		if err != nil {
+			return err
+		}
+		ui.SendingBatchChangeSuccess()
+
 		ui.SendingBatchSpec()
 		batchSpecID, err := svc.UpsertBatchSpecInput(
 			ctx,

--- a/cmd/src/batch_remote.go
+++ b/cmd/src/batch_remote.go
@@ -79,7 +79,7 @@ Examples:
 		ui.ResolvingNamespaceSuccess(namespace.ID)
 
 		ui.SendingBatchChange()
-		err = svc.UpsertBatchChange(ctx, spec.Name, namespace.ID)
+		batchChangeName, err := svc.UpsertBatchChange(ctx, spec.Name, namespace.ID)
 		if err != nil {
 			return err
 		}
@@ -132,7 +132,7 @@ Examples:
 			"%s/%s/batch-changes/%s/executions/%s",
 			strings.TrimSuffix(cfg.Endpoint, "/"),
 			strings.TrimPrefix(namespace.URL, "/"),
-			spec.Name,
+			batchChangeName,
 			batchSpecID,
 		)
 		ui.RemoteSuccess(executionURL)

--- a/cmd/src/batch_remote.go
+++ b/cmd/src/batch_remote.go
@@ -86,7 +86,7 @@ Examples:
 		ui.SendingBatchChangeSuccess()
 
 		ui.SendingBatchSpec()
-		batchSpecID, err := svc.UpsertBatchSpecInput(
+		batchSpecID, err := svc.CreateBatchSpecFromRaw(
 			ctx,
 			raw,
 			namespace.ID,

--- a/internal/batches/service/remote.go
+++ b/internal/batches/service/remote.go
@@ -24,7 +24,7 @@ mutation UpsertEmptyBatchChange(
 		name: $name,
 		namespace: $namespace
 	) {
-		id
+		name
 	}
 }
 `
@@ -33,21 +33,25 @@ func (svc *Service) UpsertBatchChange(
 	ctx context.Context,
 	name string,
 	namespaceID string,
-) error {
+) (string, error) {
 	if err := svc.areServerSideBatchChangesSupported(); err != nil {
-		return err
+		return "", err
 	}
 
-	var resp struct{}
+	var resp struct {
+		UpsertEmptyBatchChange struct {
+			Name string `json:"name"`
+		} `json:"upsertEmptyBatchChange"`
+	}
 
 	if ok, err := svc.client.NewRequest(upsertEmptyBatchChange, map[string]interface{}{
 		"name":      name,
 		"namespace": namespaceID,
 	}).Do(ctx, &resp); err != nil || !ok {
-		return err
+		return "", err
 	}
 
-	return nil
+	return resp.UpsertEmptyBatchChange.Name, nil
 }
 
 const upsertBatchSpecInputQuery = `

--- a/internal/batches/service/remote.go
+++ b/internal/batches/service/remote.go
@@ -15,6 +15,41 @@ func (svc *Service) areServerSideBatchChangesSupported() error {
 	return nil
 }
 
+const upsertEmptyBatchChange = `
+mutation UpsertEmptyBatchChange(
+	$name: String!
+	$namespace: ID!
+) {
+	upsertEmptyBatchChange(
+		name: $name,
+		namespace: $namespace
+	) {
+		id
+	}
+}
+`
+
+func (svc *Service) UpsertBatchChange(
+	ctx context.Context,
+	name string,
+	namespaceID string,
+) error {
+	if err := svc.areServerSideBatchChangesSupported(); err != nil {
+		return err
+	}
+
+	var resp struct{}
+
+	if ok, err := svc.client.NewRequest(upsertEmptyBatchChange, map[string]interface{}{
+		"name":      name,
+		"namespace": namespaceID,
+	}).Do(ctx, &resp); err != nil || !ok {
+		return err
+	}
+
+	return nil
+}
+
 const upsertBatchSpecInputQuery = `
 mutation UpsertBatchSpecInput(
     $batchSpec: String!,

--- a/internal/batches/service/remote.go
+++ b/internal/batches/service/remote.go
@@ -105,57 +105,6 @@ func (svc *Service) CreateBatchSpecFromRaw(
 	return resp.CreateBatchSpecFromRaw.ID, nil
 }
 
-const upsertBatchSpecInputQuery = `
-mutation UpsertBatchSpecInput(
-    $batchSpec: String!,
-    $namespace: ID!,
-    $allowIgnored: Boolean!,
-    $allowUnsupported: Boolean!,
-    $noCache: Boolean!,
-) {
-    upsertBatchSpecInput(
-        batchSpec: $batchSpec,
-        namespace: $namespace,
-        allowIgnored: $allowIgnored,
-        allowUnsupported: $allowUnsupported,
-        noCache: $noCache,
-    ) {
-        id
-    }
-}
-`
-
-func (svc *Service) UpsertBatchSpecInput(
-	ctx context.Context,
-	batchSpec string,
-	namespaceID string,
-	allowIgnored bool,
-	allowUnsupported bool,
-	noCache bool,
-) (string, error) {
-	if err := svc.areServerSideBatchChangesSupported(); err != nil {
-		return "", err
-	}
-
-	var resp struct {
-		UpsertBatchSpecInput struct {
-			ID string `json:"id"`
-		} `json:"upsertBatchSpecInput"`
-	}
-
-	if ok, err := svc.client.NewRequest(upsertBatchSpecInputQuery, map[string]interface{}{
-		"batchSpec":        batchSpec,
-		"namespace":        namespaceID,
-		"allowIgnored":     allowIgnored,
-		"allowUnsupported": allowUnsupported,
-		"noCache":          noCache,
-	}).Do(ctx, &resp); err != nil || !ok {
-		return "", err
-	}
-
-	return resp.UpsertBatchSpecInput.ID, nil
-}
-
 const executeBatchSpecQuery = `
 mutation ExecuteBatchSpec($batchSpec: ID!, $noCache: Boolean!) {
     executeBatchSpec(batchSpec: $batchSpec, noCache: $noCache) {

--- a/internal/batches/ui/tui.go
+++ b/internal/batches/ui/tui.go
@@ -223,6 +223,14 @@ func (ui *TUI) ApplyingBatchSpecSuccess(batchChangeURL string) {
 	block.Writef("%s", batchChangeURL)
 }
 
+func (ui *TUI) SendingBatchChange() {
+	ui.pending = batchCreatePending(ui.Out, "Sending batch change")
+}
+
+func (ui *TUI) SendingBatchChangeSuccess() {
+	batchCompletePending(ui.pending, "Sending batch change")
+}
+
 func (ui *TUI) SendingBatchSpec() {
 	ui.pending = batchCreatePending(ui.Out, "Sending batch spec")
 }


### PR DESCRIPTION
Closes #780 

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
* Create a server-side batch change with the command `src batch remote`
* When the command is done, the batch change should be accessible via the execution link outputted in the terminal