### PR TITLE
batches: Cache filesystem mount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to `src-cli` are documented in this file.
 
 ### Added
 
+- Batch specs that mount paths now cache results. [sourcegraph/sourcegraph#37216](https://github.com/sourcegraph/sourcegraph/issues/37216)
+
 ### Changed
 
 ### Fixed

--- a/cmd/src/batch_common.go
+++ b/cmd/src/batch_common.go
@@ -366,13 +366,13 @@ func executeBatchSpec(ctx context.Context, ui ui.ExecUI, opts executeBatchSpecOp
 		archiveRegistry,
 		log.NewDiskManager(opts.flags.tempDir, opts.flags.keepLogs),
 		executor.NewCoordinatorOpts{
-			Creator:         workspaceCreator,
-			Cache:           executor.NewDiskCache(opts.flags.cacheDir),
-			Parallelism:     parallelism,
-			Timeout:         opts.flags.timeout,
-			TempDir:         opts.flags.tempDir,
-			GlobalEnv:       os.Environ(),
-			AllowPathMounts: true,
+			Creator:     workspaceCreator,
+			Cache:       executor.NewDiskCache(opts.flags.cacheDir),
+			Parallelism: parallelism,
+			Timeout:     opts.flags.timeout,
+			TempDir:     opts.flags.tempDir,
+			GlobalEnv:   os.Environ(),
+			IsRemote:    false,
 		},
 	)
 

--- a/cmd/src/batch_exec.go
+++ b/cmd/src/batch_exec.go
@@ -224,7 +224,7 @@ func executeBatchSpecInWorkspaces(ctx context.Context, flags *executorModeFlags)
 			// Don't allow to read from env.
 			GlobalEnv: []string{},
 			// Temporarily prevent the ability to sending a batch spec with a mount for server-side processing.
-			AllowPathMounts: false,
+			IsRemote: true,
 		},
 	)
 

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/sourcegraph/go-diff v0.6.1
 	github.com/sourcegraph/jsonx v0.0.0-20200629203448-1a936bd500cf
 	github.com/sourcegraph/scip v0.1.0
