### PR TITLE
strip trailing slashes from repository (lsif)

### DIFF
--- a/cmd/src/code_intel_upload_flags.go
+++ b/cmd/src/code_intel_upload_flags.go
@@ -104,6 +104,9 @@ func parseAndValidateCodeIntelUploadFlags(args []string) (*output.Output, error)
 		}
 	}
 
+	// We want to strip off any trailing slash in the repository name so we don't get a 404
+	codeintelUploadFlags.repo = strings.TrimRight(codeintelUploadFlags.repo, "/")
+
 	// parse the api client flags separately and then populate the codeintelUploadFlags struct with the result
 	// we could just use insecureSkipVerify but I'm including everything here because it costs nothing
 	// and maybe we'll use some in the future


### PR DESCRIPTION
### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
Test `src lsif upload -file dump.lsif -repo https://github.com/foo/bar/` with a trailing slash and ensured from the inferred arguments, the trailing slash was stripped off.

```sh
$ go run ./cmd/src lsif upload -file dump.lsif -repo github.com/BolajiOlajide/env-utils/
💡 Inferred arguments
   repo: github.com/BolajiOlajide/env-utils
   commit: 812cde19b17fc6ca631f03c3abc02fd96d2272ce
   root: .
   file: dump.lsif
   indexer:
   indexerVersion:
```