### PR TITLE
Prepare CLI for extension sunsetting

### DIFF
--- a/cmd/src/extensions.go
+++ b/cmd/src/extensions.go
@@ -10,7 +10,8 @@ var extensionsCommands commander
 func init() {
 	usage := `'src extensions' is a tool that manages extensions in the extension registry on a Sourcegraph instance.
 
-EXPERIMENTAL: Extensions are experimental functionality on Sourcegraph and in the 'src' tool.
+DEPRECATED: We're in the process of removing Sourcegraph extensions with our September release.
+            Learn more: https://docs.sourcegraph.com/extensions/deprecation
 
 Usage:
 

--- a/cmd/src/extensions_list.go
+++ b/cmd/src/extensions_list.go
@@ -63,6 +63,7 @@ Examples:
       nodes {
         ...RegistryExtensionFields
       }
+			error
     }
   }
 }` + registryExtensionFragment
@@ -71,6 +72,7 @@ Examples:
 			ExtensionRegistry struct {
 				Extensions struct {
 					Nodes []Extension
+					Error string
 				}
 			}
 		}
@@ -79,6 +81,10 @@ Examples:
 			"query": api.NullString(*queryFlag),
 		}).Do(context.Background(), &result); err != nil || !ok {
 			return err
+		}
+
+		if result.ExtensionRegistry.Extensions.Error != "" {
+			return fmt.Errorf("%s", result.ExtensionRegistry.Extensions.Error)
 		}
 
 		for _, extension := range result.ExtensionRegistry.Extensions.Nodes {

--- a/cmd/src/extensions_list.go
+++ b/cmd/src/extensions_list.go
@@ -63,7 +63,7 @@ Examples:
       nodes {
         ...RegistryExtensionFields
       }
-			error
+      error
     }
   }
 }` + registryExtensionFragment


### PR DESCRIPTION
Part of sourcegraph/sourcegraph#39044
Part of sourcegraph/sourcegraph#39043

While auditing the CLI functionality and requirements for the upcoming extensions deprecation, I noticed two areas that are currently not working well:

- The `sg extensions` command doesn't explain the upcoming deprecation yet. I've changed it to show the same text as sourcegraph.com cc @jjinnii @ryankscott @muratsu 
- The `sg extensions list` command did not forward the GraphQL error probably. This happens because the endpoint does not use the normal GraphQL error pattern for errors. [See this for more context](https://sourcegraph.com/github.com/ilscipio/sourcegraph/-/blob/cmd/frontend/registry/api/extension_connection_graphql.go?L192-204&utm_source=VSCode-2.2.7).

All other extension endpoints work as expected and I made sure they forward an error message sent on the backend (I'll follow up with the backend changes to gate out the APIs in a separate commit [lol obviously because this is a different repo haha]).

### Test plan

![Screenshot 2022-08-17 at 11 45 39](https://user-images.githubusercontent.com/458591/185102525-024c2848-5e86-4870-abad-70e8ed84ac97.png)
![Screenshot 2022-08-17 at 12 59 44](https://user-images.githubusercontent.com/458591/185102658-9cdebfce-de8d-41df-a214-07d1f618bbce.png)


<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
