### PR TITLE
orgs: update `create` mutation

### DIFF
--- a/cmd/src/orgs_create.go
+++ b/cmd/src/orgs_create.go
@@ -26,7 +26,7 @@ Examples:
 	}
 	var (
 		nameFlag        = flagSet.String("name", "", `The new organization's name. (required)`)
-		displayNameFlag = flagSet.String("display-name", "", `The new organization's display name.`)
+		displayNameFlag = flagSet.String("display-name", "", `The new organization's display name. Defaults to organization name if unspecified.`)
 		apiFlags        = api.NewFlags(flagSet)
 	)
 
@@ -41,7 +41,7 @@ Examples:
   $name: String!,
   $displayName: String!,
 ) {
-  createOrg(
+  createOrganization(
     name: $name,
     displayName: $displayName,
   ) {


### PR DESCRIPTION
running `src orgs create -name X` was failing with

```
GraphQL errors: {
  "locations": [
    {
      "column": 3,
      "line": 5
    }
  ],
  "message": "Cannot query field \"createOrg\" on type \"Mutation\". Did you mean \"createUser\"?"
}
```

the mutation name should be `createOrganization`

### Test plan

```
SRC_ENDPOINT="https://sourcegraph.test:3443" SRC_ACCESS_TOKEN=${SG_TEST_TOKEN} go run ./cmd/src orgs create -name ce-team
Organization "ce-team" created.
```