### PR TITLE
Add `src users clean` to src-cli

### DIFF
--- a/cmd/src/users.go
+++ b/cmd/src/users.go
@@ -58,7 +58,7 @@ fragment UserFields on User {
     }
     emails {
         email
-	verified
+		verified
     }
     usageStatistics {
         lastActiveTime

--- a/cmd/src/users.go
+++ b/cmd/src/users.go
@@ -60,6 +60,10 @@ fragment UserFields on User {
         email
         verified
     }
+	usageStatistics {
+		lastActiveTime
+		lastActiveCodeHostIntegrationTime
+	}
     url
 }
 `
@@ -72,11 +76,17 @@ type User struct {
 	Organizations struct {
 		Nodes []Org
 	}
-	Emails []UserEmail
-	URL    string
+	Emails          []UserEmail
+	UsageStatistics UserUsageStatistics
+	URL             string
 }
 
 type UserEmail struct {
 	Email    string
 	Verified bool
+}
+
+type UserUsageStatistics struct {
+	LastActiveTime                    string
+	LastActiveCodeHostIntegrationTime string
 }

--- a/cmd/src/users.go
+++ b/cmd/src/users.go
@@ -58,12 +58,12 @@ fragment UserFields on User {
     }
     emails {
         email
-		verified
+	verified
     }
-	usageStatistics {
-		lastActiveTime
-		lastActiveCodeHostIntegrationTime
-	}
+    usageStatistics {
+        lastActiveTime
+        lastActiveCodeHostIntegrationTime
+    }
     url
 }
 `

--- a/cmd/src/users.go
+++ b/cmd/src/users.go
@@ -20,6 +20,7 @@ The commands are:
 	get        gets a user
 	create     creates a user account
 	delete     deletes a user account
+	clean      deletes inactive users
 	tag        add/remove a tag on a user
 
 Use "src users [command] -h" for more information about a command.

--- a/cmd/src/users.go
+++ b/cmd/src/users.go
@@ -58,7 +58,7 @@ fragment UserFields on User {
     }
     emails {
         email
-        verified
+		verified
     }
 	usageStatistics {
 		lastActiveTime

--- a/cmd/src/users_clean.go
+++ b/cmd/src/users_clean.go
@@ -97,10 +97,18 @@ query Users($first: Int, $query: String) {
 	})
 }
 
