### PR TITLE
Revert 4.0-pre changes

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -50,8 +50,7 @@ dockers:
     - "sourcegraph/src-cli:{{ .Tag }}"
     - "sourcegraph/src-cli:{{ .Major }}"
     - "sourcegraph/src-cli:{{ .Major }}.{{ .Minor }}"
-    # Disabled until 4.0 stable is released.
-    #- "sourcegraph/src-cli:latest"
+    - "sourcegraph/src-cli:latest"
 changelog:
   sort: asc
   filters:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -57,5 +57,3 @@ changelog:
     exclude:
     - '^docs:'
     - '^test:'
-release:
-  prerelease: true

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,23 +1,5 @@
 This file covers things that are good to know if you're developing or maintaining `src`. It is likely incomplete, and contributions would be most welcome!
 
-## Things are a bit weird right now, August-September 2022 edition
-
-With 3.43 having been released, we now want to remove a bunch of old backward compatibility code before 4.0 is released in late September. However, we also need to be able to fix bugs and make 3.43.x releases in the interim.
-
-**Until 4.0 is released, `main` is the 4.0 branch.**
-
-### Releasing a 3.43.x bug fix
-
-You must merge the fix into **both** the `3.43` and `main` branches. Then [perform the release normally](#releasing), except note that you **must** be on the `3.43` branch when you run `./release.sh`.
-
-### Releasing a 4.0 pre-release
-
-[Perform the release normally](#releasing), but be careful to use a version number that is clearly a pre-release, specifically in the format `4.0.0-rc.X`, where `X` is one higher than the previous pre-release.
-
-### Releasing 4.0 proper
-
-If you're reading this because you're about to release the stable 4.0.0 release, please merge #828 first to put the release machinery back the way it was.
-
 ## Contents
 
 * [Developing `src`](#development)


### PR DESCRIPTION
This PR reverts #827, and must be merged before 4.0.0 stable is released.

At the same time this is merged, we should ensure the changelog reflects any releases made on `3.43`.

### Test plan

If #827 works, this will also work.