### PR TITLE
Add a add subcommand to extsvc

### DIFF
--- a/cmd/src/extsvc.go
+++ b/cmd/src/extsvc.go
@@ -23,7 +23,7 @@ The commands are:
 
 	list      lists the external services on the Sourcegraph instance
 	edit      edits external services on the Sourcegraph instance
-  add       adds an external service on the Sourcegaph instance
+	add       add an external service on the Sourcegraph instance
 
 Use "src extsvc [command] -h" for more information about a command.
 `

--- a/cmd/src/extsvc.go
+++ b/cmd/src/extsvc.go
@@ -23,6 +23,7 @@ The commands are:
 
 	list      lists the external services on the Sourcegraph instance
 	edit      edits external services on the Sourcegraph instance
+  add       adds an external service on the Sourcegaph instance
 
 Use "src extsvc [command] -h" for more information about a command.
 `
@@ -52,6 +53,8 @@ type externalService struct {
 	CreatedAt, UpdatedAt string
 }
 
+var errServiceNotFound = errors.New("no such external service")
+
 func lookupExternalService(ctx context.Context, client api.Client, byID, byName string) (*externalService, error) {
 	var result struct {
 		ExternalServices struct {
@@ -72,5 +75,5 @@ func lookupExternalService(ctx context.Context, client api.Client, byID, byName 
 			return svc, nil
 		}
 	}
-	return nil, errors.New("no such external service")
+	return nil, errServiceNotFound
 }

--- a/cmd/src/extsvc_add.go
+++ b/cmd/src/extsvc_add.go
@@ -41,6 +41,10 @@ func init() {
 			return err
 		}
 
+		if *nameFlag == "" {
+			return errors.New("-name must be provided")
+		}
+
 		client := cfg.apiClient(apiFlags, flagSet.Output())
 		if *nameFlag != "" {
 			_, err := lookupExternalService(ctx, client, "", *nameFlag)

--- a/cmd/src/extsvc_add.go
+++ b/cmd/src/extsvc_add.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/mattn/go-isatty"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/src-cli/internal/api"
+)
+
+func init() {
+	usage := `
+  Examples:
+
+  Add an external service configuration on the Sourcegraph instance:
+
+  $ cat new-config.json | src extsvc add
+  $ src extsvc add -name 'My GitHub connection' new-config.json
+  `
+
+	flagSet := flag.NewFlagSet("add", flag.ExitOnError)
+	usageFunc := func() {
+		fmt.Fprintf(flag.CommandLine.Output(), "Usage of 'src extsvc %s':\n", flagSet.Name())
+		flagSet.PrintDefaults()
+		fmt.Println(usage)
+	}
+	var (
+		nameFlag = flagSet.String("name", "", "exact name of the external service to add")
+		kindFlag = flagSet.String("kind", "", "kind of the external service to add")
+		apiFlags = api.NewFlags(flagSet)
+	)
+
+	handler := func(args []string) (err error) {
+		ctx := context.Background()
+		if err := flagSet.Parse(args); err != nil {
+			return err
+		}
+
+		client := cfg.apiClient(apiFlags, flagSet.Output())
+		if *nameFlag != "" {
+			_, err := lookupExternalService(ctx, client, "", *nameFlag)
+			if err != errServiceNotFound {
+				return errors.New("service already exists")
+			}
+		}
+
+		var addJSON []byte
+		if len(flagSet.Args()) == 1 {
+			addJSON, err = os.ReadFile(flagSet.Arg(0))
+			if err != nil {
+				return err
+			}
+		}
+		if !isatty.IsTerminal(os.Stdin.Fd()) {
+			// stdin is a pipe not a terminal
+			addJSON, err = io.ReadAll(os.Stdin)
+			if err != nil {
+				return err
+			}
+		}
+
+		addExternalServiceInput := map[string]interface{}{
+			"kind":        strings.ToUpper(*kindFlag),
+			"displayName": *nameFlag,
+			"config":      string(addJSON),
+		}
+
+		queryVars := map[string]interface{}{
+			"input": addExternalServiceInput,
+		}
+
+		var result struct{} // TODO: future: allow formatting resulting external service
+		if ok, err := client.NewRequest(externalServicesAddMutation, queryVars).Do(ctx, &result); err != nil {
+			if strings.Contains(err.Error(), "Additional property exclude is not allowed") {
+				return errors.New(`specified external service does not support repository "exclude" list`)
+			}
+			return err
+		} else if ok {
+			fmt.Println("External service created:", *nameFlag)
+		}
+		return nil
+	}
+
+	// Register the command.
+	extsvcCommands = append(extsvcCommands, &command{
+		flagSet:   flagSet,
+		handler:   handler,
+		usageFunc: usageFunc,
+	})
+}
+
+const externalServicesAddMutation = `
+  mutation AddExternalService($input: AddExternalServiceInput!) {
+    addExternalService(input: $input) {
+      id
+      warning
+    }
+  }`


### PR DESCRIPTION
In the context of scaletesting, it's pretty useful to be able to add code hosts on the fly, while toying with a test instance. This PR adds such a command.

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->

Manually tested.