### PR TITLE
Add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @mrnugget @eseliger @LawnGnome @slimsag @efritz @sqs @keegancsmith @ryanslade @chrismwendt @kevinzliu


### PR DESCRIPTION
This PR adds the top ten (or up to ten) contributors to this repository to a CODEOWNERS file.

[_Created by Sourcegraph batch change `aharvey/add-codeowners`._](https://demo.sourcegraph.com/users/aharvey/batch-changes/add-codeowners)