### PR TITLE
temp: only trigger release workflow on explicit bad tag

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -2,8 +2,8 @@ name: Build and Release
 
 on:
   push:
-    tags:	
-      - '*'
+    tags:
+      - 'DO-NOT-PUSH-ME'
 
 # There are two cases where this GitHub action will run:
 #


### PR DESCRIPTION
For https://github.com/sourcegraph/src-cli/issues/878.

Releasing src-cli today didn't go exactly as planned because the action found the wrong tag for the most recent one. It turns out the way the src-cli repo is cloned into the container for the first job, it changes the git tag `taggerdate`s, so `git tag --sort=taggerdate` isn't a reliable sort mechanism for getting the most recent tag.

I should be able to fix this by using a GitHub environment variable that is available during the action , but I can only test it by pushing more tags. Thus, my plan to fix this up is as follows:

1. Merge this PR, which disables this action from running except when if the tag "DO-NOT-PUSH-ME" is pushed. This enables me to push test tags and delete them later, without triggering new releases. I already manually finished the release for src-cli 4.1.0, so there shouldn't be any need to push a legitimate real tag in the meantime.
2. Push up a branch that sets `most_recent_tag` with the GitHub environment variable, and disables the rest of the release workflow except the first job that determines the release type
3. Create a temporary test tag for 4.1.1 on that commit and trigger the workflow
4. Verify the correct most recent version is set and the release type is flagged as new latest rather than patch


### Test plan

Described above.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
