### PR TITLE
batches: Make sure no corrupted repozips are used

### DIFF
--- a/internal/batches/repozip/fetcher.go
+++ b/internal/batches/repozip/fetcher.go
@@ -336,7 +336,7 @@ func fetchRepositoryFile(ctx context.Context, client HTTPClient, repo RepoRevisi
 		return false, fmt.Errorf("unable to fetch archive (HTTP %d from %s)", resp.StatusCode, req.URL.String())
 	}
 
-	f, err := os.CreateTemp(path.Dir(dest), fmt.Sprintf("%s-*.tmp", path.Base(dest)))
+	f, err := os.CreateTemp(filepath.Dir(dest), fmt.Sprintf("%s-*.tmp", filepath.Base(dest)))
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
When the download of a zip was aborted, it could've left behind a corrupted archive zip. This fixes it by first storing it to a temporary location and then creating the actual file atomically by doing os.Rename.

Closes https://github.com/sourcegraph/sourcegraph/issues/39743

### Test plan

Verified things still work as expected.
