### PR TITLE
Update release process until 4.0 stable is released.

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -50,7 +50,8 @@ dockers:
     - "sourcegraph/src-cli:{{ .Tag }}"
     - "sourcegraph/src-cli:{{ .Major }}"
     - "sourcegraph/src-cli:{{ .Major }}.{{ .Minor }}"
-    - "sourcegraph/src-cli:latest"
+    # Disabled until 4.0 stable is released.
+    #- "sourcegraph/src-cli:latest"
 changelog:
   sort: asc
   filters:

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,5 +1,23 @@
 This file covers things that are good to know if you're developing or maintaining `src`. It is likely incomplete, and contributions would be most welcome!
 
+## Things are a bit weird right now, August-September 2022 edition
+
+With 3.43 having been released, we now want to remove a bunch of old backward compatibility code before 4.0 is released in late September. However, we also need to be able to fix bugs and make 3.43.x releases in the interim.
+
+**Until 4.0 is released, `main` is the 4.0 branch.**
+
+### Releasing a 3.43.x bug fix
+
+You must merge the fix into **both** the `3.43` and `main` branches. Then [perform the release normally](#releasing), except note that you **must** be on the `3.43` branch when you run `./release.sh`.
+
+### Releasing a 4.0 pre-release
+
+[Perform the release normally](#releasing), but be careful to use a version number that is clearly a pre-release, specifically in the format `4.0.0-rc.X`, where `X` is one higher than the previous pre-release.
+
+### Releasing 4.0 proper
+
+If you're reading this because you're about to release the stable 4.0.0 release, please merge #828 first to put the release machinery back the way it was.
+
 ## Contents
 
 * [Developing `src`](#development)


### PR DESCRIPTION
This PR will need to be reverted immediately before 4.0 is released, which will be accomplished by merging #828.

In terms of mechanics, we're relying on GoReleaser's [automatic detection of pre-releases](https://goreleaser.com/customization/release/#github), combined with [`.api/src-cli` automatically skipping pre-release versions of src-cli](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@a00ffa24df05ad716def5d7a053ee5586c6b3194/-/blob/internal/src-cli/version.go?L116:31&subtree=true). The only actual changes we need to make are:

1. Choosing appropriate version numbers, which are now documented in `DEVELOPMENT.md`, and
2. Not pushing the `sourcegraph/src-cli` Docker image to the `latest` tag on `main` until we're ready to release 4.0.0 stable.

Closes sourcegraph/sourcegraph#40575.

### Test plan

I'm going to make 3.43.1 and 4.0.0-rc.0 releases immediately after merging this.