### PR TITLE
search: use chunk matches to render multiline streamed results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 ./src
-./cmd/src/src
+cmd/src/src
 *.zip
 release
 ./vendor

--- a/cmd/src/format.go
+++ b/cmd/src/format.go
@@ -60,7 +60,7 @@ func parseTemplate(text string) (*template.Template, error) {
 		"addFloat": func(x, y float64) float64 {
 			return x + y
 		},
-		"addInt32": func(x, y int32) int32 {
+		"addInt": func(x, y int) int {
 			return x + y
 		},
 		"debug": func(v interface{}) string {
@@ -94,13 +94,11 @@ func parseTemplate(text string) (*template.Template, error) {
 		"buildVersionHasNewSearchInterface": searchTemplateFuncs["buildVersionHasNewSearchInterface"],
 		"renderResult":                      searchTemplateFuncs["renderResult"],
 
-		// Register stream-search specific template functions.
-		"streamSearchSequentialLineNumber": streamSearchTemplateFuncs["streamSearchSequentialLineNumber"],
-		"streamSearchHighlightMatch":       streamSearchTemplateFuncs["streamSearchHighlightMatch"],
-		"streamSearchHighlightCommit":      streamSearchTemplateFuncs["streamSearchHighlightCommit"],
-		"streamSearchRenderCommitLabel":    streamSearchTemplateFuncs["streamSearchRenderCommitLabel"],
-		"matchOrMatches":                   streamSearchTemplateFuncs["matchOrMatches"],
-		"countMatches":                     streamSearchTemplateFuncs["countMatches"],
+		"streamSearchHighlightMatch":    streamSearchTemplateFuncs["streamSearchHighlightMatch"],
+		"streamSearchHighlightCommit":   streamSearchTemplateFuncs["streamSearchHighlightCommit"],
+		"streamSearchRenderCommitLabel": streamSearchTemplateFuncs["streamSearchRenderCommitLabel"],
+		"matchOrMatches":                streamSearchTemplateFuncs["matchOrMatches"],
+		"countMatches":                  streamSearchTemplateFuncs["countMatches"],
 
 		// Alert rendering
 		"searchAlertRender": func(alert searchResultsAlert) string {

--- a/cmd/src/search_stream.go
+++ b/cmd/src/search_stream.go
@@ -226,20 +226,16 @@ const streamingTemplate = `
 	{{- color "search-repository"}}{{.Repository}}{{color "nc" -}}
 	{{- " › " -}}
 	{{- color "search-filename"}}{{.Path}}{{color "nc" -}}
-	{{- color "success"}}{{matchOrMatches (countMatches .LineMatches)}}{{color "nc" -}}
+	{{- color "success"}}{{matchOrMatches (countMatches .ChunkMatches)}}{{color "nc" -}}
 	{{- "\n" -}}
 	{{- color "search-border"}}{{"--------------------------------------------------------------------------------\n"}}{{color "nc"}}
-	
-	{{- /* Line matches */ -}}
-	{{- $lineMatches := .LineMatches -}}
-	{{- range $index, $match := $lineMatches -}}
-		{{- if not (streamSearchSequentialLineNumber $lineMatches $index) -}}
-			{{- color "search-border"}}{{"  ------------------------------------------------------------------------------\n"}}{{color "nc"}}
-		{{- end -}}
-		{{- "  "}}{{color "search-line-numbers"}}{{pad (addInt32 $match.LineNumber 1) 6 " "}}{{color "nc" -}}
-		{{- color "search-border"}}{{" |  "}}{{color "nc"}}{{streamSearchHighlightMatch $.Query $match }}
+
+	{{- /* Content matches */ -}}
+	{{- $chunks := .ChunkMatches -}}
+	{{- range $index, $chunk := $chunks -}}
+		{{streamSearchHighlightMatch $chunk }}
+                {{- color "search-border"}}{{"\n  ------------------------------------------------------------------------------\n"}}{{color "nc"}}
 	{{- end -}}
-	{{- "\n" -}}
 {{- end -}}
 
 {{define "symbol"}}
@@ -250,7 +246,7 @@ const streamingTemplate = `
 	{{- color "success"}}{{matchOrMatches (len .Symbols)}}{{color "nc" -}}
 	{{- "\n" -}}
 	{{- color "search-border"}}{{"--------------------------------------------------------------------------------\n"}}{{color "nc"}}
-	
+
 	{{- /* Symbols */ -}}
 	{{- $symbols := .Symbols -}}
 	{{- range $index, $match := $symbols -}}
@@ -278,7 +274,7 @@ const streamingTemplate = `
 	{{- color "search-link"}}{{$.SourcegraphEndpoint}}{{.URL}}{{color "nc" -}}
 	{{- color "search-border"}}{{")\n"}}{{color "nc" -}}
 	{{- color "nc" -}}
-	
+
 	{{- /* Repository > author name "commit subject" (time ago) */ -}}
 	{{- color "search-commit-subject"}}{{(streamSearchRenderCommitLabel .Label)}}{{color "nc" -}}
 	{{- color "success" -}}
@@ -321,25 +317,44 @@ const streamingTemplate = `
 `
 
 var streamSearchTemplateFuncs = map[string]interface{}{
-	"streamSearchHighlightMatch": func(query string, match streaming.EventLineMatch) string {
-		var highlights []highlight
-		if strings.Contains(query, "patterntype:structural") {
-			highlights = streamConvertMatchToHighlights(match, false)
-			return applyHighlightsForFile(match.Line, highlights)
+	"streamSearchHighlightMatch": func(match streaming.ChunkMatch) string {
+		var result []rune
+
+		addLineColumn := func(n int) []rune {
+			result = append(result, []rune(ansiColors["nc"])...)
+			result = append(result, []rune("  ")...)
+			result = append(result, []rune(ansiColors["search-line-numbers"])...)
+			result = append(result, []rune(fmt.Sprintf("% 6d", match.ContentStart.Line+1+n))...)
+			result = append(result, []rune(ansiColors["nc"])...)
+			result = append(result, []rune(ansiColors["search-border"])...)
+			result = append(result, []rune(" |  ")...)
+			result = append(result, []rune(ansiColors["nc"])...)
+			return result
 		}
 
-		highlights = streamConvertMatchToHighlights(match, true)
-		return applyHighlights(match.Line, highlights, ansiColors["search-match"], ansiColors["nc"])
-	},
+		lineCount := 0
+		addLineColumn(lineCount)
+		for offset, r := range match.Content {
+			offset++
+			if r == '\n' {
+				result = append(result, []rune(ansiColors["nc"])...)
+				lineCount++
+				result = append(result, r)
+				addLineColumn(lineCount)
+				result = append(result, []rune(ansiColors["search-match"])...)
+				continue
+			}
+			for _, rr := range match.Ranges {
+				if rr.Start.Offset-match.ContentStart.Offset+1 == offset {
+					result = append(result, []rune(ansiColors["search-match"])...)
+				} else if rr.End.Offset-match.ContentStart.Offset+1 == offset {
+					result = append(result, []rune(ansiColors["nc"])...)
+				}
+			}
+			result = append(result, r)
 
-	"streamSearchSequentialLineNumber": func(lineMatches []streaming.EventLineMatch, index int) bool {
-		prevIndex := index - 1
-		if prevIndex < 0 {
-			return true
 		}
-		prevLineNumber := lineMatches[prevIndex].LineNumber
-		lineNumber := lineMatches[index].LineNumber
-		return prevLineNumber == lineNumber-1
+		return string(result)
 	},
 
 	"streamSearchHighlightCommit": func(content string, ranges [][3]int32) string {
@@ -372,10 +387,10 @@ var streamSearchTemplateFuncs = map[string]interface{}{
 		return fmt.Sprintf(" (%d matches)", i)
 	},
 
-	"countMatches": func(lineMatches []streaming.EventLineMatch) int {
+	"countMatches": func(chunks []streaming.ChunkMatch) int {
 		count := 0
-		for _, l := range lineMatches {
-			count += len(l.OffsetAndLengths)
+		for _, c := range chunks {
+			count += len(c.Ranges)
 		}
 		return count
 	},
@@ -445,27 +460,6 @@ func stripMarkdownMarkers(content string) string {
 	content = strings.TrimPrefix(content, "```COMMIT_EDITMSG\n")
 	content = strings.TrimPrefix(content, "```diff\n")
 	return strings.TrimSuffix(content, "\n```")
-}
-
-// convertMatchToHighlights converts a FileMatch m to a highlight data type.
-// When isPreview is true, it is assumed that the result to highlight is only on
-// one line, and the offsets are relative to this line. When isPreview is false,
-// the lineNumber from the FileMatch data is used, which is relative to the file
-// content.
-func streamConvertMatchToHighlights(m streaming.EventLineMatch, isPreview bool) (highlights []highlight) {
-	var line int
-	for _, offsetAndLength := range m.OffsetAndLengths {
-		ol := offsetAndLength
-		offset := int(ol[0])
-		length := int(ol[1])
-		if isPreview {
-			line = 1
-		} else {
-			line = int(m.LineNumber)
-		}
-		highlights = append(highlights, highlight{line: line, character: offset, length: length})
-	}
-	return highlights
 }
 
 func logError(msg string) {

--- a/internal/streaming/events.go
+++ b/internal/streaming/events.go
@@ -17,12 +17,28 @@ type EventContentMatch struct {
 	// Type is always ContentMatchType. Included here for marshalling.
 	Type MatchType `json:"type"`
 
-	Path       string   `json:"path"`
-	Repository string   `json:"repository"`
-	Branches   []string `json:"branches,omitempty"`
-	Commit     string   `json:"commit,omitempty"`
+	Path         string       `json:"path"`
+	Repository   string       `json:"repository"`
+	Branches     []string     `json:"branches,omitempty"`
+	Commit       string       `json:"commit,omitempty"`
+	ChunkMatches []ChunkMatch `json:"chunkMatches"`
+}
 
-	LineMatches []EventLineMatch `json:"lineMatches"`
+type ChunkMatch struct {
+	Content      string   `json:"content"`
+	ContentStart Location `json:"contentStart"`
+	Ranges       []Range  `json:"ranges"`
+}
+
+type Location struct {
+	Offset int `json:"offset"`
+	Line   int `json:"line"`
+	Column int `json:"column"`
+}
+
+type Range struct {
+	Start Location `json:"start"`
+	End   Location `json:"end"`
 }
 
 func (e *EventContentMatch) eventMatch() {}

--- a/internal/streaming/search.go
+++ b/internal/streaming/search.go
@@ -32,6 +32,13 @@ func Search(query string, opts Opts, client api.Client, decoder Decoder) error {
 		req.URL.RawQuery = q.Encode()
 	}
 
+	{
+		// Consume chunk matches for streaming search.
+		q := req.URL.Query()
+		q.Add("cm", "t")
+		req.URL.RawQuery = q.Encode()
+	}
+
 	// Send request.
 	resp, err := client.Do(req)
 	if err != nil {


### PR DESCRIPTION
Do we want to keep line matches at all, perhaps as an option? My sense is no, get rid of it, because otherwise we can never move away to adopt chunk matches as the only source of truth. We do need publish that chunkmatches is the think to access matches in JSON, in case there are consumers.


### Test plan
TBD