### PR TITLE
batches: improve handling of non-root steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,11 @@ All notable changes to `src-cli` are documented in this file.
 
 ### Added
 
+- Batch specs being run locally with `src batch preview` or `src batch apply` can now be run with the `-run-as-root` flag, which will run all step containers as root instead of the default user for the image. This is off by default. [#886](https://github.com/sourcegraph/src-cli/pull/886)
+
 ### Changed
+
+- Batch specs being run from the server using this version of `src-cli` now run all step containers as root, rather than as the default user for the image. [#886](https://github.com/sourcegraph/src-cli/pull/886)
 
 ### Fixed
 

--- a/cmd/src/batch_common.go
+++ b/cmd/src/batch_common.go
@@ -85,6 +85,7 @@ type batchExecuteFlags struct {
 	workspace     string
 	cleanArchives bool
 	skipErrors    bool
+	runAsRoot     bool
 
 	// EXPERIMENTAL
 	textOnly bool
@@ -151,6 +152,11 @@ func newBatchExecuteFlags(flagSet *flag.FlagSet, cacheDir, tempDir string) *batc
 	)
 
 	flagSet.BoolVar(verbose, "v", false, "print verbose output")
+
+	flagSet.BoolVar(
+		&caf.runAsRoot, "run-as-root", false,
+		"If true, forces all step containers to run as root.",
+	)
 
 	return caf
 }
@@ -382,6 +388,7 @@ func executeBatchSpec(ctx context.Context, ui ui.ExecUI, opts executeBatchSpecOp
 				Timeout:             opts.flags.timeout,
 				TempDir:             opts.flags.tempDir,
 				GlobalEnv:           os.Environ(),
+				ForceRoot:           opts.flags.runAsRoot,
 			},
 			Logger:    logManager,
 			Cache:     executor.NewDiskCache(opts.flags.cacheDir),

--- a/cmd/src/batch_exec.go
+++ b/cmd/src/batch_exec.go
@@ -33,6 +33,7 @@ const (
 type executorModeFlags struct {
 	timeout           time.Duration
 	file              string
+	runAsImageUser    bool
 	tempDir           string
 	repoDir           string
 	workspaceFilesDir string
@@ -42,6 +43,7 @@ func newExecutorModeFlags(flagSet *flag.FlagSet) (f *executorModeFlags) {
 	f = &executorModeFlags{}
 	flagSet.DurationVar(&f.timeout, "timeout", 60*time.Minute, "The maximum duration a single batch spec step can take.")
 	flagSet.StringVar(&f.file, "f", "", "The workspace execution input file to read.")
+	flagSet.BoolVar(&f.runAsImageUser, "run-as-image-user", false, "True to run step containers as the default image user; if false or omitted, containers are always run as root.")
 	flagSet.StringVar(&f.tempDir, "tmp", "", "Directory for storing temporary data.")
 	flagSet.StringVar(&f.repoDir, "repo", "", "Path of the checked out repo on disk.")
 	flagSet.StringVar(&f.workspaceFilesDir, "workspaceFiles", "", "Path of workspace files on disk.")
@@ -208,6 +210,7 @@ func executeBatchSpecInWorkspaces(ctx context.Context, flags *executorModeFlags)
 		GlobalEnv:        globalEnv,
 		RepoArchive:      &repozip.NoopArchive{},
 		UI:               taskExecUI.StepsExecutionUI(task),
+		ForceRoot:        !flags.runAsImageUser,
 	}
 	results, err := executor.RunSteps(ctx, opts)
 

--- a/internal/batches/executor/executor.go
+++ b/internal/batches/executor/executor.go
@@ -68,6 +68,7 @@ type NewExecutorOpts struct {
 	TempDir          string
 	IsRemote         bool
 	GlobalEnv        []string
+	ForceRoot        bool
 }
 
 type executor struct {
@@ -178,6 +179,7 @@ func (x *executor) do(ctx context.Context, task *Task, ui TaskExecutionUI) (err 
 		Timeout:          x.opts.Timeout,
 		RepoArchive:      repoArchive,
 		WorkingDirectory: x.opts.WorkingDirectory,
+		ForceRoot:        x.opts.ForceRoot,
 
 		UI: ui.StepsExecutionUI(task),
 	}

--- a/internal/batches/executor/run_steps.go
+++ b/internal/batches/executor/run_steps.go
@@ -51,6 +51,9 @@ type RunStepsOpts struct {
 	// GlobalEnv is the os.Environ() for the execution. We don't read from os.Environ()
 	// directly to allow injecting variables and hiding others.
 	GlobalEnv []string
+	// ForceRoot forces Docker containers to be run as root:root, rather than
+	// whatever the image's default user and group are.
+	ForceRoot bool
 }
 
 func RunSteps(ctx context.Context, opts *RunStepsOpts) (stepResults []execution.AfterStepResult, err error) {
@@ -316,6 +319,10 @@ func executeSingleStep(
 		"--workdir", scriptWorkDir,
 		"--mount", fmt.Sprintf("type=bind,source=%s,target=%s,ro", runScriptFile, containerTemp),
 	}, workspaceOpts...)
+
+	if opts.ForceRoot {
+		args = append(args, "--user", "0:0")
+	}
 
 	for target, source := range filesToMount {
 		args = append(args, "--mount", fmt.Sprintf("type=bind,source=%s,target=%s,ro", source.Name(), target))


### PR DESCRIPTION
This changes the default for `src batch exec` (used by SSBC) to run all step containers as root, and adds a flag to `src batch apply` and `src batch preview` to optionally do the same thing.

Fixes sourcegraph/sourcegraph#41836.

### Test plan

Tested with client and server side batch changes and a batch spec that outputs `id` into a file, with a container image that does not run as root by default (specifically, `haproxy:alpine`).