### PR TITLE
batches: show warning when batch changes are too large

### DIFF
--- a/cmd/src/batch_remote.go
+++ b/cmd/src/batch_remote.go
@@ -119,8 +119,9 @@ Examples:
 		ui.ResolvingWorkspaces()
 		ticker := time.NewTicker(1 * time.Second)
 		defer ticker.Stop()
+		var res *service.BatchSpecWorkspaceResolution
 		for range ticker.C {
-			res, err := svc.GetBatchSpecWorkspaceResolution(ctx, batchSpecID)
+			res, err = svc.GetBatchSpecWorkspaceResolution(ctx, batchSpecID)
 			if err != nil {
 				return err
 			}
@@ -131,7 +132,7 @@ Examples:
 				break
 			}
 		}
-		ui.ResolvingWorkspacesSuccess()
+		ui.ResolvingWorkspacesSuccess(res.Workspaces.TotalCount)
 
 		// We have to enqueue this for execution with a separate operation.
 		//

--- a/internal/batches/service/remote.go
+++ b/internal/batches/service/remote.go
@@ -275,6 +275,9 @@ query BatchSpecWorkspaceResolution($batchSpec: ID!) {
             workspaceResolution {
                 failureMessage
                 state
+				workspaces {
+					totalCount
+				}
             }
         }
     }
@@ -284,6 +287,9 @@ query BatchSpecWorkspaceResolution($batchSpec: ID!) {
 type BatchSpecWorkspaceResolution struct {
 	FailureMessage string `json:"failureMessage"`
 	State          string `json:"state"`
+	Workspaces     struct {
+		TotalCount int `json:"totalCount"`
+	} `json:"workspaces"`
 }
 
 func (svc *Service) GetBatchSpecWorkspaceResolution(ctx context.Context, id string) (*BatchSpecWorkspaceResolution, error) {


### PR DESCRIPTION
<img width="637" alt="image" src="https://user-images.githubusercontent.com/229984/195293417-625cbcff-d01f-4a26-83f6-835a564b9848.png">

Closes sourcegraph/sourcegraph#42408.

### Test plan

Tested manually with large batch changes.
