### PR TITLE
goreleaser: force releases to be marked as pre-release

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -58,3 +58,5 @@ changelog:
     exclude:
     - '^docs:'
     - '^test:'
+release:
+  prerelease: true


### PR DESCRIPTION
Whatever version string sniffing goreleaser is doing isn't firing, so let's just force it. I'll add a revert to #828 for this as well.

### Test plan

We'll test this in the next 4.0.0 pre-release.