### PR TITLE
src migrate early WIP

### DIFF
--- a/cmd/src/migrate.go
+++ b/cmd/src/migrate.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+type genericData struct {
+	data []byte
+	err  error
+}
+
+func runDockerCommand(ctx context.Context, cmd string, args ...string) *genericData {
+	f := &genericData{}
+
+	f.data, f.err = exec.Command(cmd, args...).CombinedOutput()
+	if f.err != nil {
+		f.err = errors.Wrapf(f.err, "executing command: %s %s: received error: %s", cmd, strings.Join(args, " "), f.data)
+	}
+	return f
+}
+
+func init() {
+	usage := `'src migrate' helps you migrate your sourcegraph data to another instance.
+
+Usage:
+
+    TBD
+
+Examples:
+
+	TBD
+`
+
+	var container string
+	var outputPath string
+
+	flagSet := flag.NewFlagSet("migrate", flag.ExitOnError)
+	flagSet.StringVar(&container, "c", "", "The container to target")
+	flagSet.StringVar(&outputPath, "o", "", "The path for the output file")
+
+	handler := func(args []string) error {
+		fmt.Fprintf(flag.CommandLine.Output(), "From container: %s'", container)
+
+		// init context
+		ctx := context.Background()
+
+		data := runDockerCommand(
+			ctx,
+			"docker", "exec", container, "sh", "-c", "'pg_dump -C --username=postgres sourcegraph' > "+outputPath,
+		)
+		if data.err != nil {
+			fmt.Println("Error:", data.err)
+		}
+
+		return nil
+	}
+
+	// Register the command.
+	commands = append(commands, &command{
+		flagSet: flagSet,
+		aliases: []string{"migrate"},
+		handler: handler,
+		usageFunc: func() {
+			fmt.Println(usage)
+		},
+	})
+}


### PR DESCRIPTION
## Description

This PR is not to merge, just to add some context around this branch in case it's useful.

[Link to RFC](https://docs.google.com/document/d/1ldJ0WHnUGtPE3myrKak_bl1zm4V_1jLKI6gui4JVbW0/edit#heading=h.trqab8y0kufp)
[Link to Slack thread with customer interest](https://sourcegraph.slack.com/archives/C0B2RU51Q/p1665088934178309)

I used [this view on Looker](https://sourcegraph.looker.com/looks/436) to determine what sort of deployment the interested customers are using. Found it was mostly kubernetes, but also some docker compose, pure docker, and docker container deployments. I think it's important to understand where this tool needs to be run, and what kinds of differences there might be between deployments.

My plan was to use the `debug` tools (`debug-server`, `debug-compose`, `debug-kube`) to help serve as a template as to how to interact with the different types of deployments. I started with single docker since it was easy to run locally and seemed the most straight-forward to start with.

I didn't get very far with the implementation, and ran into an issue where it looks like `pg_dump` was not being found as a command. I was investigating how to fix that, but had not yet found a solution.

There is also the piece of uploading the output to the cloud, which I had not started on.

### Test plan

I was planning to do some similar testing as done in [this PR](https://github.com/sourcegraph/src-cli/pull/731) to do initial testing on a variety of environments. I think other useful environments to test on could be `k8s` and `s2`.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
