### PR TITLE
remove quotes from upload ID URL

### DIFF
--- a/cmd/src/code_intel_upload.go
+++ b/cmd/src/code_intel_upload.go
@@ -200,7 +200,7 @@ func makeCodeIntelUploadURL(uploadID int) (string, error) {
 		return "", err
 	}
 
-	graphqlID := base64.URLEncoding.EncodeToString([]byte(fmt.Sprintf(`LSIFUpload:"%d"`, uploadID)))
+	graphqlID := base64.URLEncoding.EncodeToString([]byte(fmt.Sprintf(`LSIFUpload:%d`, uploadID)))
 	url.Path = codeintelUploadFlags.repo + "/-/code-intelligence/uploads/" + graphqlID
 	url.User = nil
 	return url.String(), nil


### PR DESCRIPTION
IDs returned by the backend do not wrap the upload ID number in quotes before base64 encoding. This PR updates src-cli to do the same. 

This was interrupting my QA updating :miffed:

### Test plan

Compared IDs returned by the backend with what src-cli was returning

