### PR TITLE
batches: Refactor caching to get rid of execution cache results altogether

### DIFF
--- a/cmd/src/batch_exec.go
+++ b/cmd/src/batch_exec.go
@@ -165,7 +165,7 @@ func executeBatchSpecInWorkspaces(ctx context.Context, flags *executorModeFlags)
 		Client: &deadClient{},
 	})
 
-	if err := svc.SetFeatureFlagsForRelease(flags.sourcegraphVersion); err != nil {
+	if err := svc.SetFeatureFlagsForVersion(flags.sourcegraphVersion); err != nil {
 		return err
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/sourcegraph/go-diff v0.6.1
 	github.com/sourcegraph/jsonx v0.0.0-20200629203448-1a936bd500cf
 	github.com/sourcegraph/scip v0.1.0
-	github.com/sourcegraph/sourcegraph/lib v0.0.0-20220707111615-aabfa368a790
+	github.com/sourcegraph/sourcegraph/lib v0.0.0-20220708204051-cb0aebdbfd74
 	github.com/stretchr/testify v1.7.2
 	golang.org/x/net v0.0.0-20220526153639-5463443f8c37
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
@@ -83,7 +83,7 @@ require (
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/rogpeppe/go-internal v1.8.1 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
-	github.com/sourcegraph/log v0.0.0-20220704182018-fbd708c153e2 // indirect
+	github.com/sourcegraph/log v0.0.0-20220707160925-6a936691c838 // indirect
 	github.com/spf13/cobra v1.4.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/ssor/bom v0.0.0-20170718123548-6386211fdfcf // indirect
@@ -98,7 +98,7 @@ require (
 	go.uber.org/zap v1.21.0 // indirect
 	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
-	golang.org/x/sys v0.0.0-20220704084225-05e143d24a9e // indirect
+	golang.org/x/sys v0.0.0-20220708085239-5a0f0661e09d // indirect
 	golang.org/x/term v0.0.0-20220411215600-e5f449aeb171 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/tools v0.1.11 // indirect

--- a/go.mod
+++ b/go.mod
@@ -83,7 +83,7 @@ require (
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/rogpeppe/go-internal v1.8.1 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
-	github.com/sourcegraph/log v0.0.0-20220621231153-3bee7082c87e // indirect
+	github.com/sourcegraph/log v0.0.0-20220704182018-fbd708c153e2 // indirect
 	github.com/spf13/cobra v1.4.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/ssor/bom v0.0.0-20170718123548-6386211fdfcf // indirect
@@ -98,7 +98,7 @@ require (
 	go.uber.org/zap v1.21.0 // indirect
 	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
-	golang.org/x/sys v0.0.0-20220622161953-175b2fd9d664 // indirect
+	golang.org/x/sys v0.0.0-20220704084225-05e143d24a9e // indirect
 	golang.org/x/term v0.0.0-20220411215600-e5f449aeb171 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/tools v0.1.11 // indirect
@@ -110,3 +110,5 @@ require (
 
 // See: https://github.com/ghodss/yaml/pull/65
 replace github.com/ghodss/yaml => github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152
+
+replace github.com/sourcegraph/sourcegraph/lib => /Users/erik/Code/sourcegraph/sourcegraph/lib

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/sourcegraph/go-diff v0.6.1
 	github.com/sourcegraph/jsonx v0.0.0-20200629203448-1a936bd500cf
 	github.com/sourcegraph/scip v0.1.0
-	github.com/sourcegraph/sourcegraph/lib v0.0.0-20220624142708-f2b0579b57ff
+	github.com/sourcegraph/sourcegraph/lib v0.0.0-20220707111615-aabfa368a790
 	github.com/stretchr/testify v1.7.2
 	golang.org/x/net v0.0.0-20220526153639-5463443f8c37
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
@@ -110,5 +110,3 @@ require (
 
 // See: https://github.com/ghodss/yaml/pull/65
 replace github.com/ghodss/yaml => github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152
-
-replace github.com/sourcegraph/sourcegraph/lib => /Users/erik/Code/sourcegraph/sourcegraph/lib

--- a/go.sum
+++ b/go.sum
@@ -347,12 +347,12 @@ github.com/sourcegraph/go-diff v0.6.1 h1:hmA1LzxW0n1c3Q4YbrFgg4P99GSnebYa3x8gr0H
 github.com/sourcegraph/go-diff v0.6.1/go.mod h1:iBszgVvyxdc8SFZ7gm69go2KDdt3ag071iBaWPF6cjs=
 github.com/sourcegraph/jsonx v0.0.0-20200629203448-1a936bd500cf h1:oAdWFqhStsWiiMP/vkkHiMXqFXzl1XfUNOdxKJbd6bI=
 github.com/sourcegraph/jsonx v0.0.0-20200629203448-1a936bd500cf/go.mod h1:ppFaPm6kpcHnZGqQTFhUIAQRIEhdQDWP1PCv4/ON354=
-github.com/sourcegraph/log v0.0.0-20220704182018-fbd708c153e2 h1:zJfrKH3roMV69m7n06C5y2Xk00HextnxvlG0gnpQolI=
-github.com/sourcegraph/log v0.0.0-20220704182018-fbd708c153e2/go.mod h1:zWEPlKrWBUVpko/tOgDS+qrp7BmzaCcmUrh9+ver1iQ=
+github.com/sourcegraph/log v0.0.0-20220707160925-6a936691c838 h1:8wknDSCUVYbaRT63OD+Iyv+stwze5kE2FAzbA1HrNMA=
+github.com/sourcegraph/log v0.0.0-20220707160925-6a936691c838/go.mod h1:zWEPlKrWBUVpko/tOgDS+qrp7BmzaCcmUrh9+ver1iQ=
 github.com/sourcegraph/scip v0.1.0 h1:kTs0CJaLQvcRZjg+HpGrcJPNX2Tx31+d6szWio3ZOkQ=
 github.com/sourcegraph/scip v0.1.0/go.mod h1:/AZ8RvsnRfeCZy232PJuVZqcl9f82fJnYwdWZeU2JCo=
-github.com/sourcegraph/sourcegraph/lib v0.0.0-20220707111615-aabfa368a790 h1:cjHc8bTBbFIlOFH4SuSjDOl4udG9/BH/sCHUVCtEwRQ=
-github.com/sourcegraph/sourcegraph/lib v0.0.0-20220707111615-aabfa368a790/go.mod h1:RyepyZ2yp2D5/8PGtLw1q49v1rTIQljW1IznsnCQVNA=
+github.com/sourcegraph/sourcegraph/lib v0.0.0-20220708204051-cb0aebdbfd74 h1:XX4rxuQeXuRdg0qNupvrGKSDXKgZyk3flwbSCGMCiFU=
+github.com/sourcegraph/sourcegraph/lib v0.0.0-20220708204051-cb0aebdbfd74/go.mod h1:4efRAk7Sv9XaetWwvOxZjiBO3i32jlsmQKpemvCJmMI=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
@@ -503,8 +503,8 @@ golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211007075335-d3039528d8ac/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220209214540-3681064d5158/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220704084225-05e143d24a9e h1:CsOuNlbOuf0mzxJIefr6Q4uAUetRUwZE4qt7VfzP+xo=
-golang.org/x/sys v0.0.0-20220704084225-05e143d24a9e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220708085239-5a0f0661e09d h1:/m5NbqQelATgoSPVC2Z23sR4kVNokFwDDyWh/3rGY+I=
+golang.org/x/sys v0.0.0-20220708085239-5a0f0661e09d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20220411215600-e5f449aeb171 h1:EH1Deb8WZJ0xc0WK//leUHXcX9aLE5SymusoTmMZye8=
 golang.org/x/term v0.0.0-20220411215600-e5f449aeb171/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=

--- a/go.sum
+++ b/go.sum
@@ -347,12 +347,10 @@ github.com/sourcegraph/go-diff v0.6.1 h1:hmA1LzxW0n1c3Q4YbrFgg4P99GSnebYa3x8gr0H
 github.com/sourcegraph/go-diff v0.6.1/go.mod h1:iBszgVvyxdc8SFZ7gm69go2KDdt3ag071iBaWPF6cjs=
 github.com/sourcegraph/jsonx v0.0.0-20200629203448-1a936bd500cf h1:oAdWFqhStsWiiMP/vkkHiMXqFXzl1XfUNOdxKJbd6bI=
 github.com/sourcegraph/jsonx v0.0.0-20200629203448-1a936bd500cf/go.mod h1:ppFaPm6kpcHnZGqQTFhUIAQRIEhdQDWP1PCv4/ON354=
-github.com/sourcegraph/log v0.0.0-20220621231153-3bee7082c87e h1:7MnFFZ85BBwLNDkrQJB503/znGuSoLirDLFWRcLqHlM=
-github.com/sourcegraph/log v0.0.0-20220621231153-3bee7082c87e/go.mod h1:A+9F6IicYvBbl2aT0R81lMraKcXjVfdfw352yPe2yJI=
+github.com/sourcegraph/log v0.0.0-20220704182018-fbd708c153e2 h1:zJfrKH3roMV69m7n06C5y2Xk00HextnxvlG0gnpQolI=
+github.com/sourcegraph/log v0.0.0-20220704182018-fbd708c153e2/go.mod h1:zWEPlKrWBUVpko/tOgDS+qrp7BmzaCcmUrh9+ver1iQ=
 github.com/sourcegraph/scip v0.1.0 h1:kTs0CJaLQvcRZjg+HpGrcJPNX2Tx31+d6szWio3ZOkQ=
 github.com/sourcegraph/scip v0.1.0/go.mod h1:/AZ8RvsnRfeCZy232PJuVZqcl9f82fJnYwdWZeU2JCo=
-github.com/sourcegraph/sourcegraph/lib v0.0.0-20220624142708-f2b0579b57ff h1:lcDmWfcg43tON2jMtpxtEq61wMF6rIgvbx7KfTKA6TU=
-github.com/sourcegraph/sourcegraph/lib v0.0.0-20220624142708-f2b0579b57ff/go.mod h1:ppU4qV7WAmfjEoQhM7P1hCDWmv1Q6lIy5mT9o3Pj5t8=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
@@ -503,8 +501,8 @@ golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211007075335-d3039528d8ac/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220209214540-3681064d5158/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220622161953-175b2fd9d664 h1:wEZYwx+kK+KlZ0hpvP2Ls1Xr4+RWnlzGFwPP0aiDjIU=
-golang.org/x/sys v0.0.0-20220622161953-175b2fd9d664/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220704084225-05e143d24a9e h1:CsOuNlbOuf0mzxJIefr6Q4uAUetRUwZE4qt7VfzP+xo=
+golang.org/x/sys v0.0.0-20220704084225-05e143d24a9e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20220411215600-e5f449aeb171 h1:EH1Deb8WZJ0xc0WK//leUHXcX9aLE5SymusoTmMZye8=
 golang.org/x/term v0.0.0-20220411215600-e5f449aeb171/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=

--- a/go.sum
+++ b/go.sum
@@ -351,6 +351,8 @@ github.com/sourcegraph/log v0.0.0-20220704182018-fbd708c153e2 h1:zJfrKH3roMV69m7
 github.com/sourcegraph/log v0.0.0-20220704182018-fbd708c153e2/go.mod h1:zWEPlKrWBUVpko/tOgDS+qrp7BmzaCcmUrh9+ver1iQ=
 github.com/sourcegraph/scip v0.1.0 h1:kTs0CJaLQvcRZjg+HpGrcJPNX2Tx31+d6szWio3ZOkQ=
 github.com/sourcegraph/scip v0.1.0/go.mod h1:/AZ8RvsnRfeCZy232PJuVZqcl9f82fJnYwdWZeU2JCo=
+github.com/sourcegraph/sourcegraph/lib v0.0.0-20220707111615-aabfa368a790 h1:cjHc8bTBbFIlOFH4SuSjDOl4udG9/BH/sCHUVCtEwRQ=
+github.com/sourcegraph/sourcegraph/lib v0.0.0-20220707111615-aabfa368a790/go.mod h1:RyepyZ2yp2D5/8PGtLw1q49v1rTIQljW1IznsnCQVNA=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=

--- a/internal/batches/executor/coordinator.go
+++ b/internal/batches/executor/coordinator.go
@@ -259,7 +259,7 @@ func (c *Coordinator) doExecute(ctx context.Context, tasks []*Task, ui TaskExecu
 	for _, res := range results {
 		for _, stepRes := range res.stepResults {
 			cacheKey := res.task.cacheKey(c.opts.GlobalEnv, c.opts.IsRemote, stepRes.StepIndex)
-			if err := c.opts.Cache.Set(ctx, cacheKey, stepRes); err != nil {
+			if err := c.cache.Set(ctx, cacheKey, stepRes); err != nil {
 				return nil, errors.Wrapf(err, "caching result for step %d", stepRes.StepIndex)
 			}
 		}

--- a/internal/batches/executor/coordinator_test.go
+++ b/internal/batches/executor/coordinator_test.go
@@ -24,8 +24,8 @@ import (
 
 func TestCoordinator_Execute(t *testing.T) {
 	publishedFalse := overridable.FromBoolOrString(false)
-	srcCLITask := &Task{Repository: testRepo1}
-	sourcegraphTask := &Task{Repository: testRepo2}
+	srcCLITask := &Task{Repository: testRepo1, Steps: []batcheslib.Step{{Run: "echo Hello World"}}}
+	sourcegraphTask := &Task{Repository: testRepo2, Steps: []batcheslib.Step{{Run: "echo Hello Sourcegraph"}}}
 
 	buildSpecFor := func(repo *graphql.Repository, modify func(*batcheslib.ChangesetSpec)) *batcheslib.ChangesetSpec {
 		spec := &batcheslib.ChangesetSpec{
@@ -318,9 +318,9 @@ func TestCoordinator_Execute(t *testing.T) {
 
 			verifyCache := func(t *testing.T) {
 				// Verify that there is a cache entry for each repo.
-				if have, want := c.size(), tc.wantCacheEntries; have != want {
-					t.Errorf("unexpected number of cache entries: have=%d want=%d cache=%+v", have, want, c)
-				}
+				// if have, want := c.size(), tc.wantCacheEntries; have != want {
+				// 	t.Errorf("unexpected number of cache entries: have=%d want=%d cache=%+v", have, want, c)
+				// }
 			}
 
 			// Sanity check, since we're going to be looking at the side effects

--- a/internal/batches/executor/coordinator_test.go
+++ b/internal/batches/executor/coordinator_test.go
@@ -61,8 +61,9 @@ func TestCoordinator_Execute(t *testing.T) {
 		tasks     []*Task
 		batchSpec *batcheslib.BatchSpec
 
-		wantSpecs      []*batcheslib.ChangesetSpec
-		wantErrInclude string
+		wantCacheEntries int
+		wantSpecs        []*batcheslib.ChangesetSpec
+		wantErrInclude   string
 	}{
 		{
 			name: "success",
@@ -83,6 +84,7 @@ func TestCoordinator_Execute(t *testing.T) {
 			},
 			opts: NewCoordinatorOpts{Features: featuresAllEnabled()},
 
+			wantCacheEntries: 2,
 			wantSpecs: []*batcheslib.ChangesetSpec{
 				buildSpecFor(testRepo1, func(spec *batcheslib.ChangesetSpec) {
 					spec.Commits[0].Diff = `dummydiff1`
@@ -150,6 +152,7 @@ func TestCoordinator_Execute(t *testing.T) {
 			},
 			opts: NewCoordinatorOpts{Features: featuresAllEnabled()},
 
+			wantCacheEntries: 1,
 			wantSpecs: []*batcheslib.ChangesetSpec{
 				buildSpecFor(testRepo1, func(spec *batcheslib.ChangesetSpec) {
 					spec.HeadRef = "refs/heads/templated-branch-myOutputValue1"
@@ -203,6 +206,7 @@ func TestCoordinator_Execute(t *testing.T) {
 			// TODO: Fix comment.
 			// We have 4 ChangesetSpecs, but we only want 2 cache entries,
 			// since we cache per Task, not per resulting changeset spec.
+			wantCacheEntries: 2,
 			wantSpecs: []*batcheslib.ChangesetSpec{
 				buildSpecFor(testRepo1, func(spec *batcheslib.ChangesetSpec) {
 					spec.HeadRef = "refs/heads/" + testChangesetTemplate.Branch
@@ -318,9 +322,9 @@ func TestCoordinator_Execute(t *testing.T) {
 
 			verifyCache := func(t *testing.T) {
 				// Verify that there is a cache entry for each repo.
-				// if have, want := c.size(), tc.wantCacheEntries; have != want {
-				// 	t.Errorf("unexpected number of cache entries: have=%d want=%d cache=%+v", have, want, c)
-				// }
+				if have, want := c.size(), tc.wantCacheEntries; have != want {
+					t.Errorf("unexpected number of cache entries: have=%d want=%d cache=%+v", have, want, c)
+				}
 			}
 
 			// Sanity check, since we're going to be looking at the side effects

--- a/internal/batches/executor/coordinator_test.go
+++ b/internal/batches/executor/coordinator_test.go
@@ -61,9 +61,8 @@ func TestCoordinator_Execute(t *testing.T) {
 		tasks     []*Task
 		batchSpec *batcheslib.BatchSpec
 
-		wantCacheEntries int
-		wantSpecs        []*batcheslib.ChangesetSpec
-		wantErrInclude   string
+		wantSpecs      []*batcheslib.ChangesetSpec
+		wantErrInclude string
 	}{
 		{
 			name: "success",
@@ -84,7 +83,6 @@ func TestCoordinator_Execute(t *testing.T) {
 			},
 			opts: NewCoordinatorOpts{Features: featuresAllEnabled()},
 
-			wantCacheEntries: 2,
 			wantSpecs: []*batcheslib.ChangesetSpec{
 				buildSpecFor(testRepo1, func(spec *batcheslib.ChangesetSpec) {
 					spec.Commits[0].Diff = `dummydiff1`
@@ -152,7 +150,6 @@ func TestCoordinator_Execute(t *testing.T) {
 			},
 			opts: NewCoordinatorOpts{Features: featuresAllEnabled()},
 
-			wantCacheEntries: 1,
 			wantSpecs: []*batcheslib.ChangesetSpec{
 				buildSpecFor(testRepo1, func(spec *batcheslib.ChangesetSpec) {
 					spec.HeadRef = "refs/heads/templated-branch-myOutputValue1"
@@ -203,9 +200,9 @@ func TestCoordinator_Execute(t *testing.T) {
 			},
 			opts: NewCoordinatorOpts{Features: featuresAllEnabled()},
 
+			// TODO: Fix comment.
 			// We have 4 ChangesetSpecs, but we only want 2 cache entries,
 			// since we cache per Task, not per resulting changeset spec.
-			wantCacheEntries: 2,
 			wantSpecs: []*batcheslib.ChangesetSpec{
 				buildSpecFor(testRepo1, func(spec *batcheslib.ChangesetSpec) {
 					spec.HeadRef = "refs/heads/" + testChangesetTemplate.Branch
@@ -250,7 +247,6 @@ func TestCoordinator_Execute(t *testing.T) {
 			},
 			opts: NewCoordinatorOpts{Features: featuresAllEnabled()},
 
-			wantCacheEntries: 2,
 			wantSpecs: []*batcheslib.ChangesetSpec{
 				buildSpecFor(testRepo1, func(spec *batcheslib.ChangesetSpec) {
 					spec.Commits[0].Diff = `dummydiff1`
@@ -330,7 +326,7 @@ func TestCoordinator_Execute(t *testing.T) {
 			// Sanity check, since we're going to be looking at the side effects
 			// on the cache.
 			if c.size() != 0 {
-				t.Fatalf("unexpectedly hot cache: %+v", c)
+				t.Fatalf("unexpected hot cache: %+v", c)
 			}
 
 			// Run with a cold cache.
@@ -586,7 +582,7 @@ func (c *inMemoryExecutionCache) getCacheItem(key cache.Keyer) (interface{}, boo
 	return res, ok, nil
 }
 
-func (c *inMemoryExecutionCache) GetStepResult(ctx context.Context, key cache.Keyer) (execution.AfterStepResult, bool, error) {
+func (c *inMemoryExecutionCache) Get(ctx context.Context, key cache.Keyer) (execution.AfterStepResult, bool, error) {
 	res, ok, err := c.getCacheItem(key)
 	if err != nil || !ok {
 		return execution.AfterStepResult{}, ok, err
@@ -596,7 +592,7 @@ func (c *inMemoryExecutionCache) GetStepResult(ctx context.Context, key cache.Ke
 	return execResult, ok, nil
 }
 
-func (c *inMemoryExecutionCache) SetStepResult(ctx context.Context, key cache.Keyer, result execution.AfterStepResult) error {
+func (c *inMemoryExecutionCache) Set(ctx context.Context, key cache.Keyer, result execution.AfterStepResult) error {
 	k, err := key.Key()
 	if err != nil {
 		return err

--- a/internal/batches/executor/execution_cache.go
+++ b/internal/batches/executor/execution_cache.go
@@ -35,19 +35,6 @@ func (c ExecutionDiskCache) cacheFilePath(key cache.Keyer) (string, error) {
 	return filepath.Join(c.Dir, key.Slug(), keyString+cacheFileExt), nil
 }
 
-func (c ExecutionDiskCache) Get(ctx context.Context, key cache.Keyer) (execution.Result, bool, error) {
-	var result execution.Result
-
-	path, err := c.cacheFilePath(key)
-	if err != nil {
-		return result, false, err
-	}
-
-	found, err := readCacheFile(path, &result)
-
-	return result, found, err
-}
-
 func readCacheFile(path string, result interface{}) (bool, error) {
 	if _, err := os.Stat(path); os.IsNotExist(err) {
 		return false, nil
@@ -80,15 +67,6 @@ func (c ExecutionDiskCache) writeCacheFile(path string, result interface{}) erro
 	}
 
 	return os.WriteFile(path, raw, 0600)
-}
-
-func (c ExecutionDiskCache) Set(ctx context.Context, key cache.Keyer, result execution.Result) error {
-	path, err := c.cacheFilePath(key)
-	if err != nil {
-		return err
-	}
-
-	return c.writeCacheFile(path, &result)
 }
 
 func (c ExecutionDiskCache) Clear(ctx context.Context, key cache.Keyer) error {
@@ -132,14 +110,6 @@ func (c ExecutionDiskCache) SetStepResult(ctx context.Context, key cache.Keyer, 
 // retrieve cache entries.
 type ExecutionNoOpCache struct{}
 
-func (ExecutionNoOpCache) Get(ctx context.Context, key cache.Keyer) (result execution.Result, found bool, err error) {
-	return execution.Result{}, false, nil
-}
-
-func (ExecutionNoOpCache) Set(ctx context.Context, key cache.Keyer, result execution.Result) error {
-	return nil
-}
-
 func (ExecutionNoOpCache) Clear(ctx context.Context, key cache.Keyer) error {
 	return nil
 }
@@ -153,29 +123,12 @@ func (ExecutionNoOpCache) GetStepResult(ctx context.Context, key cache.Keyer) (e
 }
 
 type JSONCacheWriter interface {
-	WriteExecutionResult(key string, value execution.Result)
 	WriteAfterStepResult(key string, value execution.AfterStepResult)
 }
 
 type ServerSideCache struct {
 	CacheDir string
 	Writer   JSONCacheWriter
-}
-
-func (c *ServerSideCache) Get(ctx context.Context, key cache.Keyer) (result execution.Result, found bool, err error) {
-	// noop
-	return execution.Result{}, false, nil
-}
-
-func (c *ServerSideCache) Set(ctx context.Context, key cache.Keyer, result execution.Result) error {
-	k, err := key.Key()
-	if err != nil {
-		return err
-	}
-
-	c.Writer.WriteExecutionResult(k, result)
-
-	return nil
 }
 
 func (c *ServerSideCache) SetStepResult(ctx context.Context, key cache.Keyer, result execution.AfterStepResult) error {

--- a/internal/batches/executor/execution_cache.go
+++ b/internal/batches/executor/execution_cache.go
@@ -82,7 +82,7 @@ func (c ExecutionDiskCache) Clear(ctx context.Context, key cache.Keyer) error {
 	return os.Remove(path)
 }
 
-func (c ExecutionDiskCache) GetStepResult(ctx context.Context, key cache.Keyer) (execution.AfterStepResult, bool, error) {
+func (c ExecutionDiskCache) Get(ctx context.Context, key cache.Keyer) (execution.AfterStepResult, bool, error) {
 	var result execution.AfterStepResult
 	path, err := c.cacheFilePath(key)
 	if err != nil {
@@ -97,7 +97,7 @@ func (c ExecutionDiskCache) GetStepResult(ctx context.Context, key cache.Keyer) 
 	return result, found, nil
 }
 
-func (c ExecutionDiskCache) SetStepResult(ctx context.Context, key cache.Keyer, result execution.AfterStepResult) error {
+func (c ExecutionDiskCache) Set(ctx context.Context, key cache.Keyer, result execution.AfterStepResult) error {
 	path, err := c.cacheFilePath(key)
 	if err != nil {
 		return err
@@ -114,11 +114,11 @@ func (ExecutionNoOpCache) Clear(ctx context.Context, key cache.Keyer) error {
 	return nil
 }
 
-func (ExecutionNoOpCache) SetStepResult(ctx context.Context, key cache.Keyer, result execution.AfterStepResult) error {
+func (ExecutionNoOpCache) Set(ctx context.Context, key cache.Keyer, result execution.AfterStepResult) error {
 	return nil
 }
 
-func (ExecutionNoOpCache) GetStepResult(ctx context.Context, key cache.Keyer) (execution.AfterStepResult, bool, error) {
+func (ExecutionNoOpCache) Get(ctx context.Context, key cache.Keyer) (execution.AfterStepResult, bool, error) {
 	return execution.AfterStepResult{}, false, nil
 }
 
@@ -131,7 +131,7 @@ type ServerSideCache struct {
 	Writer   JSONCacheWriter
 }
 
-func (c *ServerSideCache) SetStepResult(ctx context.Context, key cache.Keyer, result execution.AfterStepResult) error {
+func (c *ServerSideCache) Set(ctx context.Context, key cache.Keyer, result execution.AfterStepResult) error {
 	k, err := key.Key()
 	if err != nil {
 		return err
@@ -142,7 +142,7 @@ func (c *ServerSideCache) SetStepResult(ctx context.Context, key cache.Keyer, re
 	return nil
 }
 
-func (c *ServerSideCache) GetStepResult(ctx context.Context, key cache.Keyer) (result execution.AfterStepResult, found bool, err error) {
+func (c *ServerSideCache) Get(ctx context.Context, key cache.Keyer) (result execution.AfterStepResult, found bool, err error) {
 	rawKey, err := key.Key()
 	if err != nil {
 		return result, false, err

--- a/internal/batches/executor/execution_cache_test.go
+++ b/internal/batches/executor/execution_cache_test.go
@@ -43,14 +43,14 @@ index 0000000..3363c39
 func TestExecutionDiskCache_GetSet(t *testing.T) {
 	ctx := context.Background()
 
-	cacheKey1 := &cache.StepsCacheKey{
+	cacheKey1 := &cache.CacheKey{
 		Repository: cacheRepo1,
 		Steps: []batcheslib.Step{
 			{Run: "echo 'Hello World'", Container: "alpine:3"},
 		},
 	}
 
-	cacheKey2 := &cache.StepsCacheKey{
+	cacheKey2 := &cache.CacheKey{
 		Repository: cacheRepo2,
 		Steps: []batcheslib.Step{
 			{Run: "echo 'Hello World'", Container: "alpine:3"},
@@ -72,7 +72,7 @@ func TestExecutionDiskCache_GetSet(t *testing.T) {
 	assertCacheMiss(t, cache, cacheKey2)
 
 	// Set the cache
-	if err := cache.SetStepResult(ctx, cacheKey1, value); err != nil {
+	if err := cache.Set(ctx, cacheKey1, value); err != nil {
 		t.Fatalf("cache.Set returned unexpected error: %s", err)
 	}
 
@@ -89,10 +89,10 @@ func TestExecutionDiskCache_GetSet(t *testing.T) {
 	assertCacheMiss(t, cache, cacheKey1)
 }
 
-func assertCacheHit(t *testing.T, c ExecutionDiskCache, k *cache.StepsCacheKey, want execution.AfterStepResult) {
+func assertCacheHit(t *testing.T, c ExecutionDiskCache, k cache.Keyer, want execution.AfterStepResult) {
 	t.Helper()
 
-	have, found, err := c.GetStepResult(context.Background(), k)
+	have, found, err := c.Get(context.Background(), k)
 	if err != nil {
 		t.Fatalf("cache.Get returned unexpected error: %s", err)
 	}
@@ -105,10 +105,10 @@ func assertCacheHit(t *testing.T, c ExecutionDiskCache, k *cache.StepsCacheKey, 
 	}
 }
 
-func assertCacheMiss(t *testing.T, c ExecutionDiskCache, k *cache.StepsCacheKey) {
+func assertCacheMiss(t *testing.T, c ExecutionDiskCache, k cache.Keyer) {
 	t.Helper()
 
-	_, found, err := c.GetStepResult(context.Background(), k)
+	_, found, err := c.Get(context.Background(), k)
 	if err != nil {
 		t.Fatalf("cache.Get returned unexpected error: %s", err)
 	}

--- a/internal/batches/executor/execution_cache_test.go
+++ b/internal/batches/executor/execution_cache_test.go
@@ -43,23 +43,23 @@ index 0000000..3363c39
 func TestExecutionDiskCache_GetSet(t *testing.T) {
 	ctx := context.Background()
 
-	cacheKey1 := &cache.ExecutionKey{
+	cacheKey1 := &cache.StepsCacheKey{
 		Repository: cacheRepo1,
 		Steps: []batcheslib.Step{
 			{Run: "echo 'Hello World'", Container: "alpine:3"},
 		},
 	}
 
-	cacheKey2 := &cache.ExecutionKey{
+	cacheKey2 := &cache.StepsCacheKey{
 		Repository: cacheRepo2,
 		Steps: []batcheslib.Step{
 			{Run: "echo 'Hello World'", Container: "alpine:3"},
 		},
 	}
 
-	value := execution.Result{
+	value := execution.AfterStepResult{
 		Diff: testDiff,
-		ChangedFiles: &git.Changes{
+		ChangedFiles: git.Changes{
 			Added: []string{"README.md"},
 		},
 		Outputs: map[string]interface{}{},
@@ -72,7 +72,7 @@ func TestExecutionDiskCache_GetSet(t *testing.T) {
 	assertCacheMiss(t, cache, cacheKey2)
 
 	// Set the cache
-	if err := cache.Set(ctx, cacheKey1, value); err != nil {
+	if err := cache.SetStepResult(ctx, cacheKey1, value); err != nil {
 		t.Fatalf("cache.Set returned unexpected error: %s", err)
 	}
 
@@ -89,10 +89,10 @@ func TestExecutionDiskCache_GetSet(t *testing.T) {
 	assertCacheMiss(t, cache, cacheKey1)
 }
 
-func assertCacheHit(t *testing.T, c ExecutionDiskCache, k *cache.ExecutionKey, want execution.Result) {
+func assertCacheHit(t *testing.T, c ExecutionDiskCache, k *cache.StepsCacheKey, want execution.AfterStepResult) {
 	t.Helper()
 
-	have, found, err := c.Get(context.Background(), k)
+	have, found, err := c.GetStepResult(context.Background(), k)
 	if err != nil {
 		t.Fatalf("cache.Get returned unexpected error: %s", err)
 	}
@@ -105,10 +105,10 @@ func assertCacheHit(t *testing.T, c ExecutionDiskCache, k *cache.ExecutionKey, w
 	}
 }
 
-func assertCacheMiss(t *testing.T, c ExecutionDiskCache, k *cache.ExecutionKey) {
+func assertCacheMiss(t *testing.T, c ExecutionDiskCache, k *cache.StepsCacheKey) {
 	t.Helper()
 
-	_, found, err := c.Get(context.Background(), k)
+	_, found, err := c.GetStepResult(context.Background(), k)
 	if err != nil {
 		t.Fatalf("cache.Get returned unexpected error: %s", err)
 	}

--- a/internal/batches/executor/executor_test.go
+++ b/internal/batches/executor/executor_test.go
@@ -424,7 +424,7 @@ func TestExecutor_Integration(t *testing.T) {
 			}
 
 			if have, want := len(results), wantResults; have != want {
-				t.Fatalf("wrong number of execution results. want=%d, have=%d", want, have)
+				t.Fatalf("wrong number of results. want=%d, have=%d", want, have)
 			}
 
 			for _, taskResult := range results {
@@ -530,6 +530,7 @@ index 02a19af..c9644dd 100644
 			BatchChangeAttributes: &template.BatchChangeAttributes{},
 			Steps: []batcheslib.Step{
 				{Run: `echo -e "foobar\n" >> README.md`},
+				{Run: `echo -e "foobar\n" >> README.md`},
 			},
 			CachedStepResultFound: true,
 			CachedStepResult: execution.AfterStepResult{
@@ -546,18 +547,18 @@ index 02a19af..c9644dd 100644
 		}
 
 		if have, want := len(results), 1; have != want {
-			t.Fatalf("wrong number of execution results. want=%d, have=%d", want, have)
-		}
-
-		// We want the diff to be the same as the cached one, since we only had to
-		// execute a single step
-		executionResult := results[0].stepResults[0]
-		if diff := cmp.Diff(executionResult.Diff, cachedDiff); diff != "" {
-			t.Fatalf("wrong diff: %s", diff)
+			t.Fatalf("wrong number of results. want=%d, have=%d", want, have)
 		}
 
 		if have, want := len(results[0].stepResults), 1; have != want {
 			t.Fatalf("wrong length of step results. have=%d, want=%d", have, want)
+		}
+
+		// We want the diff to be the same as the cached one, since we only had to
+		// execute a single step.
+		executionResult := results[0].stepResults[0]
+		if diff := cmp.Diff(executionResult.Diff, cachedDiff); diff != "" {
+			t.Fatalf("wrong diff: %s", diff)
 		}
 
 		stepResult := results[0].stepResults[0]
@@ -668,7 +669,7 @@ echo "previous_step.modified_files=${{ previous_step.modified_files }}" >> READM
 		}
 
 		if have, want := len(results), 1; have != want {
-			t.Fatalf("wrong number of execution results. want=%d, have=%d", want, have)
+			t.Fatalf("wrong number of results. want=%d, have=%d", want, have)
 		}
 
 		executionResult := results[0].stepResults[0]
@@ -739,7 +740,7 @@ index 3040106..5f2f924 100644
 		}
 
 		if have, want := len(results), 1; have != want {
-			t.Fatalf("wrong number of execution results. want=%d, have=%d", want, have)
+			t.Fatalf("wrong number of results. want=%d, have=%d", want, have)
 		}
 
 		executionResult := results[0].stepResults[0]

--- a/internal/batches/executor/executor_test.go
+++ b/internal/batches/executor/executor_test.go
@@ -543,7 +543,6 @@ index 02a19af..c9644dd 100644
 			BatchChangeAttributes: &template.BatchChangeAttributes{},
 			Steps: []batcheslib.Step{
 				{Run: `echo -e "foobar\n" >> README.md`},
-				{Run: `echo -e "foobar\n" >> README.md`},
 			},
 			CachedStepResultFound: true,
 			CachedStepResult: execution.AfterStepResult{
@@ -567,24 +566,15 @@ index 02a19af..c9644dd 100644
 			t.Fatalf("wrong length of step results. have=%d, want=%d", have, want)
 		}
 
-		wantResult := execution.AfterStepResult{
-			ChangedFiles: git.Changes{
-				Modified: []string{"README.md"},
-			},
-			StepIndex: 1,
-			Outputs:   make(map[string]any),
-			Diff: `diff --git README.md README.md
-index 02a19af..1dd6a96 100644
---- README.md
-+++ README.md
-@@ -1 +1,4 @@
-# Welcome to the README
-+foobar
-+foobar
-`,
+		// We want the diff to be the same as the cached one, since we only had to
+		// execute a single step
+		executionResult := results[0].stepResults[0]
+		if diff := cmp.Diff(executionResult.Diff, cachedDiff); diff != "" {
+			t.Fatalf("wrong diff: %s", diff)
 		}
+
 		stepResult := results[0].stepResults[0]
-		if diff := cmp.Diff(stepResult, wantResult); diff != "" {
+		if diff := cmp.Diff(stepResult, task.CachedStepResult); diff != "" {
 			t.Fatalf("wrong stepResult: %s", diff)
 		}
 	})

--- a/internal/batches/executor/run_steps.go
+++ b/internal/batches/executor/run_steps.go
@@ -13,7 +13,6 @@ import (
 
 	batcheslib "github.com/sourcegraph/sourcegraph/lib/batches"
 	"github.com/sourcegraph/sourcegraph/lib/batches/execution"
-	"github.com/sourcegraph/sourcegraph/lib/batches/git"
 	"github.com/sourcegraph/sourcegraph/lib/batches/template"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 
@@ -26,73 +25,84 @@ import (
 	yamlv3 "gopkg.in/yaml.v3"
 )
 
-type executionOpts struct {
-	wc          workspace.Creator
+type runStepsOpts struct {
+	// wc is the workspace creator to use. It will be called at the beginning of
+	// runSteps to prepare the workspace for execution.
+	wc workspace.Creator
+	// ensureImage is called in runSteps to make sure the used image has been
+	// pulled from the registry.
 	ensureImage imageEnsurer
-
+	// task is the definition of the workspace execution.
 	task *Task
-
+	// tempDir points to where temporary files of the execution should live at.
 	tempDir string
 
 	logger log.TaskLogger
 
 	ui StepsExecutionUI
 
+	// isRemote toggles server-side execution mode. This disables file mounts using
+	// step.mounts.
 	isRemote bool
 
+	// globalEnv is the os.Environ() for the execution. We don't read from os.Environ()
+	// directly to allow injecting variables and hiding others.
 	globalEnv []string
-
+	// writeStepCacheResult will be called after each step to write the AfterStepResult to the cache
+	// as early as possible.
 	writeStepCacheResult func(ctx context.Context, stepResult execution.AfterStepResult, task *Task) error
 }
 
-func runSteps(ctx context.Context, opts *executionOpts) (result execution.Result, stepResults []execution.AfterStepResult, err error) {
+func runSteps(ctx context.Context, opts *runStepsOpts) (stepResults []execution.AfterStepResult, err error) {
 	opts.ui.ArchiveDownloadStarted()
-	err = opts.task.Archive.Ensure(ctx)
+	err = opts.task.RepoArchive.Ensure(ctx)
 	opts.ui.ArchiveDownloadFinished(err)
 	if err != nil {
-		return execution.Result{}, nil, errors.Wrap(err, "fetching repo")
+		return nil, errors.Wrap(err, "fetching repo")
 	}
-	defer opts.task.Archive.Close()
+	defer opts.task.RepoArchive.Close()
 
 	opts.ui.WorkspaceInitializationStarted()
-	ws, err := opts.wc.Create(ctx, opts.task.Repository, opts.task.Steps, opts.task.Archive)
+	ws, err := opts.wc.Create(ctx, opts.task.Repository, opts.task.Steps, opts.task.RepoArchive)
 	if err != nil {
-		return execution.Result{}, nil, errors.Wrap(err, "creating workspace")
+		return nil, errors.Wrap(err, "creating workspace")
 	}
 	defer ws.Close(ctx)
 	opts.ui.WorkspaceInitializationFinished()
 
 	var (
-		execResult = execution.Result{
-			Diff:         "",
-			ChangedFiles: &git.Changes{},
-			Outputs:      make(map[string]interface{}),
-			Path:         opts.task.Path,
-		}
-		previousStepResult execution.StepResult
-		startStep          int
+		// lastOutputs are the step.outputs from the previously run step.
+		// Outputs are additive, so we will only ever append to this map,
+		// but never clear it.
+		lastOutputs        = make(map[string]any)
+		previousStepResult execution.AfterStepResult
+		// startStep is the index of the step we start executing with. Set when
+		// there's a partial cache result for the task.
+		startStep int
 	)
 
-	if opts.task.CachedResultFound {
+	if opts.task.CachedStepResultFound {
 		// Set the Outputs to the cached outputs
-		execResult.Outputs = opts.task.CachedResult.Outputs
-
-		lastStep := opts.task.CachedResult.StepIndex
+		lastOutputs = opts.task.CachedStepResult.Outputs
+		previousStepResult = opts.task.CachedStepResult
+		lastStep := opts.task.CachedStepResult.StepIndex
+		stepResults = append(stepResults, opts.task.CachedStepResult)
 
 		// If we have cached results and don't need to execute any more steps,
-		// we can quit
+		// we can quit.
+		// TODO: This doesn't consider skipped steps, but it's not _that_
+		// bad, we will find out about that further down and correctly finish
+		// execution early.
 		if lastStep == len(opts.task.Steps)-1 {
-			// Build the execution result from the step result.
-			changes, err := git.ChangesInDiff([]byte(opts.task.CachedResult.Diff))
-			if err != nil {
-				return execResult, nil, errors.Wrap(err, "parsing cached step diff")
+			return stepResults, nil
+		}
+
+		// If the previous steps made any modifications to the workspace yet,
+		// apply them.
+		if opts.task.CachedStepResult.Diff != "" {
+			if err := ws.ApplyDiff(ctx, []byte(opts.task.CachedStepResult.Diff)); err != nil {
+				return nil, errors.Wrap(err, "applying diff of cache result")
 			}
-
-			execResult.Diff = opts.task.CachedResult.Diff
-			execResult.ChangedFiles = &changes
-			stepResults = append(stepResults, opts.task.CachedResult)
-
-			return execResult, stepResults, nil
 		}
 
 		startStep = lastStep + 1
@@ -103,41 +113,24 @@ func runSteps(ctx context.Context, opts *executionOpts) (result execution.Result
 		)
 	}
 
-	var lastDiff string
-
 	for i := startStep; i < len(opts.task.Steps); i++ {
 		step := opts.task.Steps[i]
 
 		stepContext := template.StepContext{
 			BatchChange: *opts.task.BatchChangeAttributes,
 			Repository:  util.NewTemplatingRepo(opts.task.Repository.Name, opts.task.Repository.FileMatches),
-			Outputs:     execResult.Outputs,
+			Outputs:     lastOutputs,
 			Steps: template.StepsContext{
-				Path:    execResult.Path,
-				Changes: previousStepResult.Files,
+				Path:    opts.task.Path,
+				Changes: previousStepResult.ChangedFiles,
 			},
 			PreviousStep: previousStepResult,
 		}
 
-		if opts.task.CachedResultFound && i == startStep {
-			previousStepResult = opts.task.CachedResult.StepResult
-
-			stepContext.PreviousStep = previousStepResult
-			stepContext.Steps.Changes = previousStepResult.Files
-			stepContext.Outputs = opts.task.CachedResult.Outputs
-
-			// If the previous steps made any modifications in the workspace yet,
-			// apply them.
-			if opts.task.CachedResult.Diff != "" {
-				if err := ws.ApplyDiff(ctx, []byte(opts.task.CachedResult.Diff)); err != nil {
-					return execResult, nil, errors.Wrap(err, "applying diff of cache result")
-				}
-			}
-		}
-
+		// Check if the step needs to be skipped.
 		cond, err := template.EvalStepCondition(step.IfCondition(), &stepContext)
 		if err != nil {
-			return execResult, nil, errors.Wrap(err, "evaluating step condition")
+			return nil, errors.Wrap(err, "evaluating step condition")
 		}
 		if !cond {
 			opts.ui.StepSkipped(i + 1)
@@ -147,12 +140,13 @@ func runSteps(ctx context.Context, opts *executionOpts) (result execution.Result
 		// We need to grab the digest for the exact image we're using.
 		img, err := opts.ensureImage(ctx, step.Container)
 		if err != nil {
-			return execResult, nil, err
+			return nil, err
 		}
 		digest, err := img.Digest(ctx)
 		if err != nil {
-			return execResult, nil, err
+			return nil, err
 		}
+
 		stdoutBuffer, stderrBuffer, err := executeSingleStep(ctx, opts, ws, i, step, digest, &stepContext)
 		defer func() {
 			if err != nil {
@@ -165,76 +159,72 @@ func runSteps(ctx context.Context, opts *executionOpts) (result execution.Result
 			}
 		}()
 		if err != nil {
-			return execResult, nil, err
+			return nil, err
 		}
 
 		changes, err := ws.Changes(ctx)
 		if err != nil {
-			return execResult, nil, errors.Wrap(err, "getting changed files in step")
-		}
-
-		result := execution.StepResult{Files: changes, Stdout: stdoutBuffer.String(), Stderr: stderrBuffer.String()}
-
-		// Set stepContext.Step to current step's results before rendering outputs
-		stepContext.Step = result
-		// Render and evaluate outputs
-		if err := setOutputs(step.Outputs, execResult.Outputs, &stepContext); err != nil {
-			return execResult, nil, errors.Wrap(err, "setting step outputs")
+			return nil, errors.Wrap(err, "getting changed files in step")
 		}
 
 		// Get the current diff and store that away as the per-step result.
 		stepDiff, err := ws.Diff(ctx)
 		if err != nil {
-			return execResult, nil, errors.Wrap(err, "getting diff produced by step")
+			return nil, errors.Wrap(err, "getting diff produced by step")
 		}
+
 		stepResult := execution.AfterStepResult{
-			StepIndex:  i,
-			Diff:       string(stepDiff),
-			Outputs:    make(map[string]interface{}),
-			StepResult: result,
+			ChangedFiles: changes,
+			Stdout:       stdoutBuffer.String(),
+			Stderr:       stderrBuffer.String(),
+			StepIndex:    i,
+			Diff:         string(stepDiff),
+			Outputs:      make(map[string]interface{}),
 		}
-		for k, v := range execResult.Outputs {
+
+		// Set stepContext.Step to current step's results before rendering outputs.
+		stepContext.Step = stepResult
+		// Render and evaluate outputs.
+		if err := setOutputs(step.Outputs, lastOutputs, &stepContext); err != nil {
+			return nil, errors.Wrap(err, "setting step outputs")
+		}
+		for k, v := range lastOutputs {
 			stepResult.Outputs[k] = v
 		}
 		stepResults = append(stepResults, stepResult)
-		previousStepResult = result
+		previousStepResult = stepResult
 
-		// cache the result here
+		// Write the step result to the cache.
 		err = opts.writeStepCacheResult(ctx, stepResult, opts.task)
 		if err != nil {
-			return execResult, nil, errors.Wrap(err, "failed to cache stepResult")
+			return nil, errors.Wrap(err, "failed to cache stepResult")
 		}
 
-		opts.ui.StepFinished(i+1, stepResult.Diff, result.Files, stepResult.Outputs)
-
-		lastDiff = stepResult.Diff
+		opts.ui.StepFinished(i+1, stepResult.Diff, stepResult.ChangedFiles, stepResult.Outputs)
 	}
 
-	execResult.Diff = lastDiff
-	execResult.ChangedFiles = previousStepResult.Files
-
-	return execResult, stepResults, err
+	return stepResults, err
 }
 
 const workDir = "/work"
 
 func executeSingleStep(
 	ctx context.Context,
-	opts *executionOpts,
+	opts *runStepsOpts,
 	workspace workspace.Workspace,
-	i int,
+	stepIdx int,
 	step batcheslib.Step,
 	imageDigest string,
 	stepContext *template.StepContext,
-) (bytes.Buffer, bytes.Buffer, error) {
+) (stdout bytes.Buffer, stderr bytes.Buffer, err error) {
 	// ----------
 	// PREPARATION
 	// ----------
-	opts.ui.StepPreparingStart(i + 1)
+	opts.ui.StepPreparingStart(stepIdx + 1)
 
 	cidFile, cleanup, err := createCidFile(ctx, opts.tempDir, util.SlugForRepo(opts.task.Repository.Name, opts.task.Repository.Rev()))
 	if err != nil {
-		opts.ui.StepPreparingFailed(i+1, err)
+		opts.ui.StepPreparingFailed(stepIdx+1, err)
 		return bytes.Buffer{}, bytes.Buffer{}, err
 	}
 	defer cleanup()
@@ -243,13 +233,13 @@ func executeSingleStep(
 	shell, containerTemp, err := probeImageForShell(ctx, imageDigest)
 	if err != nil {
 		err = errors.Wrapf(err, "probing image %q for shell", step.Container)
-		opts.ui.StepPreparingFailed(i+1, err)
+		opts.ui.StepPreparingFailed(stepIdx+1, err)
 		return bytes.Buffer{}, bytes.Buffer{}, err
 	}
 
 	runScriptFile, runScript, cleanup, err := createRunScriptFile(ctx, opts.tempDir, step.Run, stepContext)
 	if err != nil {
-		opts.ui.StepPreparingFailed(i+1, err)
+		opts.ui.StepPreparingFailed(stepIdx+1, err)
 		return bytes.Buffer{}, bytes.Buffer{}, err
 	}
 	defer cleanup()
@@ -257,7 +247,7 @@ func executeSingleStep(
 	// Parse and render the step.Files.
 	filesToMount, cleanup, err := createFilesToMount(opts.tempDir, step, stepContext)
 	if err != nil {
-		opts.ui.StepPreparingFailed(i+1, err)
+		opts.ui.StepPreparingFailed(stepIdx+1, err)
 		return bytes.Buffer{}, bytes.Buffer{}, err
 	}
 	defer cleanup()
@@ -266,23 +256,23 @@ func executeSingleStep(
 	stepEnv, err := step.Env.Resolve(opts.globalEnv)
 	if err != nil {
 		err = errors.Wrap(err, "resolving step environment")
-		opts.ui.StepPreparingFailed(i+1, err)
+		opts.ui.StepPreparingFailed(stepIdx+1, err)
 		return bytes.Buffer{}, bytes.Buffer{}, err
 	}
 	// Render the step.Env variables as templates.
 	env, err := template.RenderStepMap(stepEnv, stepContext)
 	if err != nil {
 		err = errors.Wrap(err, "parsing step environment")
-		opts.ui.StepPreparingFailed(i+1, err)
+		opts.ui.StepPreparingFailed(stepIdx+1, err)
 		return bytes.Buffer{}, bytes.Buffer{}, err
 	}
 
-	opts.ui.StepPreparingSuccess(i + 1)
+	opts.ui.StepPreparingSuccess(stepIdx + 1)
 
 	// ----------
 	// EXECUTION
 	// ----------
-	opts.ui.StepStarted(i+1, runScript, env)
+	opts.ui.StepStarted(stepIdx+1, runScript, env)
 
 	workspaceOpts, err := workspace.DockerRunOpts(ctx, workDir)
 	if err != nil {
@@ -308,9 +298,9 @@ func executeSingleStep(
 		args = append(args, "--mount", fmt.Sprintf("type=bind,source=%s,target=%s,ro", source.Name(), target))
 	}
 
-	// Temporarily add a guard to prevent a path to mount path for server-side processing
+	// Temporarily add a guard to prevent a path to mount path for server-side processing.
 	if !opts.isRemote {
-		// Mount any paths on the local system to the docker container. The paths have already been validated during parsing
+		// Mount any paths on the local system to the docker container. The paths have already been validated during parsing.
 		for _, mount := range step.Mount {
 			args = append(args, "--mount", fmt.Sprintf("type=bind,source=%s,target=%s,ro", mount.Path, mount.Mountpoint))
 		}
@@ -330,19 +320,18 @@ func executeSingleStep(
 
 	writerCtx, writerCancel := context.WithCancel(ctx)
 	defer writerCancel()
-	outputWriter := opts.ui.StepOutputWriter(writerCtx, opts.task, i+1)
+	outputWriter := opts.ui.StepOutputWriter(writerCtx, opts.task, stepIdx+1)
 	defer func() {
 		outputWriter.Close()
 	}()
 
-	var stdoutBuffer, stderrBuffer bytes.Buffer
-	stdout := io.MultiWriter(&stdoutBuffer, outputWriter.StdoutWriter(), opts.logger.PrefixWriter("stdout"))
-	stderr := io.MultiWriter(&stderrBuffer, outputWriter.StderrWriter(), opts.logger.PrefixWriter("stderr"))
+	stdoutWriter := io.MultiWriter(&stdout, outputWriter.StdoutWriter(), opts.logger.PrefixWriter("stdout"))
+	stderrWriter := io.MultiWriter(&stderr, outputWriter.StderrWriter(), opts.logger.PrefixWriter("stderr"))
 
 	// Setup readers that pipe the output into the given buffers
-	wg, err := process.PipeOutput(ctx, cmd, stdout, stderr)
+	wg, err := process.PipeOutput(ctx, cmd, stdoutWriter, stderrWriter)
 	if err != nil {
-		return bytes.Buffer{}, bytes.Buffer{}, errors.Wrap(err, "piping process output")
+		return stdout, stderr, errors.Wrap(err, "piping process output")
 	}
 
 	newStepFailedErr := func(wrappedErr error) stepFailedErr {
@@ -358,34 +347,35 @@ func executeSingleStep(
 			Run:         runScript,
 			Container:   step.Container,
 			TmpFilename: containerTemp,
-			Stdout:      strings.TrimSpace(stdoutBuffer.String()),
-			Stderr:      strings.TrimSpace(stderrBuffer.String()),
+			Stdout:      strings.TrimSpace(stdout.String()),
+			Stderr:      strings.TrimSpace(stderr.String()),
 		}
 	}
 
-	opts.logger.Logf("[Step %d] run: %q, container: %q", i+1, step.Run, step.Container)
-	opts.logger.Logf("[Step %d] full command: %q", i+1, strings.Join(cmd.Args, " "))
+	opts.logger.Logf("[Step %d] run: %q, container: %q", stepIdx+1, step.Run, step.Container)
+	opts.logger.Logf("[Step %d] full command: %q", stepIdx+1, strings.Join(cmd.Args, " "))
 
-	// Start the command
+	// Start the command.
 	t0 := time.Now()
 	if err := cmd.Start(); err != nil {
-		opts.logger.Logf("[Step %d] error starting Docker container: %+v", i+1, err)
-		return stdoutBuffer, stderrBuffer, newStepFailedErr(err)
+		opts.logger.Logf("[Step %d] error starting Docker container: %+v", stepIdx+1, err)
+		return stdout, stderr, newStepFailedErr(err)
 	}
 
 	// Wait for the readers, because the pipes used by PipeOutput under the
-	// hood are closed when the command exits
+	// hood are closed when the command exits.
 	wg.Wait()
-	// Now wait for the command
+
+	// Now wait for the command.
 	err = cmd.Wait()
 	elapsed := time.Since(t0).Round(time.Millisecond)
 	if err != nil {
-		opts.logger.Logf("[Step %d] took %s; error running Docker container: %+v", i+1, elapsed, err)
-		return stdoutBuffer, stderrBuffer, newStepFailedErr(err)
+		opts.logger.Logf("[Step %d] took %s; error running Docker container: %+v", stepIdx+1, elapsed, err)
+		return stdout, stderr, newStepFailedErr(err)
 	}
 
-	opts.logger.Logf("[Step %d] complete in %s", i+1, elapsed)
-	return stdoutBuffer, stderrBuffer, nil
+	opts.logger.Logf("[Step %d] complete in %s", stepIdx+1, elapsed)
+	return stdout, stderr, nil
 }
 
 func setOutputs(stepOutputs batcheslib.Outputs, global map[string]interface{}, stepCtx *template.StepContext) error {

--- a/internal/batches/executor/testdata/dummydocker/docker
+++ b/internal/batches/executor/testdata/dummydocker/docker
@@ -32,7 +32,7 @@ if [[ "${1}" == "run" ]]; then
         # 2. The script that we need to execute
         #
         # We need (1) to execute (2) in the correct subfolder.
-        # And (2) is in the in the matching host temp file, which should
+        # And (2) is in the matching host temp file, which should
         # be mounted into the temp file inside the container.
         #
         # We need to find it in the args and then execute it.
@@ -59,6 +59,11 @@ if [[ "${1}" == "run" ]]; then
 
         # Let's strip the prefix off the workdir
         relative_workdir="${workdir#"${workdir_prefix}"}"
+        if [[ "$relative_workdir" = "/work" ]]; then
+          # If we couldn't strip of the prefix, it's still "/work", so we set
+          # it to "".
+          relative_workdir=""
+        fi
         # If the non-prefixed version is not blank, then we need to `cd` into it
         if [[ ! -z "${relative_workdir}" ]]; then
           cd "${relative_workdir}"

--- a/internal/batches/executor/ui.go
+++ b/internal/batches/executor/ui.go
@@ -45,7 +45,7 @@ type StepsExecutionUI interface {
 
 	StepOutputWriter(context.Context, *Task, int) StepOutputWriter
 
-	StepFinished(idx int, diff string, changes *git.Changes, outputs map[string]interface{})
+	StepFinished(idx int, diff string, changes git.Changes, outputs map[string]interface{})
 	StepFailed(idx int, err error, exitCode int)
 }
 
@@ -65,7 +65,7 @@ func (noop NoopStepsExecUI) StepStarted(step int, runScript string, env map[stri
 func (noop NoopStepsExecUI) StepOutputWriter(ctx context.Context, task *Task, step int) StepOutputWriter {
 	return NoopStepOutputWriter{}
 }
-func (noop NoopStepsExecUI) StepFinished(idx int, diff string, changes *git.Changes, outputs map[string]interface{}) {
+func (noop NoopStepsExecUI) StepFinished(idx int, diff string, changes git.Changes, outputs map[string]interface{}) {
 }
 func (noop NoopStepsExecUI) StepFailed(idx int, err error, exitCode int) {
 }

--- a/internal/batches/service/service.go
+++ b/internal/batches/service/service.go
@@ -99,8 +99,8 @@ func (svc *Service) DetermineFeatureFlags(ctx context.Context) error {
 	return svc.features.SetFromVersion(version)
 }
 
-func (svc *Service) SetFeatureFlagsForRelease(release string) error {
-	return svc.features.SetFromVersion(release)
+func (svc *Service) SetFeatureFlagsForVersion(version string) error {
+	return svc.features.SetFromVersion(version)
 }
 
 // TODO(campaigns-deprecation): this shim can be removed in Sourcegraph 4.0.

--- a/internal/batches/service/service.go
+++ b/internal/batches/service/service.go
@@ -396,7 +396,7 @@ func validateMount(batchSpecDir string, spec *batcheslib.BatchSpec, isRemote boo
 	for i, step := range spec.Steps {
 		for j, mount := range step.Mount {
 			if isRemote {
-				return errors.New("mounts are not support for server-side processing")
+				return errors.New("mounts are not supported for server-side processing")
 			}
 			p := mount.Path
 			if !filepath.IsAbs(p) {
@@ -419,6 +419,7 @@ func validateMount(batchSpecDir string, spec *batcheslib.BatchSpec, isRemote boo
 			}
 			// Update the mount path to the absolute path so building the absolute path (above) does not need to be
 			// redone when adding the mount argument to the Docker container.
+			// TODO: Can this mess with caching? We wouldn't be doing that server-side.
 			step.Mount[j].Path = p
 		}
 	}

--- a/internal/batches/service/service_test.go
+++ b/internal/batches/service/service_test.go
@@ -1027,7 +1027,7 @@ changesetTemplate:
     message: Test
 `,
 			isRemote:    true,
-			expectedErr: errors.New("handling mount: mounts are not support for server-side processing"),
+			expectedErr: errors.New("handling mount: mounts are not supported for server-side processing"),
 		},
 	}
 	for _, test := range tests {

--- a/internal/batches/ui/json_lines.go
+++ b/internal/batches/ui/json_lines.go
@@ -174,10 +174,6 @@ func (ui *JSONLines) ExecutionError(err error) {
 
 var _ executor.JSONCacheWriter = &JSONLines{}
 
-func (ui *JSONLines) WriteExecutionResult(key string, value execution.Result) {
-	// Noop, we don't need execution results.
-}
-
 func (ui *JSONLines) WriteAfterStepResult(key string, value execution.AfterStepResult) {
 	logOperationSuccess(batcheslib.LogEventOperationCacheAfterStepResult, &batcheslib.CacheAfterStepResultMetadata{
 		Key:   key,
@@ -210,8 +206,8 @@ func (ui *taskExecutionJSONLines) Start(tasks []*executor.Task) {
 			Repository:             t.Repository.Name,
 			Workspace:              t.Path,
 			Steps:                  t.Steps,
-			CachedStepResultsFound: t.CachedResultFound,
-			StartStep:              t.CachedResult.StepIndex,
+			CachedStepResultsFound: t.CachedStepResultFound,
+			StartStep:              t.CachedStepResult.StepIndex,
 		}
 		ui.linesTasks[t] = linesTask
 		linesTasks = append(linesTasks, linesTask)
@@ -329,7 +325,7 @@ func (ui *stepsExecutionJSONLines) StepOutputWriter(ctx context.Context, task *e
 	return NewIntervalProcessWriter(ctx, stepFlushDuration, sink)
 }
 
-func (ui *stepsExecutionJSONLines) StepFinished(step int, diff string, changes *git.Changes, outputs map[string]interface{}) {
+func (ui *stepsExecutionJSONLines) StepFinished(step int, diff string, changes git.Changes, outputs map[string]interface{}) {
 	logOperationSuccess(
 		batcheslib.LogEventOperationTaskStep,
 		&batcheslib.TaskStepMetadata{

--- a/internal/batches/ui/task_exec_tui.go
+++ b/internal/batches/ui/task_exec_tui.go
@@ -471,7 +471,7 @@ func (ui stepsExecTUI) StepOutputWriter(ctx context.Context, task *executor.Task
 	return executor.NoopStepOutputWriter{}
 }
 
-func (ui stepsExecTUI) StepFinished(idx int, diff string, changes *git.Changes, outputs map[string]interface{}) {
+func (ui stepsExecTUI) StepFinished(idx int, diff string, changes git.Changes, outputs map[string]interface{}) {
 	// noop right now
 }
 func (ui stepsExecTUI) StepFailed(idx int, err error, exitCode int) {

--- a/internal/batches/ui/task_exec_tui_test.go
+++ b/internal/batches/ui/task_exec_tui_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	batcheslib "github.com/sourcegraph/sourcegraph/lib/batches"
 	"github.com/sourcegraph/sourcegraph/lib/output"
+
 	"github.com/sourcegraph/src-cli/internal/batches/executor"
 	"github.com/sourcegraph/src-cli/internal/batches/graphql"
 )
@@ -77,7 +78,7 @@ func TestTaskExecTUI_Integration(t *testing.T) {
 	printer.TaskStarted(tasks[2])
 
 	expectOutput(t, buf, []string{
-		"⠋  Executing... (0/4, 0 errored)  ",
+		"⠋  Executing... (0/4, 0 errored)                                              0%",
 		"│                                                                               ",
 		"├── github.com/sourcegraph/sourcegraph  ...                                   0s",
 		"├── github.com/sourcegraph/src-cli      ...                                   0s",
@@ -91,7 +92,7 @@ func TestTaskExecTUI_Integration(t *testing.T) {
 	printer.TaskCurrentlyExecuting(tasks[2], "echo Hello World > README.md")
 
 	expectOutput(t, buf, []string{
-		"⠋  Executing... (0/4, 0 errored)  ",
+		"⠋  Executing... (0/4, 0 errored)                                              0%",
 		"│                                                                               ",
 		"├── github.com/sourcegraph/sourcegraph  echo Hello World > README.md          0s",
 		"├── github.com/sourcegraph/src-cli      Downloading archive                   0s",
@@ -105,7 +106,7 @@ func TestTaskExecTUI_Integration(t *testing.T) {
 	printer.TaskCurrentlyExecuting(tasks[2], "echo Hello World > README.md")
 
 	expectOutput(t, buf, []string{
-		"⠋  Executing... (0/4, 0 errored)  ",
+		"⠋  Executing... (0/4, 0 errored)                                              0%",
 		"│                                                                               ",
 		"├── github.com/sourcegraph/sourcegraph  gofmt                                 0s",
 		"├── github.com/sourcegraph/src-cli      echo Hello World > README.md          0s",
@@ -118,7 +119,7 @@ func TestTaskExecTUI_Integration(t *testing.T) {
 	printer.TaskFinished(tasks[2], nil)
 
 	expectOutput(t, buf, []string{
-		"⠋  Executing... (1/4, 0 errored)  ███████████▌",
+		"⠋  Executing... (1/4, 0 errored)  ██████████▎                                25%",
 		"│                                                                               ",
 		"├── github.com/sourcegraph/sourcegraph  gofmt                                 0s",
 		"├── github.com/sourcegraph/src-cli      echo Hello World > README.md          0s",
@@ -131,7 +132,7 @@ func TestTaskExecTUI_Integration(t *testing.T) {
 	printer.TaskFinished(tasks[0], nil)
 
 	expectOutput(t, buf, []string{
-		"⠋  Executing... (2/4, 0 errored)  ███████████████████████",
+		"⠋  Executing... (2/4, 0 errored)  ████████████████████▌                      50%",
 		"│                                                                               ",
 		"├── github.com/sourcegraph/sourcegraph  Done!                                 0s",
 		"├── github.com/sourcegraph/src-cli      echo Hello World > README.md          0s",
@@ -168,7 +169,7 @@ func TestTaskExecTUI_Integration(t *testing.T) {
 		"  3 files changed, 4 insertions, 2 deletions",
 		"  Execution took 10s",
 		"",
-		"⠋  Executing... (2/4, 0 errored)  ███████████████████████",
+		"⠋  Executing... (2/4, 0 errored)  ████████████████████▌                      50%",
 		"│                                                                               ",
 		"├── github.com/sourcegraph/sourcegraph  Done!                                 0s",
 		"├── github.com/sourcegraph/src-cli      echo Hello World > README.md          0s",
@@ -188,7 +189,7 @@ func TestTaskExecTUI_Integration(t *testing.T) {
 		"  3 files changed, 4 insertions, 2 deletions",
 		"  Execution took 10s",
 		"",
-		"⠋  Executing... (2/4, 0 errored)  ███████████████████████",
+		"⠋  Executing... (2/4, 0 errored)  ████████████████████▌                      50%",
 		"│                                                                               ",
 		"├── github.com/sourcegraph/tiny-go-...  rm -rf ~/.horse-ascii-art             0s",
 		"├── github.com/sourcegraph/src-cli      echo Hello World > README.md          0s",
@@ -236,7 +237,7 @@ func TestProgressUpdateAfterComplete(t *testing.T) {
 	printer.TaskCurrentlyExecuting(tasks[1], "Downloading archive")
 
 	expectOutput(t, buf, []string{
-		"⠋  Executing... (0/2, 0 errored)  ",
+		"⠋  Executing... (0/2, 0 errored)                                              0%",
 		"│                                                                               ",
 		"├── github.com/sourcegraph/sourcegraph  echo Hello World > README.md          0s",
 		"└── github.com/sourcegraph/src-cli      Downloading archive                   0s",
@@ -253,7 +254,7 @@ func TestProgressUpdateAfterComplete(t *testing.T) {
 	// The actual output is slightly less important at this point, but let's
 	// check it anyway.
 	expectOutput(t, buf, []string{
-		"✅ Executing... (0/2, 0 errored)  ██████████████████████████████████████████████",
+		"✅ Executing... (0/2, 0 errored)  ████████████████████████████████████████  100%",
 		"│                                                                               ",
 		"├── github.com/sourcegraph/sourcegraph  exit 42                               0s",
 		"└── github.com/sourcegraph/src-cli      Downloading archive                   0s",

--- a/internal/batches/workspace/bind_workspace.go
+++ b/internal/batches/workspace/bind_workspace.go
@@ -129,22 +129,22 @@ func (w *dockerBindWorkspace) DockerRunOpts(ctx context.Context, target string) 
 
 func (w *dockerBindWorkspace) WorkDir() *string { return &w.dir }
 
-func (w *dockerBindWorkspace) Changes(ctx context.Context) (*git.Changes, error) {
+func (w *dockerBindWorkspace) Changes(ctx context.Context) (git.Changes, error) {
 	if _, err := runGitCmd(ctx, w.dir, "add", "--all"); err != nil {
-		return nil, errors.Wrap(err, "git add failed")
+		return git.Changes{}, errors.Wrap(err, "git add failed")
 	}
 
 	statusOut, err := runGitCmd(ctx, w.dir, "status", "--porcelain", "--no-ahead-behind")
 	if err != nil {
-		return nil, errors.Wrap(err, "git status failed")
+		return git.Changes{}, errors.Wrap(err, "git status failed")
 	}
 
 	changes, err := git.ParseGitStatus(statusOut)
 	if err != nil {
-		return nil, errors.Wrap(err, "parsing git status output")
+		return git.Changes{}, errors.Wrap(err, "parsing git status output")
 	}
 
-	return &changes, nil
+	return changes, nil
 }
 
 func (w *dockerBindWorkspace) Diff(ctx context.Context) ([]byte, error) {

--- a/internal/batches/workspace/volume_workspace.go
+++ b/internal/batches/workspace/volume_workspace.go
@@ -229,7 +229,7 @@ func (w *dockerVolumeWorkspace) DockerRunOpts(ctx context.Context, target string
 
 func (w *dockerVolumeWorkspace) WorkDir() *string { return nil }
 
-func (w *dockerVolumeWorkspace) Changes(ctx context.Context) (*git.Changes, error) {
+func (w *dockerVolumeWorkspace) Changes(ctx context.Context) (git.Changes, error) {
 	script := `#!/bin/sh
 
 set -e
@@ -241,15 +241,15 @@ exec git status --porcelain
 
 	out, err := w.runScript(ctx, "/work", script)
 	if err != nil {
-		return nil, errors.Wrap(err, "running git status")
+		return git.Changes{}, errors.Wrap(err, "running git status")
 	}
 
 	changes, err := git.ParseGitStatus(out)
 	if err != nil {
-		return nil, errors.Wrapf(err, "parsing git status output:\n\n%s", string(out))
+		return git.Changes{}, errors.Wrapf(err, "parsing git status output:\n\n%s", string(out))
 	}
 
-	return &changes, nil
+	return changes, nil
 }
 
 func (w *dockerVolumeWorkspace) Diff(ctx context.Context) ([]byte, error) {

--- a/internal/batches/workspace/volume_workspace_test.go
+++ b/internal/batches/workspace/volume_workspace_test.go
@@ -446,11 +446,11 @@ func TestVolumeWorkspace_Changes(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		for name, tc := range map[string]struct {
 			stdout string
-			want   *git.Changes
+			want   git.Changes
 		}{
 			"empty": {
 				stdout: "",
-				want:   &git.Changes{},
+				want:   git.Changes{},
 			},
 			"valid": {
 				stdout: `
@@ -458,7 +458,7 @@ M  go.mod
 M  internal/campaigns/volume_workspace.go
 M  internal/campaigns/volume_workspace_test.go				
 				`,
-				want: &git.Changes{Modified: []string{
+				want: git.Changes{Modified: []string{
 					"go.mod",
 					"internal/campaigns/volume_workspace.go",
 					"internal/campaigns/volume_workspace_test.go",

--- a/internal/batches/workspace/workspace.go
+++ b/internal/batches/workspace/workspace.go
@@ -41,7 +41,7 @@ type Workspace interface {
 
 	// Changes is called after each step is executed, and should return the
 	// cumulative file changes that have occurred since Prepare was called.
-	Changes(ctx context.Context) (*git.Changes, error)
+	Changes(ctx context.Context) (git.Changes, error)
 
 	// Diff should return the total diff for the workspace. This may be called
 	// multiple times in the life of a workspace.


### PR DESCRIPTION
This PR cleans up the caching mess that I left behind after the refactors for SSBC to get rid of execution results. We now finally don't have a distinction between the two at all. There are simply step results and if the step is the last step to execute, we are done and build the changeset specs from it. 
Additionally, we save a few passes to parse git diffs and such, which is always nice. 

Accompanied by https://github.com/sourcegraph/sourcegraph/pull/38311

### Test plan

Rely on test suite which is (except renames and some caching number tweaks) untouched and manually verified everything still works.