-	github.com/sourcegraph/sourcegraph/lib v0.0.0-20220614233452-81dc06f6e96e
+	github.com/sourcegraph/sourcegraph/lib v0.0.0-20220624142708-f2b0579b57ff
 	github.com/stretchr/testify v1.7.2
 	golang.org/x/net v0.0.0-20220526153639-5463443f8c37
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
@@ -83,7 +83,7 @@ require (
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/rogpeppe/go-internal v1.8.1 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
-	github.com/sourcegraph/log v0.0.0-20220613150728-bb50c87ba841 // indirect
+	github.com/sourcegraph/log v0.0.0-20220621231153-3bee7082c87e // indirect
 	github.com/spf13/cobra v1.4.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/ssor/bom v0.0.0-20170718123548-6386211fdfcf // indirect
@@ -98,7 +98,7 @@ require (
 	go.uber.org/zap v1.21.0 // indirect
 	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
-	golang.org/x/sys v0.0.0-20220614162138-6c1b26c55098 // indirect
+	golang.org/x/sys v0.0.0-20220622161953-175b2fd9d664 // indirect
 	golang.org/x/term v0.0.0-20220411215600-e5f449aeb171 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/tools v0.1.11 // indirect

--- a/go.sum
+++ b/go.sum
@@ -347,12 +347,12 @@ github.com/sourcegraph/go-diff v0.6.1 h1:hmA1LzxW0n1c3Q4YbrFgg4P99GSnebYa3x8gr0H
 github.com/sourcegraph/go-diff v0.6.1/go.mod h1:iBszgVvyxdc8SFZ7gm69go2KDdt3ag071iBaWPF6cjs=
 github.com/sourcegraph/jsonx v0.0.0-20200629203448-1a936bd500cf h1:oAdWFqhStsWiiMP/vkkHiMXqFXzl1XfUNOdxKJbd6bI=
 github.com/sourcegraph/jsonx v0.0.0-20200629203448-1a936bd500cf/go.mod h1:ppFaPm6kpcHnZGqQTFhUIAQRIEhdQDWP1PCv4/ON354=
-github.com/sourcegraph/log v0.0.0-20220613150728-bb50c87ba841 h1:kiYxuyQ1zSNA4YPtVVJQAFw5ZRNaFRkFqgKyEJQTzhg=
-github.com/sourcegraph/log v0.0.0-20220613150728-bb50c87ba841/go.mod h1:A+9F6IicYvBbl2aT0R81lMraKcXjVfdfw352yPe2yJI=
+github.com/sourcegraph/log v0.0.0-20220621231153-3bee7082c87e h1:7MnFFZ85BBwLNDkrQJB503/znGuSoLirDLFWRcLqHlM=
+github.com/sourcegraph/log v0.0.0-20220621231153-3bee7082c87e/go.mod h1:A+9F6IicYvBbl2aT0R81lMraKcXjVfdfw352yPe2yJI=
 github.com/sourcegraph/scip v0.1.0 h1:kTs0CJaLQvcRZjg+HpGrcJPNX2Tx31+d6szWio3ZOkQ=
 github.com/sourcegraph/scip v0.1.0/go.mod h1:/AZ8RvsnRfeCZy232PJuVZqcl9f82fJnYwdWZeU2JCo=
-github.com/sourcegraph/sourcegraph/lib v0.0.0-20220614233452-81dc06f6e96e h1:O+XG50CIAdzjuELX2gHhkc9Br1AaAXaOkZWg1YSRFpQ=
-github.com/sourcegraph/sourcegraph/lib v0.0.0-20220614233452-81dc06f6e96e/go.mod h1:Orrt+5wdseAvxsVxgdswYPzJgVkTk0rLlmFHZW61epo=
+github.com/sourcegraph/sourcegraph/lib v0.0.0-20220624142708-f2b0579b57ff h1:lcDmWfcg43tON2jMtpxtEq61wMF6rIgvbx7KfTKA6TU=
+github.com/sourcegraph/sourcegraph/lib v0.0.0-20220624142708-f2b0579b57ff/go.mod h1:ppU4qV7WAmfjEoQhM7P1hCDWmv1Q6lIy5mT9o3Pj5t8=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
@@ -503,8 +503,8 @@ golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211007075335-d3039528d8ac/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220209214540-3681064d5158/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220614162138-6c1b26c55098 h1:PgOr27OhUx2IRqGJ2RxAWI4dJQ7bi9cSrB82uzFzfUA=
-golang.org/x/sys v0.0.0-20220614162138-6c1b26c55098/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220622161953-175b2fd9d664 h1:wEZYwx+kK+KlZ0hpvP2Ls1Xr4+RWnlzGFwPP0aiDjIU=
+golang.org/x/sys v0.0.0-20220622161953-175b2fd9d664/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20220411215600-e5f449aeb171 h1:EH1Deb8WZJ0xc0WK//leUHXcX9aLE5SymusoTmMZye8=
 golang.org/x/term v0.0.0-20220411215600-e5f449aeb171/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=

--- a/internal/batches/executor/coordinator.go
+++ b/internal/batches/executor/coordinator.go
@@ -49,10 +49,10 @@ type NewCoordinatorOpts struct {
 	// Used by batcheslib.BuildChangesetSpecs
 	Features batches.FeatureFlags
 
-	Parallelism     int
-	Timeout         time.Duration
-	TempDir         string
-	AllowPathMounts bool
+	Parallelism int
+	Timeout     time.Duration
+	TempDir     string
+	IsRemote    bool
 }
 
 func NewCoordinator(opts NewCoordinatorOpts, logger log.LogManager) *Coordinator {
@@ -62,11 +62,11 @@ func NewCoordinator(opts NewCoordinatorOpts, logger log.LogManager) *Coordinator
 		Creator:             opts.Creator,
 		Logger:              logger,
 
-		Parallelism:     opts.Parallelism,
-		Timeout:         opts.Timeout,
-		TempDir:         opts.TempDir,
-		AllowPathMounts: opts.AllowPathMounts,
-		GlobalEnv:       opts.GlobalEnv,
+		Parallelism: opts.Parallelism,
+		Timeout:     opts.Timeout,
+		TempDir:     opts.TempDir,
+		IsRemote:    opts.IsRemote,
+		GlobalEnv:   opts.GlobalEnv,
 		WriteStepCacheResult: func(ctx context.Context, stepResult execution.AfterStepResult, task *Task) error {
 			cacheKey := task.cacheKey(opts.GlobalEnv)
 			return writeToCache(ctx, opts.Cache, stepResult, task, cacheKey)

--- a/internal/batches/executor/coordinator_test.go
+++ b/internal/batches/executor/coordinator_test.go
@@ -262,7 +262,7 @@ func TestCoordinator_Execute(t *testing.T) {
 			},
 		},
 		{
-			name: "skip cache for step mount",
+			name: "cache for step mount",
 
 			tasks: []*Task{srcCLITask, sourcegraphTask},
 
@@ -286,7 +286,7 @@ func TestCoordinator_Execute(t *testing.T) {
 			},
 			opts: NewCoordinatorOpts{Features: featuresAllEnabled()},
 
-			wantCacheEntries: 0,
+			wantCacheEntries: 2,
 			wantSpecs: []*batcheslib.ChangesetSpec{
 				buildSpecFor(testRepo1, func(spec *batcheslib.ChangesetSpec) {
 					spec.Commits[0].Diff = `dummydiff1`

--- a/internal/batches/executor/executor.go
+++ b/internal/batches/executor/executor.go
@@ -63,7 +63,7 @@ type newExecutorOpts struct {
 	Parallelism          int
 	Timeout              time.Duration
 	TempDir              string
-	AllowPathMounts      bool
+	IsRemote             bool
 	GlobalEnv            []string
 	WriteStepCacheResult func(ctx context.Context, stepResult execution.AfterStepResult, task *Task) error
 }
@@ -175,13 +175,13 @@ func (x *executor) do(ctx context.Context, task *Task, ui TaskExecutionUI) (err 
 
 	// Actually execute the steps.
 	opts := &executionOpts{
-		task:            task,
-		logger:          l,
-		wc:              x.opts.Creator,
-		ensureImage:     x.opts.EnsureImage,
-		tempDir:         x.opts.TempDir,
-		allowPathMounts: x.opts.AllowPathMounts,
-		globalEnv:       x.opts.GlobalEnv,
+		task:        task,
+		logger:      l,
+		wc:          x.opts.Creator,
+		ensureImage: x.opts.EnsureImage,
+		tempDir:     x.opts.TempDir,
+		isRemote:    x.opts.IsRemote,
+		globalEnv:   x.opts.GlobalEnv,
 
 		ui:                   ui.StepsExecutionUI(task),
 		writeStepCacheResult: x.opts.WriteStepCacheResult,

--- a/internal/batches/executor/run_steps.go
+++ b/internal/batches/executor/run_steps.go
@@ -38,7 +38,7 @@ type executionOpts struct {
 
 	ui StepsExecutionUI
 
-	allowPathMounts bool
+	isRemote bool
 
 	globalEnv []string
 
@@ -309,7 +309,7 @@ func executeSingleStep(
 	}
 
 	// Temporarily add a guard to prevent a path to mount path for server-side processing
-	if opts.allowPathMounts {
+	if !opts.isRemote {
 		// Mount any paths on the local system to the docker container. The paths have already been validated during parsing
 		for _, mount := range step.Mount {
 			args = append(args, "--mount", fmt.Sprintf("type=bind,source=%s,target=%s,ro", mount.Path, mount.Mountpoint))

--- a/internal/batches/executor/task.go
+++ b/internal/batches/executor/task.go
@@ -1,10 +1,14 @@
 package executor
 
 import (
+	"os"
+	"path/filepath"
+
 	batcheslib "github.com/sourcegraph/sourcegraph/lib/batches"
 	"github.com/sourcegraph/sourcegraph/lib/batches/execution"
 	"github.com/sourcegraph/sourcegraph/lib/batches/execution/cache"
 	"github.com/sourcegraph/sourcegraph/lib/batches/template"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 
 	"github.com/sourcegraph/src-cli/internal/batches/graphql"
 	"github.com/sourcegraph/src-cli/internal/batches/repozip"
@@ -45,7 +49,7 @@ func (t *Task) cacheKey(globalEnv []string, isRemote bool) *cache.ExecutionKeyWi
 	var metadataRetriever cache.MetadataRetriever
 	// If the task is being run locally, set the metadata retrieve to use the filesystem based implementation.
 	if !isRemote {
-		metadataRetriever = cache.FileMetadataRetriever{}
+		metadataRetriever = fileMetadataRetriever{}
 	}
 	return &cache.ExecutionKeyWithGlobalEnv{
 		GlobalEnv: globalEnv,
@@ -64,6 +68,64 @@ func (t *Task) cacheKey(globalEnv []string, isRemote bool) *cache.ExecutionKeyWi
 			MetadataRetriever:     metadataRetriever,
 		},
 	}
+}
+
+type fileMetadataRetriever struct {
+}
+
+func (f fileMetadataRetriever) Get(steps []batcheslib.Step) ([]cache.MountMetadata, error) {
+	var mountsMetadata []cache.MountMetadata
+	for _, step := range steps {
+		// Build up the metadata for each mount for each step
+		for _, mount := range step.Mount {
+			metadata, err := getMountMetadata(mount.Path)
+			if err != nil {
+				return nil, err
+			}
+			// A mount could be a directory containing multiple files
+			mountsMetadata = append(mountsMetadata, metadata...)
+		}
+	}
+	return mountsMetadata, nil
+}
+
+func getMountMetadata(path string) ([]cache.MountMetadata, error) {
+	info, err := os.Stat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, errors.Newf("path %s does not exist", path)
+	} else if err != nil {
+		return nil, err
+	}
+	var metadata []cache.MountMetadata
+	if info.IsDir() {
+		dirMetadata, err := getDirectoryMountMetadata(path)
+		if err != nil {
+			return nil, err
+		}
+		metadata = append(metadata, dirMetadata...)
+	} else {
+		metadata = append(metadata, cache.MountMetadata{Path: path, Size: info.Size(), Modified: info.ModTime().UTC()})
+	}
+	return metadata, nil
+}
+
+func getDirectoryMountMetadata(path string) ([]cache.MountMetadata, error) {
+	dir, err := os.ReadDir(path)
+	if err != nil {
+		return nil, err
+	}
+	var metadata []cache.MountMetadata
+	for _, dirEntry := range dir {
+		newPath := filepath.Join(path, dirEntry.Name())
+		// Go back to the very start. Need to get the FileInfo again for the new path and figure out if it is a
+		// directory or a file.
+		fileMetadata, err := getMountMetadata(newPath)
+		if err != nil {
+			return nil, err
+		}
+		metadata = append(metadata, fileMetadata...)
+	}
+	return metadata, nil
 }
 
 func cacheKeyForStep(key *cache.ExecutionKeyWithGlobalEnv, stepIndex int) *cache.StepsCacheKeyWithGlobalEnv {

--- a/internal/batches/executor/task.go
+++ b/internal/batches/executor/task.go
@@ -41,7 +41,12 @@ func (t *Task) ArchivePathToFetch() string {
 	return ""
 }
 
-func (t *Task) cacheKey(globalEnv []string) *cache.ExecutionKeyWithGlobalEnv {
+func (t *Task) cacheKey(globalEnv []string, isRemote bool) *cache.ExecutionKeyWithGlobalEnv {
+	var metadataRetriever cache.MetadataRetriever
+	// If the task is being run locally, set the metadata retrieve to use the filesystem based implementation.
+	if !isRemote {
+		metadataRetriever = cache.FileMetadataRetriever{}
+	}
 	return &cache.ExecutionKeyWithGlobalEnv{
 		GlobalEnv: globalEnv,
 		ExecutionKey: &cache.ExecutionKey{
@@ -56,6 +61,7 @@ func (t *Task) cacheKey(globalEnv []string) *cache.ExecutionKeyWithGlobalEnv {
 			OnlyFetchWorkspace:    t.OnlyFetchWorkspace,
 			Steps:                 t.Steps,
 			BatchChangeAttributes: t.BatchChangeAttributes,
+			MetadataRetriever:     metadataRetriever,
 		},
 	}
 }

--- a/internal/batches/executor/task_test.go
+++ b/internal/batches/executor/task_test.go
@@ -1,0 +1,145 @@
+package executor
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcegraph/sourcegraph/lib/batches"
+	"github.com/sourcegraph/sourcegraph/lib/batches/execution/cache"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+func TestFileMetadataRetriever_Get(t *testing.T) {
+	tempDir := t.TempDir()
+
+	// Set a specific date on the temp files
+	modDate := time.Date(2022, 1, 2, 3, 5, 6, 7, time.UTC)
+
+	// create temp files/dirs that can be used by the tests
+	sampleScriptPath := filepath.Join(tempDir, "sample.sh")
+	_, err := os.Create(sampleScriptPath)
+	require.NoError(t, err)
+	err = os.Chtimes(sampleScriptPath, modDate, modDate)
+	require.NoError(t, err)
+
+	anotherScriptPath := filepath.Join(tempDir, "another.sh")
+	_, err = os.Create(anotherScriptPath)
+	require.NoError(t, err)
+	err = os.Chtimes(anotherScriptPath, modDate, modDate)
+	require.NoError(t, err)
+
+	retriever := fileMetadataRetriever{}
+
+	tests := []struct {
+		name             string
+		steps            []batches.Step
+		expectedMetadata []cache.MountMetadata
+		expectedError    error
+	}{
+		{
+			name: "simple file",
+			steps: []batches.Step{
+				{
+					Run: "foo",
+					Mount: []batches.Mount{{
+						Path:       sampleScriptPath,
+						Mountpoint: "/tmp/foo.sh",
+					}},
+				},
+			},
+			expectedMetadata: []cache.MountMetadata{
+				{Path: sampleScriptPath, Size: 0, Modified: modDate},
+			},
+		},
+		{
+			name: "multiple files",
+			steps: []batches.Step{
+				{
+					Run: "foo",
+					Mount: []batches.Mount{
+						{
+							Path:       sampleScriptPath,
+							Mountpoint: "/tmp/foo.sh",
+						},
+						{
+							Path:       anotherScriptPath,
+							Mountpoint: "/tmp/bar.sh",
+						},
+					},
+				},
+			},
+			expectedMetadata: []cache.MountMetadata{
+				{Path: sampleScriptPath, Size: 0, Modified: modDate},
+				{Path: anotherScriptPath, Size: 0, Modified: modDate},
+			},
+		},
+		{
+			name: "directory",
+			steps: []batches.Step{
+				{
+					Run: "foo",
+					Mount: []batches.Mount{{
+						Path:       tempDir,
+						Mountpoint: "/tmp/scripts",
+					}},
+				},
+			},
+			expectedMetadata: []cache.MountMetadata{
+				{Path: anotherScriptPath, Size: 0, Modified: modDate},
+				{Path: sampleScriptPath, Size: 0, Modified: modDate},
+			},
+		},
+		{
+			name: "file does not exist",
+			steps: []batches.Step{
+				{
+					Run: "foo",
+					Mount: []batches.Mount{{
+						Path:       filepath.Join(tempDir, "some-file-does-not-exist.sh"),
+						Mountpoint: "/tmp/file.sh",
+					}},
+				},
+			},
+			expectedError: errors.Newf("path %s does not exist", filepath.Join(tempDir, "some-file-does-not-exist.sh")),
+		},
+		{
+			name: "multiple steps",
+			steps: []batches.Step{
+				{
+					Run: "foo",
+					Mount: []batches.Mount{{
+						Path:       sampleScriptPath,
+						Mountpoint: "/tmp/foo.sh",
+					}},
+				},
+				{
+					Run: "foo",
+					Mount: []batches.Mount{{
+						Path:       sampleScriptPath,
+						Mountpoint: "/tmp/foo.sh",
+					}},
+				},
+			},
+			expectedMetadata: []cache.MountMetadata{
+				{Path: sampleScriptPath, Size: 0, Modified: modDate},
+				{Path: sampleScriptPath, Size: 0, Modified: modDate},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			metadata, err := retriever.Get(test.steps)
+			if test.expectedError != nil {
+				assert.Equal(t, test.expectedError.Error(), err.Error())
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, test.expectedMetadata, metadata)
+			}
+		})
+	}
+}

--- a/internal/batches/executor/task_test.go
+++ b/internal/batches/executor/task_test.go
@@ -18,7 +18,7 @@ func TestFileMetadataRetriever_Get(t *testing.T) {
 	tempDir := t.TempDir()
 
 	// Set a specific date on the temp files
-	modDate := time.Date(2022, 1, 2, 3, 5, 6, 7, time.UTC)
+	modDate := time.Date(2022, 1, 2, 3, 5, 6, 0, time.UTC)
 
 	// create temp files/dirs that can be used by the tests
 	sampleScriptPath := filepath.Join(tempDir, "sample.sh")

--- a/internal/batches/executor/task_test.go
+++ b/internal/batches/executor/task_test.go
@@ -1,6 +1,7 @@
 package executor
 
 import (
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -15,14 +16,20 @@ import (
 )
 
 func TestFileMetadataRetriever_Get(t *testing.T) {
-	tempDir := t.TempDir()
+	// TODO: use TempDir when https://github.com/golang/go/issues/51442 is cherry-picked into 1.18 or upgrade to 1.19+
+	//tempDir := t.TempDir()
+	tempDir, err := ioutil.TempDir("", "metadata")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		os.RemoveAll(tempDir)
+	})
 
 	// Set a specific date on the temp files
 	modDate := time.Date(2022, 1, 2, 3, 5, 6, 0, time.UTC)
 
 	// create temp files/dirs that can be used by the tests
 	sampleScriptPath := filepath.Join(tempDir, "sample.sh")
-	_, err := os.Create(sampleScriptPath)
+	_, err = os.Create(sampleScriptPath)
 	require.NoError(t, err)
 	err = os.Chtimes(sampleScriptPath, modDate, modDate)
 	require.NoError(t, err)

--- a/internal/batches/executor/task_test.go
+++ b/internal/batches/executor/task_test.go
@@ -1,7 +1,6 @@
 package executor
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -18,7 +17,7 @@ import (
 func TestFileMetadataRetriever_Get(t *testing.T) {
 	// TODO: use TempDir when https://github.com/golang/go/issues/51442 is cherry-picked into 1.18 or upgrade to 1.19+
 	//tempDir := t.TempDir()
-	tempDir, err := ioutil.TempDir("", "metadata")
+	tempDir, err := os.MkdirTemp("", "metadata")
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		os.RemoveAll(tempDir)


### PR DESCRIPTION
Closes [#37216](https://github.com/sourcegraph/sourcegraph/issues/37216).

* Removed the cache checks to enable caching for `mount`
* Renamed `AllowMountPaths` to `IsRemote` for usage in the caching (enables caching for filesystem only)

### Test plan

Go Unit tests and manual testing. See [#37363](https://github.com/sourcegraph/sourcegraph/pull/37363)