-func delete_users_not_active_in(users_data string, days_threshold int) error {
+func delete_users_not_active_in(usage string, days_threshold int) error {
 	timeNow := time.Now()
+	timeLast, err := time.Parse(time.RFC3339, usage)
+	if err != nil {
+		fmt.Printf("failed to parse lastActive time: %s", err)
+	}
+	timeDiff := timeNow.Sub(timeLast)
+	if err != nil {
+		fmt.Printf("failed to diff lastActive to current time: %s", err)
+	}
 
-	fmt.Printf("Time now: %s\nLast Active: %s", timeNow, users_data)
+	fmt.Printf("Time now: %s\nLast active: %s\nTime diff: %d\n\n", timeNow, timeLast, int(timeDiff.Hours()/24))
 	query := `mutation DeleteUser(
   $user: ID!
 ) {
@@ -110,7 +118,7 @@ func delete_users_not_active_in(users_data string, days_threshold int) error {
     alwaysNil
   }
 }`
-	fmt.Printf("%s -- %d\n", users_data, days_threshold)
+	fmt.Printf("%s -- %d\n", usage, days_threshold)
 	if days_threshold == 0 {
 		fmt.Println(query)
 	}

--- a/cmd/src/users_clean.go
+++ b/cmd/src/users_clean.go
@@ -125,17 +125,16 @@ query Users($first: Int, $query: String) {
 
 // computes days since last usage from current day and time and UsageStatistics.LastActiveTime, uses time.Parse
 func computeDaysSinceLastUse(user User) (timeDiff int, wasLastActive bool, _ error) {
-	timeNow := time.Now()
 	// handle for null lastActiveTime returned from
 	if user.UsageStatistics.LastActiveTime == "" {
 		wasLastActive = false
 		return 0, wasLastActive, nil
 	}
-	timeLast, err := time.Parse(time.RFC3339, user.UsageStatistics.LastActiveTime)
+	lastActive, err := time.Parse(time.RFC3339, user.UsageStatistics.LastActiveTime)
 	if err != nil {
 		return 0, false, err
 	}
-	timeDiff = int(timeNow.Sub(timeLast).Hours() / 24)
+	timeDiff = int(time.Since(timeLast).Hours() / 24)
 
 	return timeDiff, true, err
 }

--- a/cmd/src/users_clean.go
+++ b/cmd/src/users_clean.go
@@ -33,7 +33,7 @@ Examples:
 		ctx := context.Background()
 		client := cfg.apiClient(apiFlags, flagSet.Output())
 
-		tmpl, err := parseTemplate("{{.Username}}  {{.SiteAdmin}}")
+		tmpl, err := parseTemplate("{{.Username}}  {{.SiteAdmin}} {{(index .Emails 0).Email}} {{.UsageStatistics.LastActiveTime}}")
 		if err != nil {
 			return err
 		}
@@ -41,19 +41,34 @@ Examples:
 			"-d": api.NullInt(*days),
 		}
 
-		query := `query Users(
-  $first: Int,
-  $query: String,
-) {
-  users(
-first: $first,
-    query: $query,
-  ) {
-    nodes {
-      ...UserFields
-    }
-  }
-}` + userFragment
+		query := `
+query Users($first: Int, $query: String) {
+	users(first: $first, query: $query) {
+		nodes {
+			id
+			username
+			displayName
+			siteAdmin
+			organizations {
+				nodes {
+					id
+					name
+					displayName
+				}
+			}
+			emails {
+				email
+				verified
+			}
+			usageStatistics {
+				lastActiveTime
+				lastActiveCodeHostIntegrationTime
+			}
+			url
+		}
+	}
+}
+`
 
 		var result struct {
 			Users struct {

--- a/cmd/src/users_clean.go
+++ b/cmd/src/users_clean.go
@@ -25,12 +25,15 @@ Examples:
 		fmt.Println(usage)
 	}
 	var (
-		daysToDelete       = flagSet.Int("d", 365, "Day threshold on which to remove users, defaults to 365")
-		noAdmin            = flagSet.Bool("no-admin", false, "Omit admin accounts from cleanup")
-		toEmail            = flagSet.Bool("email", false, "send removed users an email")
+		daysToDelete = flagSet.Int("d", 365, "Day threshold on which to remove users, defaults to 365")
+		noAdmin      = flagSet.Bool("no-admin", false, "Omit admin accounts from cleanup")
+		// TODO: Add an email functionality to email removed users, open editor like in git commit
+		// toEmail            = flagSet.Bool("email", false, "send removed users an email")
 		removeNoLastActive = flagSet.Bool("removeNeverActive", false, "removes users with null lastActive value")
 		skipConfirmation   = flagSet.Bool("skip-conf", false, "skips user confirmation step allowing programmatic use")
-		apiFlags           = api.NewFlags(flagSet)
+		// TODO: Write json file containing users to be deleted, last active usage, site-admin status, and emails
+		// json               = flagSet.Bool("json", false, "Write json file containing users to be deleted, last active usage, site-admin status, and emails")
+		apiFlags = api.NewFlags(flagSet)
 	)
 
 	handler := func(args []string) error {
@@ -91,11 +94,12 @@ query Users($first: Int, $query: String) {
 				if err := removeUser(user.User, client, ctx); err != nil {
 					return err
 				}
-				if *toEmail {
-					if err := sendEmail(user.User); err != nil {
-						fmt.Printf("failer to send email to %s with error: %s", user.User.Emails[0].Email, err)
-					}
-				}
+				// TODO: see flag toEmail
+				//if *toEmail {
+				//	if err := sendEmail(user.User); err != nil {
+				//		fmt.Printf("failed to send email to %s with error: %s", user.User.Emails[0].Email, err)
+				//	}
+				//}
 			}
 			return nil
 		}
@@ -110,11 +114,12 @@ query Users($first: Int, $query: String) {
 				if err := removeUser(user.User, client, ctx); err != nil {
 					return err
 				}
-				if *toEmail {
-					if err := sendEmail(user.User); err != nil {
-						fmt.Printf("failer to send email to %s with error: %s", user.User.Emails[0].Email, err)
-					}
-				}
+				// TODO: see flag toEmail
+				//if *toEmail {
+				//	if err := sendEmail(user.User); err != nil {
+				//		fmt.Printf("failed to send email to %s with error: %s", user.User.Emails[0].Email, err)
+				//	}
+				//}
 			}
 		}
 
@@ -170,6 +175,7 @@ type UserToDelete struct {
 	DaysSinceLastUse int
 }
 
+// TODO: improve formatting of list output
 func confirmUserRemoval(usersToRemove []UserToDelete) (bool, error) {
 	fmt.Printf("Users to remove from instance at %s \n\t\t(Username|DisplayName|Email|DaysSinceLastActive)\n", cfg.Endpoint)
 	for _, user := range usersToRemove {
@@ -189,7 +195,8 @@ func confirmUserRemoval(usersToRemove []UserToDelete) (bool, error) {
 	return strings.ToLower(input) == "y", nil
 }
 
-func sendEmail(user User) error {
-	fmt.Printf("This sent an email to %s", user.Emails[0].Email)
-	return nil
-}
+// TODO: function to execute email
+//func sendEmail(user User) error {
+//	fmt.Printf("This sent an email to %s", user.Emails[0].Email)
+//	return nil
+//}

--- a/cmd/src/users_clean.go
+++ b/cmd/src/users_clean.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"time"
 
 	"github.com/sourcegraph/src-cli/internal/api"
 )
@@ -33,7 +34,7 @@ Examples:
 		ctx := context.Background()
 		client := cfg.apiClient(apiFlags, flagSet.Output())
 
-		tmpl, err := parseTemplate("{{.Username}}  {{.SiteAdmin}} {{(index .Emails 0).Email}} {{.UsageStatistics.LastActiveTime}}")
+		tmpl, err := parseTemplate("{{.Username}}  {{.SiteAdmin}} {{(index .Emails 0).Email}}")
 		if err != nil {
 			return err
 		}
@@ -97,6 +98,21 @@ query Users($first: Int, $query: String) {
 }
 
 func delete_users_not_active_in(users_data string, days_threshold int) error {
+	timeNow := time.Now()
+
+	fmt.Printf("Time now: %s\nLast Active: %s", timeNow, users_data)
+	query := `mutation DeleteUser(
+  $user: ID!
+) {
+  deleteUser(
+    user: $user
+  ) {
+    alwaysNil
+  }
+}`
 	fmt.Printf("%s -- %d\n", users_data, days_threshold)
+	if days_threshold == 0 {
+		fmt.Println(query)
+	}
 	return nil
 }

--- a/cmd/src/users_clean.go
+++ b/cmd/src/users_clean.go
@@ -74,7 +74,7 @@ query Users($first: Int, $query: String) {
 			if *noAdmin && user.SiteAdmin {
 				continue
 			}
-			if daysSinceLastUse <= *daysToDelete {
+			if daysSinceLastUse <= *daysToDelete && wasLastActive {
 				continue
 			}
 
@@ -113,7 +113,6 @@ func computeDaysSinceLastUse(user User) (timeDiff int, wasLastActive bool, _ err
 	timeNow := time.Now()
 	// handle for null lastActiveTime returned from
 	if user.UsageStatistics.LastActiveTime == "" {
-		fmt.Printf("\n%s has no lastActive value\n", user.Username)
 		wasLastActive = false
 		return 0, wasLastActive, nil
 	}
@@ -150,7 +149,11 @@ func removeUser(user User, client api.Client, ctx context.Context) error {
 func confirmUserRemoval(usersToRemove []User) (bool, error) {
 	fmt.Printf("The following users will be removed from your Sourcegraph instance:\n")
 	for _, user := range usersToRemove {
-		fmt.Printf("\t%s  %s  %s\n", user.Username, user.DisplayName, user.Emails[0].Email)
+		if len(user.Emails) > 0 {
+			fmt.Printf("\t%s  %s  %s\n", user.Username, user.DisplayName, user.Emails[0].Email)
+		} else {
+			fmt.Printf("\t%s  %s\n", user.Username, user.DisplayName)
+		}
 	}
 	input := ""
 	for strings.ToLower(input) != "y" && strings.ToLower(input) != "n" {

--- a/cmd/src/users_clean.go
+++ b/cmd/src/users_clean.go
@@ -21,7 +21,7 @@ Examples:
 
 	$ src users clean -days 182
 	
-	$ src users clean -removeAdmin -removeNeverActive 
+	$ src users clean -remove-admin -remove-never-active 
 `
 
 	flagSet := flag.NewFlagSet("clean", flag.ExitOnError)
@@ -32,8 +32,8 @@ Examples:
 	}
 	var (
 		daysToDelete       = flagSet.Int("days", 60, "Days threshold on which to remove users, must be 60 days or greater and defaults to this value ")
-		removeAdmin        = flagSet.Bool("removeAdmin", false, "clean admin accounts")
-		removeNoLastActive = flagSet.Bool("removeNeverActive", false, "removes users with null lastActive value")
+		removeAdmin        = flagSet.Bool("remove-admin", false, "clean admin accounts")
+		removeNoLastActive = flagSet.Bool("remove-never-active", false, "removes users with null lastActive value")
 		skipConfirmation   = flagSet.Bool("force", false, "skips user confirmation step allowing programmatic use")
 		apiFlags           = api.NewFlags(flagSet)
 	)

--- a/cmd/src/users_clean.go
+++ b/cmd/src/users_clean.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/sourcegraph/src-cli/internal/api"
+)
+
+func init() {
+	usage := `
+Examples:
+
+	$ src users clean -d 182
+
+`
+
+	flagSet := flag.NewFlagSet("clean", flag.ExitOnError)
+	usageFunc := func() {
+		fmt.Fprintf(flag.CommandLine.Output(), "Usage of 'src users %s':\n", flagSet.Name())
+		flagSet.PrintDefaults()
+		fmt.Println(usage)
+	}
+	var (
+		days     = flagSet.Int("d", 1000, "Returns the first n users from the list. (use -1 for unlimited)")
+		apiFlags = api.NewFlags(flagSet)
+	)
+
+	handler := func(args []string) error {
+		flagSet.Parse(args)
+
+		ctx := context.Background()
+		client := cfg.apiClient(apiFlags, flagSet.Output())
+
+		tmpl, err := parseTemplate("{{.Username}}  {{.SiteAdmin}}")
+		if err != nil {
+			return err
+		}
+		vars := map[string]interface{}{
+			"-d": api.NullInt(*days),
+		}
+
+		query := `query Users(
+  $first: Int,
+  $query: String,
+) {
+  users(
+first: $first,
+    query: $query,
+  ) {
+    nodes {
+      ...UserFields
+    }
+  }
+}` + userFragment
+
+		var result struct {
+			Users struct {
+				Nodes []User
+			}
+		}
+		if ok, err := client.NewRequest(query, vars).Do(ctx, &result); err != nil || !ok {
+			return err
+		}
+
+		for _, user := range result.Users.Nodes {
+			if err := execTemplate(tmpl, user); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	// Register the command.
+	usersCommands = append(usersCommands, &command{
+		flagSet:   flagSet,
+		handler:   handler,
+		usageFunc: usageFunc,
+	})
+}

--- a/cmd/src/users_clean.go
+++ b/cmd/src/users_clean.go
@@ -130,7 +130,7 @@ func computeDaysSinceLastUse(user User) (timeDiff int, wasLastActive bool, _ err
 		wasLastActive = false
 		return 0, wasLastActive, nil
 	}
-	lastActive, err := time.Parse(time.RFC3339, user.UsageStatistics.LastActiveTime)
+	timeLast, err := time.Parse(time.RFC3339, user.UsageStatistics.LastActiveTime)
 	if err != nil {
 		return 0, false, err
 	}

--- a/cmd/src/users_clean.go
+++ b/cmd/src/users_clean.go
@@ -15,13 +15,13 @@ import (
 
 func init() {
 	usage := `
-This command removes users from a Sourcegraph instance who have been inactive for 60 or more days.
+This command removes users from a Sourcegraph instance who have been inactive for 60 or more days. Admin accounts are omitted by default.
 	
 Examples:
 
 	$ src users clean -days 182
 	
-	$ src users clean -noAdmin -removeNeverActive 
+	$ src users clean -removeAdmin -removeNeverActive 
 `
 
 	flagSet := flag.NewFlagSet("clean", flag.ExitOnError)
@@ -32,7 +32,7 @@ Examples:
 	}
 	var (
 		daysToDelete       = flagSet.Int("days", 60, "Days threshold on which to remove users, must be 60 days or greater and defaults to this value ")
-		noAdmin            = flagSet.Bool("noAdmin", false, "Omit admin accounts from cleanup")
+		removeAdmin        = flagSet.Bool("removeAdmin", false, "clean admin accounts")
 		removeNoLastActive = flagSet.Bool("removeNeverActive", false, "removes users with null lastActive value")
 		skipConfirmation   = flagSet.Bool("force", false, "skips user confirmation step allowing programmatic use")
 		apiFlags           = api.NewFlags(flagSet)
@@ -79,7 +79,7 @@ query Users() {
 			if !wasLastActive && !*removeNoLastActive {
 				continue
 			}
-			if *noAdmin && user.SiteAdmin {
+			if !*removeAdmin && user.SiteAdmin {
 				continue
 			}
 			if daysSinceLastUse <= *daysToDelete && wasLastActive {

--- a/cmd/src/users_clean.go
+++ b/cmd/src/users_clean.go
@@ -80,11 +80,12 @@ query Users($first: Int, $query: String) {
 		}
 
 		for _, user := range result.Users.Nodes {
+			delete_users_not_active_in(user.UsageStatistics.LastActiveTime, *days)
 			if err := execTemplate(tmpl, user); err != nil {
 				return err
 			}
 		}
-		return nil
+		return err
 	}
 
 	// Register the command.
@@ -93,4 +94,9 @@ query Users($first: Int, $query: String) {
 		handler:   handler,
 		usageFunc: usageFunc,
 	})
+}
+
+func delete_users_not_active_in(users_data string, days_threshold int) error {
+	fmt.Printf("%s -- %d\n", users_data, days_threshold)
+	return nil
 }

--- a/cmd/src/users_clean.go
+++ b/cmd/src/users_clean.go
@@ -142,12 +142,8 @@ func computeDaysSinceLastUse(user User) (timeDiff int, wasLastActive bool, _ err
 
 // Issue graphQL api request to remove user
 func removeUser(user User, client api.Client, ctx context.Context) error {
-	query := `mutation DeleteUser(
-  $user: ID!
-) {
-  deleteUser(
-    user: $user
-  ) {
+	query := `mutation DeleteUser($user: ID!) {
+  deleteUser(user: $user) {
     alwaysNil
   }
 }`

--- a/cmd/src/users_clean.go
+++ b/cmd/src/users_clean.go
@@ -147,12 +147,12 @@ func removeUser(user User, client api.Client, ctx context.Context) error {
 }
 
 func confirmUserRemoval(usersToRemove []User) (bool, error) {
-	fmt.Printf("The following users will be removed from your Sourcegraph instance:\n")
+	fmt.Printf("Users to remove from instance at %s:\n", cfg.Endpoint)
 	for _, user := range usersToRemove {
 		if len(user.Emails) > 0 {
-			fmt.Printf("\t%s  %s  %s\n", user.Username, user.DisplayName, user.Emails[0].Email)
+			fmt.Printf("\t\t%s  %s  %s\n", user.Username, user.DisplayName, user.Emails[0].Email)
 		} else {
-			fmt.Printf("\t%s  %s\n", user.Username, user.DisplayName)
+			fmt.Printf("\t\t%s  %s\n", user.Username, user.DisplayName)
 		}
 	}
 	input := ""

--- a/cmd/src/users_clean.go
+++ b/cmd/src/users_clean.go
@@ -51,8 +51,8 @@ Examples:
 		client := cfg.apiClient(apiFlags, flagSet.Output())
 
 		query := `
-query Users($first: Int, $query: String) {
-	users(first: $first, query: $query) {
+query Users() {
+	users() {
 		nodes {
 			...UserFields
 		}

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/google/go-cmp v0.5.8
 	github.com/grafana/regexp v0.0.0-20220304100321-149c8afcd6cb
 	github.com/hexops/autogold v1.3.0
+	github.com/jedib0t/go-pretty/v6 v6.3.7
 	github.com/jig/teereadcloser v0.0.0-20181016160506-953720c48e05
 	github.com/json-iterator/go v1.1.12
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51

--- a/go.sum
+++ b/go.sum
@@ -198,6 +198,8 @@ github.com/iris-contrib/pongo2 v0.0.1/go.mod h1:Ssh+00+3GAZqSQb30AvBRNxBx7rf0Gqw
 github.com/iris-contrib/schema v0.0.1/go.mod h1:urYA3uvUNG1TIIjOSCzHr9/LmbQo8LrOcOqfqxa4hXw=
 github.com/jdxcode/netrc v0.0.0-20210204082910-926c7f70242a h1:d4+I1YEKVmWZrgkt6jpXBnLgV2ZjO0YxEtLDdfIZfH4=
 github.com/jdxcode/netrc v0.0.0-20210204082910-926c7f70242a/go.mod h1:Zi/ZFkEqFHTm7qkjyNJjaWH4LQA9LQhGJyF0lTYGpxw=
+github.com/jedib0t/go-pretty/v6 v6.3.7 h1:H3Ulkf7h6A+p0HgKBGzgDn0bZIupRbKKWF4pO4Bs7iA=
+github.com/jedib0t/go-pretty/v6 v6.3.7/go.mod h1:MgmISkTWDSFu0xOqiZ0mKNntMQ2mDgOcwOkwBEkMDJI=
 github.com/jhump/gopoet v0.0.0-20190322174617-17282ff210b3/go.mod h1:me9yfT6IJSlOL3FCfrg+L6yzUEZ+5jW6WHt4Sk+UPUI=
 github.com/jhump/gopoet v0.1.0/go.mod h1:me9yfT6IJSlOL3FCfrg+L6yzUEZ+5jW6WHt4Sk+UPUI=
 github.com/jhump/goprotoc v0.5.0/go.mod h1:VrbvcYrQOrTi3i0Vf+m+oqQWk9l72mjkJCYo7UvLHRQ=
@@ -396,6 +398,7 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.4/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=


### PR DESCRIPTION
This draft PR tracks work on registering a new `src users` subcommand `src users clean` which allows admins to remove users in bulk given some conditions like admin status and days since last active use registered.
https://github.com/sourcegraph/sourcegraph/issues/40102

The command is still in development at the time of publishing this draft, it seems near MVP though

Two Additional nice to have features would be:
- output json file containing users removed and some data on the users (for use to send emails to removed users mostly)
- open an editor to compose general email to be sent to removed users and send. Functionality behind `-send-email` flag

_Please check carefully, I'm new at this!_
### Test plan
Manually test each command option against `cse-aws` and `cse-k8s`

Open to additional testing

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
