### PR TITLE
Fix workspace resolution for non-server-side

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ All notable changes to `src-cli` are documented in this file.
 
 ### Removed
 
+## 3.42.1
+
+### Fixed
+
+- Fixed an issue where no workspaces would be executed on after successful workspace resolution.
+
 ## 3.42.0
 
 ### Changed

--- a/cmd/src/batch_common.go
+++ b/cmd/src/batch_common.go
@@ -371,7 +371,7 @@ func executeBatchSpec(ctx context.Context, ui ui.ExecUI, opts executeBatchSpecOp
 		ui.DeterminingWorkspacesSuccess(len(workspaces))
 	} else {
 		ui.ResolvingRepositories()
-		repos, err := svc.ResolveRepositories(ctx, batchSpec, opts.flags.allowUnsupported, opts.flags.allowIgnored)
+		repos, err = svc.ResolveRepositories(ctx, batchSpec, opts.flags.allowUnsupported, opts.flags.allowIgnored)
 		if err != nil {
 			if repoSet, ok := err.(batches.UnsupportedRepoSet); ok {
 				ui.ResolvingRepositoriesDone(repos, repoSet, nil)
@@ -385,7 +385,7 @@ func executeBatchSpec(ctx context.Context, ui ui.ExecUI, opts executeBatchSpecOp
 		}
 
 		ui.DeterminingWorkspaces()
-		workspaces, err := svc.DetermineWorkspaces(ctx, repos, batchSpec)
+		workspaces, err = svc.DetermineWorkspaces(ctx, repos, batchSpec)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
That's what you get for restructuring. Also thank you go for allowing shadowing so silently :upside_down_face:

### Test plan

Verified manually workspaces are not empty again.
