### PR TITLE
Cancel reading from stdin on Ctrl-C

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ All notable changes to `src-cli` are documented in this file.
 
 ### Fixed
 
+- Handle SIGINT interrupt when reading from Stdin. [#794](https://github.com/sourcegraph/src-cli/pull/794)
+
 ### Removed
 
 ## 3.41.0

--- a/cmd/src/batch_common.go
+++ b/cmd/src/batch_common.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/mattn/go-isatty"
@@ -220,7 +221,7 @@ func batchDefaultTempDirPrefix() string {
 	return os.TempDir()
 }
 
-func batchOpenFileFlag(flag string) (io.ReadCloser, error) {
+func batchOpenFileFlag(flag string) (*os.File, error) {
 	if flag == "" || flag == "-" {
 		if flag != "-" {
 			// If the flag wasn't set, we want to check stdin. If it's not a TTY,
@@ -238,8 +239,13 @@ func batchOpenFileFlag(flag string) (io.ReadCloser, error) {
 				}
 			}
 		}
+		// https://github.com/golang/go/issues/24842
+		if err := syscall.SetNonblock(0, true); err != nil {
+			panic(err)
+		}
+		stdin := os.NewFile(0, "stdin")
 
-		return os.Stdin, nil
+		return stdin, nil
 	}
 
 	file, err := os.Open(flag)
@@ -292,7 +298,7 @@ func executeBatchSpec(ctx context.Context, ui ui.ExecUI, opts executeBatchSpecOp
 
 	// Parse flags and build up our service and executor options.
 	ui.ParsingBatchSpec()
-	batchSpec, rawSpec, err := parseBatchSpec(opts.file, svc, false)
+	batchSpec, rawSpec, err := parseBatchSpec(ctx, opts.file, svc, false)
 	if err != nil {
 		var multiErr errors.MultiError
 		if errors.As(err, &multiErr) {
@@ -481,17 +487,32 @@ func executeBatchSpec(ctx context.Context, ui ui.ExecUI, opts executeBatchSpecOp
 	return nil
 }
 
+type ReadDeadliner interface {
+	SetReadDeadline(t time.Time) error
+}
+
+func SetReadDeadlineOnCancel(ctx context.Context, d ReadDeadliner) {
+	go func() {
+		<-ctx.Done()
+		d.SetReadDeadline(time.Now())
+	}()
+}
+
 // parseBatchSpec parses and validates the given batch spec. If the spec has
 // validation errors, they are returned.
 //
 // isRemote argument is a temporary argument used to determine if the batch spec is being parsed for remote
 // (server-side) processing. Remote processing does not support mounts yet.
-func parseBatchSpec(file string, svc *service.Service, isRemote bool) (*batcheslib.BatchSpec, string, error) {
+func parseBatchSpec(ctx context.Context, file string, svc *service.Service, isRemote bool) (*batcheslib.BatchSpec, string, error) {
 	f, err := batchOpenFileFlag(file)
 	if err != nil {
 		return nil, "", err
 	}
 	defer f.Close()
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	SetReadDeadlineOnCancel(ctx, f)
 
 	data, err := io.ReadAll(f)
 	if err != nil {

--- a/cmd/src/batch_remote.go
+++ b/cmd/src/batch_remote.go
@@ -63,7 +63,7 @@ Examples:
 		// may as well validate it at the same time so we don't even have to go to
 		// the backend if it's invalid.
 		ui.ParsingBatchSpec()
-		spec, raw, err := parseBatchSpec(file, svc, true)
+		spec, raw, err := parseBatchSpec(ctx, file, svc, true)
 		if err != nil {
 			ui.ParsingBatchSpecFailure(err)
 			return err

--- a/cmd/src/batch_repositories.go
+++ b/cmd/src/batch_repositories.go
@@ -75,7 +75,7 @@ Examples:
 		}
 
 		out := output.NewOutput(flagSet.Output(), output.OutputOpts{Verbose: *verbose})
-		spec, _, err := parseBatchSpec(file, svc, false)
+		spec, _, err := parseBatchSpec(ctx, file, svc, false)
 		if err != nil {
 			ui := &ui.TUI{Out: out}
 			ui.ParsingBatchSpecFailure(err)

--- a/cmd/src/batch_validate.go
+++ b/cmd/src/batch_validate.go
@@ -75,7 +75,7 @@ Examples:
 			return err
 		}
 
-		if _, _, err := parseBatchSpec(file, svc, false); err != nil {
+		if _, _, err := parseBatchSpec(ctx, file, svc, false); err != nil {
 			ui.ParsingBatchSpecFailure(err)
 			return err
 		}


### PR DESCRIPTION
This is essentially a copy-paste implementation of the ideas presented
in this comment here: https://github.com/golang/go/issues/20280#issuecomment-655588450

It fixes #775 and helps with the issue described in https://github.com/sourcegraph/src-cli/pull/793#issuecomment-1163310725. Not sure if it has unintended side-effects.

<img width="651" alt="screenshot_2022-06-23_10 26 51@2x" src="https://user-images.githubusercontent.com/1185253/175253632-59a72636-6593-4c3f-b40e-9160db5c5e9a.png">

### Test plan

- Manually tested **only** the `src batch preview -f -` case, not the other cases.