### PR TITLE
Don't keep unsupported/ignored repos error for server-side resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ All notable changes to `src-cli` are documented in this file.
 
 ### Removed
 
+## 3.42.2
+
+### Fixed
+
+- Fixed an issue where execution would eventually fail with an error when there were unsupported or ignored workspaces found by server-side execution.
+
 ## 3.42.1
 
 ### Fixed

--- a/internal/batches/service/build_tasks.go
+++ b/internal/batches/service/build_tasks.go
@@ -1,8 +1,6 @@
 package service
 
 import (
-	"context"
-
 	batcheslib "github.com/sourcegraph/sourcegraph/lib/batches"
 	"github.com/sourcegraph/sourcegraph/lib/batches/template"
 
@@ -10,7 +8,7 @@ import (
 )
 
 // buildTasks returns *executor.Tasks for all the workspaces determined for the given spec.
-func buildTasks(ctx context.Context, attributes *template.BatchChangeAttributes, steps []batcheslib.Step, workspaces []RepoWorkspace) []*executor.Task {
+func buildTasks(attributes *template.BatchChangeAttributes, steps []batcheslib.Step, workspaces []RepoWorkspace) []*executor.Task {
 	tasks := make([]*executor.Task, 0, len(workspaces))
 
 	for _, ws := range workspaces {

--- a/internal/batches/service/service.go
+++ b/internal/batches/service/service.go
@@ -368,8 +368,8 @@ func (svc *Service) DetermineWorkspaces(ctx context.Context, repos []*graphql.Re
 	return findWorkspaces(ctx, spec, svc, repos)
 }
 
-func (svc *Service) BuildTasks(ctx context.Context, attributes *templatelib.BatchChangeAttributes, steps []batcheslib.Step, workspaces []RepoWorkspace) []*executor.Task {
-	return buildTasks(ctx, attributes, steps, workspaces)
+func (svc *Service) BuildTasks(attributes *templatelib.BatchChangeAttributes, steps []batcheslib.Step, workspaces []RepoWorkspace) []*executor.Task {
+	return buildTasks(attributes, steps, workspaces)
 }
 
 func (svc *Service) Features() batches.FeatureFlags {

--- a/internal/batches/service/service_test.go
+++ b/internal/batches/service/service_test.go
@@ -134,7 +134,7 @@ func mockGraphQLClient(responses ...string) (client api.Client, done func()) {
 	mux := http.NewServeMux()
 
 	var count int
-	mux.HandleFunc("/.api/graphql", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/.api/graphql", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 
 		_, _ = w.Write([]byte(responses[count]))


### PR DESCRIPTION
The error was the global error and wasn't unset ever, so the execution would go on and eventually it fails with that error in the end.
Also fixes a swallowed error for clear cache.

### Test plan

Verified the error is no longer kept.
