### PR TITLE
readme: add instructions for docker

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -63,6 +63,14 @@ chmod +x /usr/local/bin/src
 
 See [Sourcegraph CLI for Windows](WINDOWS.md).
 
+### Installation: Docker
+
+`sourcegraph/src-cli` is published to DockerHub. You can use the `latest` tag or a specific version such as `3.43`. To see all versions view [sourcegraph/src-cli tags](https://hub.docker.com/r/sourcegraph/src-cli/tags).
+
+```bash
+docker run --rm=true sourcegraph/src-cli:latest search 'hello world'
+```
+
 ## Log into your Sourcegraph instance
 
 Run <code><strong>src login <i>SOURCEGRAPH-URL</i></strong></code> to authenticate `src` to access your Sourcegraph instance with your user credentials.

--- a/README.markdown
+++ b/README.markdown
@@ -65,7 +65,7 @@ See [Sourcegraph CLI for Windows](WINDOWS.md).
 
 ### Installation: Docker
 
-`sourcegraph/src-cli` is published to DockerHub. You can use the `latest` tag or a specific version such as `3.43`. To see all versions view [sourcegraph/src-cli tags](https://hub.docker.com/r/sourcegraph/src-cli/tags).
+`sourcegraph/src-cli` is published to Docker Hub. You can use the `latest` tag or a specific version such as `3.43`. To see all versions view [sourcegraph/src-cli tags](https://hub.docker.com/r/sourcegraph/src-cli/tags).
 
 ```bash
 docker run --rm=true sourcegraph/src-cli:latest search 'hello world'


### PR DESCRIPTION
We received feedback that some users prefer using src-cli via docker. We publish an image for the purpose of serve-git, so was only documented there. This includes basic information for those inclined to use docker.

Test Plan: run the supplied command in docs
