### PR TITLE
Prepare changelog for 4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,11 +19,17 @@ All notable changes to `src-cli` are documented in this file.
 
 ### Removed
 
+## 4.1.0
+
+### Changed
+
+- All current and future versions of src-cli from version 3.43.2 and up will now be available for installation via Homebrew in addition to the latest version. A specific version can be installed with the command `brew install sourcegraph/src-cli/src-cli@X.Y.Z`. [#864](https://github.com/sourcegraph/src-cli/pull/864)
+
 ## 4.0.1
 
 ### Added
 
-- Mounting files now works when running batch changes server side. [sourcegraph/src-cli#816](https://github.com/sourcegraph/src-cli/pull/816)
+- Mounting files now works when running batch changes server side. [#816](https://github.com/sourcegraph/src-cli/pull/816)
 
 ## 4.0.0
 
@@ -139,7 +145,7 @@ All notable changes to `src-cli` are documented in this file.
 
 ### Fixed
 
-- Global git email gets inserted as plain text when running `src batch new -f <file_name>` and doesn't result in a schema validation failure. [sourcegraph/src-cli#773](https://github.com/sourcegraph/src-cli/pull/773)
+- Global git email gets inserted as plain text when running `src batch new -f <file_name>` and doesn't result in a schema validation failure. [#773](https://github.com/sourcegraph/src-cli/pull/773)
 
 ## 3.40.8
 
@@ -155,7 +161,7 @@ All notable changes to `src-cli` are documented in this file.
 
 ### Added
 
-- It's now possible to install src-cli via `npm install -g @sourcegraph/src`. [sourcegraph/src-cli#760](https://github.com/sourcegraph/src-cli/pull/760)
+- It's now possible to install src-cli via `npm install -g @sourcegraph/src`. [#760](https://github.com/sourcegraph/src-cli/pull/760)
 
 ## 3.40.3
 


### PR DESCRIPTION
We didn't have any feature changes/fixes for 4.1, but the Homebrew install availability is kinda a change so I decided to put that! We had a similar entry for when src-cli became available on npm.

### Test plan

Just docs change.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
