### PR TITLE
batches: fix Docker Desktop for Linux handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ All notable changes to `src-cli` are documented in this file.
 
 ### Fixed
 
+- The default directory used to mount files into containers will be automatically changed to a temporary directory within `$HOME` if Docker Desktop for Linux is in use. [#754](https://github.com/sourcegraph/src-cli/issues/754)
+
 ### Removed
 
 ## 3.42.3

--- a/internal/batches/docker/info.go
+++ b/internal/batches/docker/info.go
@@ -10,6 +10,31 @@ import (
 	"github.com/sourcegraph/src-cli/internal/exec"
 )
 
+// CurrentContext returns the name of the current Docker context (not to be
+// confused with a Go context).
+func CurrentContext(ctx context.Context) (string, error) {
+	dctx, cancel, err := withFastCommandContext(ctx)
+	if err != nil {
+		return "", err
+	}
+	defer cancel()
+
+	args := []string{"context", "inspect", "--format", "{{ .Name }}"}
+	out, err := exec.CommandContext(dctx, "docker", args...).CombinedOutput()
+	if errors.IsDeadlineExceeded(err) || errors.IsDeadlineExceeded(dctx.Err()) {
+		return "", newFastCommandTimeoutError(dctx, args...)
+	} else if err != nil {
+		return "", err
+	}
+
+	name := string(bytes.TrimSpace(out))
+	if name == "" {
+		return "", errors.New("no context returned from Docker")
+	}
+
+	return name, nil
+}
+
 // NCPU returns the number of CPU cores available to Docker.
 func NCPU(ctx context.Context) (int, error) {
 	dctx, cancel, err := withFastCommandContext(ctx)

--- a/internal/batches/docker/info_test.go
+++ b/internal/batches/docker/info_test.go
@@ -11,6 +11,62 @@ import (
 	"github.com/sourcegraph/src-cli/internal/exec/expect"
 )
 
+func Test_CurrentContext(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("docker fails", func(t *testing.T) {
+		expect.Commands(t, contextInspectFailure())
+
+		name, err := CurrentContext(ctx)
+		assert.Empty(t, name)
+		assert.Error(t, err)
+	})
+
+	t.Run("docker times out", func(t *testing.T) {
+		tctx, cancel := context.WithTimeout(ctx, -1*time.Second)
+		t.Cleanup(cancel)
+
+		expect.Commands(t, contextInspectSuccess("desktop-linux"))
+
+		name, err := CurrentContext(tctx)
+		assert.Zero(t, name)
+		var terr *fastCommandTimeoutError
+		assert.ErrorAs(t, err, &terr)
+		assert.Equal(t, []string{"context", "inspect", "--format", "{{ .Name }}"}, terr.args)
+		assert.Equal(t, fastCommandTimeoutDefault, terr.timeout)
+	})
+
+	t.Run("docker succeeds, but returns nothing", func(t *testing.T) {
+		expect.Commands(t, contextInspectSuccess(""))
+
+		name, err := CurrentContext(ctx)
+		assert.Empty(t, name)
+		assert.Error(t, err)
+	})
+
+	t.Run("docker succeeds", func(t *testing.T) {
+		expect.Commands(t, contextInspectSuccess("desktop-linux"))
+
+		name, err := CurrentContext(ctx)
+		assert.Equal(t, "desktop-linux", name)
+		assert.NoError(t, err)
+	})
+}
+
+func contextInspectSuccess(ncpu string) *expect.Expectation {
+	return expect.NewLiteral(
+		expect.Behaviour{Stdout: []byte(fmt.Sprintf("%s\n", ncpu))},
+		"docker", "context", "inspect", "--format", "{{ .Name }}",
+	)
+}
+
+func contextInspectFailure() *expect.Expectation {
+	return expect.NewLiteral(
+		expect.Behaviour{ExitCode: 1},
+		"docker", "context", "inspect", "--format", "{{ .Name }}",
+	)
+}
+
 func Test_NCPU(t *testing.T) {
 	ctx := context.Background()
 


### PR DESCRIPTION
If the default temporary directory is in use _and_ Docker Desktop for Linux is the default Docker context, this changes the temporary directory to be one under `~/.cache/sourcegraph/batch-tmp` instead.

Fixes #754.

### Test plan

Tested manually in both workspace modes.