### PR TITLE
snapshot: add 'snapshot summary', 'snapshot test'

### DIFF
--- a/cmd/src/snapshot.go
+++ b/cmd/src/snapshot.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+)
+
+var snapshotCommands commander
+
+func init() {
+	usage := `'src snapshot' manages snapshots of Sourcegraph instance data. All subcommands are currently EXPERIMENTAL.
+
+USAGE
+	src [-v] snapshot <command>
+
+COMMANDS
+
+	summary   export summary data about an instance for acceptance testing of a restored Sourcegraph instance
+	test      use exported summary data and instance health indicators to validate a restored and upgraded instance
+`
+	flagSet := flag.NewFlagSet("snapshot", flag.ExitOnError)
+
+	commands = append(commands, &command{
+		flagSet: flagSet,
+		handler: func(args []string) error {
+			snapshotCommands.run(flagSet, "src snapshot", usage, args)
+			return nil
+		},
+		usageFunc: func() { fmt.Fprint(flag.CommandLine.Output(), usage) },
+	})
+}

--- a/cmd/src/snapshot_summary.go
+++ b/cmd/src/snapshot_summary.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/output"
+
+	"github.com/sourcegraph/src-cli/internal/api"
+)
+
+func init() {
+	usage := `'src snapshot summary' generates summary data for acceptance testing of a restored Sourcegraph instance with 'src snapshot test'.
+
+USAGE
+	src login # site-admin authentication required
+	src [-v] snapshot summary [-summary-path="./src-snapshot-summary.json"]
+`
+	flagSet := flag.NewFlagSet("summary", flag.ExitOnError)
+	snapshotPath := flagSet.String("summary-path", "./src-snapshot-summary.json", "path to write snapshot summary to")
+	apiFlags := api.NewFlags(flagSet)
+
+	snapshotCommands = append(snapshotCommands, &command{
+		flagSet: flagSet,
+		handler: func(args []string) error {
+			if err := flagSet.Parse(args); err != nil {
+				return err
+			}
+			out := output.NewOutput(flagSet.Output(), output.OutputOpts{Verbose: *verbose})
+
+			client := cfg.apiClient(apiFlags, flagSet.Output())
+
+			snapshotResult, err := fetchSnapshotSummary(context.Background(), client)
+			if err != nil {
+				return err
+			}
+
+			f, err := os.OpenFile(*snapshotPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.ModePerm)
+			if err != nil {
+				return errors.Wrap(err, "open snapshot file")
+			}
+			enc := json.NewEncoder(f)
+			enc.SetIndent("", "\t")
+			if err := enc.Encode(snapshotResult); err != nil {
+				return errors.Wrap(err, "write snapshot file")
+			}
+
+			out.WriteLine(output.Emoji(output.EmojiSuccess, "Summary snapshot data generated!"))
+			return nil
+		},
+		usageFunc: func() { fmt.Fprint(flag.CommandLine.Output(), usage) },
+	})
+}
+
+type snapshotSummary struct {
+	ExternalServices struct {
+		TotalCount int
+		Nodes      []struct {
+			Kind string
+			ID   string
+		}
+	}
+	Site struct {
+		AuthProviders struct {
+			TotalCount int
+			Nodes      []struct {
+				ServiceType string
+				ServiceID   string
+			}
+		}
+	}
+}
+
+func fetchSnapshotSummary(ctx context.Context, client api.Client) (*snapshotSummary, error) {
+	var snapshotResult snapshotSummary
+	ok, err := client.NewQuery(`
+		query GenerateSnapshotAcceptanceData {
+			externalServices {
+				totalCount
+				nodes {
+					kind
+					id
+				}
+			}
+			site {
+				authProviders {
+					totalCount
+					nodes {
+						serviceType
+						serviceID
+					}
+				}
+			}
+		}
+	`).Do(ctx, &snapshotResult)
+	if err != nil {
+		return nil, errors.Wrap(err, "generate snapshot")
+	} else if !ok {
+		return nil, errors.New("received no data")
+	}
+	return &snapshotResult, nil
+}

--- a/cmd/src/snapshot_testcmd.go
+++ b/cmd/src/snapshot_testcmd.go
@@ -66,12 +66,12 @@ USAGE
 			}
 
 			// generate checks set
-			checks := instancehealth.NewChecks(out, *since, *instanceHealth)
+			checks := instancehealth.NewChecks(*since, *instanceHealth)
 
 			// Run checks
 			var validationErrors error
 			for _, check := range checks {
-				validationErrors = errors.Append(validationErrors, check())
+				validationErrors = errors.Append(validationErrors, check(out))
 			}
 			if validationErrors != nil {
 				out.WriteLine(output.Linef(output.EmojiFailure, output.StyleFailure,

--- a/cmd/src/snapshot_testcmd.go
+++ b/cmd/src/snapshot_testcmd.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/output"
+
+	"github.com/sourcegraph/src-cli/internal/api"
+	"github.com/sourcegraph/src-cli/internal/instancehealth"
+)
+
+// note that this file is called '_testcmd.go' because '_test.go' cannot be used
+
+func init() {
+	usage := `'src snapshot test' uses exported summary data to validate a restored and upgraded instance.
+
+USAGE
+	src login # site-admin authentication required
+	src [-v] snapshot test [-summary-path="./src-snapshot-summary.json"]
+`
+	flagSet := flag.NewFlagSet("test", flag.ExitOnError)
+	snapshotSummaryPath := flagSet.String("summary-path", "./src-snapshot-summary.json", "path to read snapshot summary from")
+	since := flagSet.Duration("since", 1*time.Hour, "duration ago to look for healthcheck data")
+	apiFlags := api.NewFlags(flagSet)
+
+	snapshotCommands = append(snapshotCommands, &command{
+		flagSet: flagSet,
+		handler: func(args []string) error {
+			if err := flagSet.Parse(args); err != nil {
+				return err
+			}
+			out := output.NewOutput(flagSet.Output(), output.OutputOpts{Verbose: *verbose})
+			client := cfg.apiClient(apiFlags, flagSet.Output())
+
+			// Fetch health data
+			instanceHealth, err := instancehealth.GetIndicators(context.Background(), client)
+			if err != nil {
+				return err
+			}
+
+			// Optionally validate snapshots
+			if *snapshotSummaryPath != "" {
+				f, err := os.OpenFile(*snapshotSummaryPath, os.O_RDONLY, os.ModePerm)
+				if err != nil {
+					return errors.Wrap(err, "open snapshot file")
+				}
+				var recordedSummary snapshotSummary
+				if err := json.NewDecoder(f).Decode(&recordedSummary); err != nil {
+					return errors.Wrap(err, "read snapshot file")
+				}
+				// Fetch new snapshot
+				newSummary, err := fetchSnapshotSummary(context.Background(), client)
+				if err != nil {
+					return errors.Wrap(err, "get snapshot")
+				}
+				if err := compareSnapshotSummaries(out, recordedSummary, *newSummary); err != nil {
+					return err
+				}
+			}
+
+			// generate checks set
+			checks := instancehealth.NewChecks(out, *since, *instanceHealth)
+
+			// Run checks
+			var validationErrors error
+			for _, check := range checks {
+				validationErrors = errors.Append(validationErrors, check())
+			}
+			if validationErrors != nil {
+				out.WriteLine(output.Linef(output.EmojiFailure, output.StyleFailure,
+					"Critical issues found: %s", err.Error()))
+				return errors.New("validation failed")
+			}
+			out.WriteLine(output.Line(output.EmojiSuccess, output.StyleSuccess,
+				"No critical issues found!"))
+			return nil
+		},
+		usageFunc: func() { fmt.Fprint(flag.CommandLine.Output(), usage) },
+	})
+}
+
+func compareSnapshotSummaries(out *output.Output, recordedSummary, newSummary snapshotSummary) error {
+	b := out.Block(output.Styled(output.StyleBold, "Snapshot contents"))
+	defer b.Close()
+
+	// Compare
+	diff := cmp.Diff(recordedSummary, newSummary)
+	if diff != "" {
+		b.WriteLine(output.Line(output.EmojiFailure, output.StyleFailure, "Snapshot diff detected:"))
+		b.WriteCode("diff", diff)
+		return errors.New("snapshot mismatch")
+	}
+	b.WriteLine(output.Emoji(output.EmojiSuccess, "Snapshots match!"))
+	return nil
+}

--- a/internal/instancehealth/checks.go
+++ b/internal/instancehealth/checks.go
@@ -17,32 +17,31 @@ import (
 // Each test errors with only a brief summary of what went wrong, and only if
 // the error is critical. Detailed output should be written to out.
 func NewChecks(
-	out *output.Output,
 	since time.Duration,
 	instanceHealth Summary,
-) []func() error {
-	return []func() error{
-		func() error {
+) []func(out *output.Output) error {
+	return []func(out *output.Output) error{
+		func(out *output.Output) error {
 			b := out.Block(output.Styled(output.StyleBold, "Site alerts"))
 			defer b.Close()
 			return checkSiteAlerts(b, instanceHealth)
 		},
-		func() error {
+		func(out *output.Output) error {
 			b := out.Block(output.Styled(output.StyleBold, "Site configuration"))
 			defer b.Close()
 			return checkSiteConfiguration(b, instanceHealth)
 		},
-		func() error {
+		func(out *output.Output) error {
 			b := out.Block(output.Styled(output.StyleBold, "Monitoring alerts"))
 			defer b.Close()
 			return checkMonitoringAlerts(b, since, instanceHealth)
 		},
-		func() error {
+		func(out *output.Output) error {
 			b := out.Block(output.Styled(output.StyleBold, "External services"))
 			defer b.Close()
 			return checkExternalServices(b, since, instanceHealth)
 		},
-		func() error {
+		func(out *output.Output) error {
 			b := out.Block(output.Styled(output.StyleBold, "Permissions syncing"))
 			defer b.Close()
 			return checkPermissionsSyncing(b, since, instanceHealth)

--- a/internal/instancehealth/checks.go
+++ b/internal/instancehealth/checks.go
@@ -18,7 +18,7 @@ import (
 // the error is critical. Detailed output should be written to out.
 func NewChecks(
 	since time.Duration,
-	instanceHealth Summary,
+	instanceHealth Indicators,
 ) []func(out *output.Output) error {
 	return []func(out *output.Output) error{
 		func(out *output.Output) error {
@@ -52,7 +52,7 @@ func NewChecks(
 // checkSiteAlerts indicates if there are any alerts issued by the application
 func checkSiteAlerts(
 	out output.Writer,
-	instanceHealth Summary,
+	instanceHealth Indicators,
 ) error {
 	if len(instanceHealth.Site.Alerts) > 0 {
 		out.WriteLine(output.Linef(output.EmojiWarning, output.StyleWarning,
@@ -70,7 +70,7 @@ func checkSiteAlerts(
 // configuration validation
 func checkSiteConfiguration(
 	out output.Writer,
-	instanceHealth Summary,
+	instanceHealth Indicators,
 ) error {
 	if len(instanceHealth.Site.Configuration.ValidationMessages) > 0 {
 		out.WriteLine(output.Linef(output.EmojiWarning, output.StyleWarning,
@@ -90,7 +90,7 @@ func checkSiteConfiguration(
 func checkMonitoringAlerts(
 	out output.Writer,
 	since time.Duration,
-	instanceHealth Summary,
+	instanceHealth Indicators,
 ) error {
 	var criticalAlerts int
 	for _, a := range instanceHealth.Site.MonitoringStatistics.Alerts {
@@ -117,7 +117,7 @@ func checkMonitoringAlerts(
 func checkExternalServices(
 	out output.Writer,
 	since time.Duration,
-	instanceHealth Summary,
+	instanceHealth Indicators,
 ) error {
 	if len(instanceHealth.ExternalServices.Nodes) == 0 {
 		out.WriteLine(output.Linef(output.EmojiWarning, output.StyleWarning,
@@ -162,7 +162,7 @@ func checkExternalServices(
 func checkPermissionsSyncing(
 	out output.Writer,
 	since time.Duration,
-	instanceHealth Summary,
+	instanceHealth Indicators,
 ) error {
 	var syncCount int
 	var syncErrors []string

--- a/internal/instancehealth/checks.go
+++ b/internal/instancehealth/checks.go
@@ -1,0 +1,232 @@
+package instancehealth
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/output"
+)
+
+// NewChecks returns a set of checks against the given inputs to validate the
+// health of a Sourcegraph application. It is designed primarily to validate
+// information that can be provided via the GraphQL API - see GetSummary for
+// more details.
+//
+// Each test errors with only a brief summary of what went wrong, and only if
+// the error is critical. Detailed output should be written to out.
+func NewChecks(
+	out *output.Output,
+	since time.Duration,
+	instanceHealth Summary,
+) []func() error {
+	return []func() error{
+		func() error {
+			b := out.Block(output.Styled(output.StyleBold, "Site alerts"))
+			defer b.Close()
+			return checkSiteAlerts(b, instanceHealth)
+		},
+		func() error {
+			b := out.Block(output.Styled(output.StyleBold, "Site configuration"))
+			defer b.Close()
+			return checkSiteConfiguration(b, instanceHealth)
+		},
+		func() error {
+			b := out.Block(output.Styled(output.StyleBold, "Monitoring alerts"))
+			defer b.Close()
+			return checkMonitoringAlerts(b, since, instanceHealth)
+		},
+		func() error {
+			b := out.Block(output.Styled(output.StyleBold, "External services"))
+			defer b.Close()
+			return checkExternalServices(b, since, instanceHealth)
+		},
+		func() error {
+			b := out.Block(output.Styled(output.StyleBold, "Permissions syncing"))
+			defer b.Close()
+			return checkPermissionsSyncing(b, since, instanceHealth)
+		},
+	}
+}
+
+// checkSiteAlerts indicates if there are any alerts issued by the application
+func checkSiteAlerts(
+	out output.Writer,
+	instanceHealth Summary,
+) error {
+	if len(instanceHealth.Site.Alerts) > 0 {
+		out.WriteLine(output.Linef(output.EmojiWarning, output.StyleWarning,
+			"Found site-level alerts:"))
+		for _, a := range instanceHealth.Site.Alerts {
+			out.Writef("\t%s: %q", a.Type, a.Message)
+		}
+		return errors.New("site-level alerts")
+	}
+	out.WriteLine(output.Emoji(output.EmojiSuccess, "No site-level alerts!"))
+	return nil
+}
+
+// checkSiteAlerts indicates if there are any alerts issued by the application regarding
+// configuration validation
+func checkSiteConfiguration(
+	out output.Writer,
+	instanceHealth Summary,
+) error {
+	if len(instanceHealth.Site.Configuration.ValidationMessages) > 0 {
+		out.WriteLine(output.Linef(output.EmojiWarning, output.StyleWarning,
+			"Found configuration validation alerts:"))
+		for _, m := range instanceHealth.Site.Configuration.ValidationMessages {
+			out.Writef("\t%s", m)
+		}
+	} else {
+		out.WriteLine(output.Emoji(output.EmojiSuccess, "No site configuration issues!"))
+	}
+	// never error, just issue printed warning, since the application should still work
+	// even with validation messages
+	return nil
+}
+
+// checkMonitoringAlerts indicates if there are any alerts issued by monitoring infra
+func checkMonitoringAlerts(
+	out output.Writer,
+	since time.Duration,
+	instanceHealth Summary,
+) error {
+	var criticalAlerts int
+	for _, a := range instanceHealth.Site.MonitoringStatistics.Alerts {
+		if a.Average == 0 || !strings.Contains(strings.ToLower(a.Name), "critical") {
+			continue
+		}
+		// average is ratio of 12h windows that alert was active, so we set the threshold
+		// if it's possible this alert could have been active in this 'since' window.
+		if a.Average*0.5 >= since.Hours()/12 {
+			criticalAlerts += 1
+			out.WriteLine(output.Linef(output.EmojiWarning, output.StyleWarning,
+				"Found recently active alert: %q", a.Name))
+		}
+	}
+	if criticalAlerts == 0 {
+		out.WriteLine(output.Emoji(output.EmojiSuccess, "No critical monitoring alerts!"))
+	}
+	// never error, just issue printed warning, since critical alerts aren't all _that_
+	// reliable today, though they provide a potentially useful signal.
+	return nil
+}
+
+// checkExternalServices checks the health of external service syncing
+func checkExternalServices(
+	out output.Writer,
+	since time.Duration,
+	instanceHealth Summary,
+) error {
+	if len(instanceHealth.ExternalServices.Nodes) == 0 {
+		out.WriteLine(output.Linef(output.EmojiWarning, output.StyleWarning,
+			"No external services found"))
+		return nil
+	}
+
+	var hasExtsvcIssue bool
+	for _, extsvc := range instanceHealth.ExternalServices.Nodes {
+		var jobCount int
+		for _, job := range extsvc.SyncJobs.Nodes {
+			if job.FinishedAt.Before(time.Now().Add(-since)) {
+				continue
+			}
+			jobCount++
+		}
+
+		if extsvc.LastSyncError != nil {
+			hasExtsvcIssue = true
+			out.WriteLine(output.Linef(output.EmojiFailure, output.StyleFailure,
+				"External service %s %q encountered sync error: %q",
+				extsvc.Kind, extsvc.ID, *extsvc.LastSyncError))
+		} else if jobCount == 0 {
+			// not critical, this is somewhat normal behaviour
+			out.WriteLine(output.Linef(output.EmojiInfo, output.StyleSuggestion,
+				"External service %s %q had no sync jobs in last %s",
+				extsvc.Kind, extsvc.ID, since.String()))
+		} else {
+			out.WriteLine(output.Emojif(output.EmojiSuccess,
+				"External service %s %q healthy",
+				extsvc.Kind, extsvc.ID))
+		}
+	}
+	if hasExtsvcIssue {
+		return errors.New("encountered external service issues")
+	}
+	out.WriteLine(output.Emoji(output.EmojiSuccess, "No external service issues!"))
+	return nil
+}
+
+// checkPermissionsSyncing checks the health of permissions syncing
+func checkPermissionsSyncing(
+	out output.Writer,
+	since time.Duration,
+	instanceHealth Summary,
+) error {
+	var syncCount int
+	var syncErrors []string
+	var seenProviders = make(map[string]map[string]string) // provider : state : message
+	for _, sync := range instanceHealth.PermissionsSyncJobs.Nodes {
+		if sync.CompletedAt.Before(time.Now().Add(-since)) {
+			continue
+		}
+		syncCount += 1
+		if sync.Status == "ERROR" {
+			syncErrors = append(syncErrors, sync.Message)
+		}
+		for _, p := range sync.Providers {
+			key := fmt.Sprintf("%s - %s", p.Type, p.ID)
+			if _, ok := seenProviders[key]; !ok {
+				seenProviders[key] = make(map[string]string)
+			}
+			// Just track one message per state for reference
+			seenProviders[key][p.Status] = p.Message
+		}
+	}
+
+	if syncCount == 0 {
+		out.WriteLine(output.Linef(output.EmojiWarning, output.StyleWarning,
+			"No permissions sync jobs since %s ago", since.String()))
+		return nil // there may be no permissions sync configured
+	}
+
+	// Summarize results by provider
+	if len(seenProviders) == 0 {
+		out.WriteLine(output.Linef(output.EmojiWarning, output.StyleWarning,
+			"No authz providers running since %s ago", since.String()))
+	} else {
+		for key, messages := range seenProviders {
+			for state := range messages {
+				switch state {
+				case "SUCCESS":
+					out.WriteLine(output.Emojif(output.EmojiSuccess,
+						"Authz provider %q healthy", key))
+				default:
+					out.WriteLine(output.Linef(output.EmojiWarning, output.StyleWarning,
+						"Authz provider %q state %s: %q", key, state, messages[state]))
+				}
+			}
+		}
+	}
+
+	// Note if syncing is failing
+	if len(syncErrors) > 0 {
+		out.WriteLine(output.Linef(output.EmojiFailure, output.StyleFailure,
+			"Encountered permissions sync errors:"))
+		for i, msg := range syncErrors {
+			out.Writef("\t%q", msg)
+			if i > 3 && len(syncErrors)-i > 0 {
+				out.Writef("\t... %d more", len(syncErrors)-i)
+				break
+			}
+		}
+		return errors.New("permissions sync errors")
+	} else if syncCount > 0 {
+		out.WriteLine(output.Emoji(output.EmojiSuccess,
+			"Permissions syncing healthy!"))
+	}
+
+	return nil
+}

--- a/internal/instancehealth/checks_test.go
+++ b/internal/instancehealth/checks_test.go
@@ -1,0 +1,85 @@
+package instancehealth
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/lib/output"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// run with -v for output
+func TestCheckPermissionsSyncing(t *testing.T) {
+	for _, tt := range []struct {
+		name           string
+		instanceHealth Summary
+
+		wantEmojis []string
+		wantErr    string
+	}{{
+		name: "no jobs",
+		instanceHealth: Summary{
+			PermissionsSyncJobs: struct{ Nodes []permissionsSyncJob }{
+				Nodes: nil,
+			},
+		},
+		wantEmojis: []string{output.EmojiWarning},
+		wantErr:    "",
+	}, {
+		name: "healthy",
+		instanceHealth: Summary{
+			PermissionsSyncJobs: struct{ Nodes []permissionsSyncJob }{
+				Nodes: []permissionsSyncJob{{
+					CompletedAt: time.Now(),
+					Status:      "SUCCESS",
+					Providers: []permissionsProviderStatus{{
+						Type:   "github",
+						ID:     "https://github.com/",
+						Status: "SUCCESS",
+					}},
+				}},
+			},
+		},
+		wantEmojis: []string{output.EmojiSuccess},
+		wantErr:    "",
+	}, {
+		name: "unhealthy",
+		instanceHealth: Summary{
+			PermissionsSyncJobs: struct{ Nodes []permissionsSyncJob }{
+				Nodes: []permissionsSyncJob{{
+					CompletedAt: time.Now(),
+					Status:      "ERROR",
+					Message:     "oh no!",
+					Providers: []permissionsProviderStatus{{
+						Type:   "github",
+						ID:     "https://github.com/",
+						Status: "ERROR",
+					}},
+				}},
+			},
+		},
+		wantEmojis: []string{output.EmojiFailure},
+		wantErr:    "permissions sync errors",
+	}} {
+		t.Run(tt.name, func(t *testing.T) {
+			var out bytes.Buffer
+			err := checkPermissionsSyncing(output.NewOutput(io.MultiWriter(os.Stderr, &out), output.OutputOpts{}), time.Hour, tt.instanceHealth)
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			}
+			if len(tt.wantEmojis) > 0 {
+				data := out.String()
+				for _, emoji := range tt.wantEmojis {
+					assert.Contains(t, data, emoji)
+				}
+			}
+		})
+	}
+}

--- a/internal/instancehealth/checks_test.go
+++ b/internal/instancehealth/checks_test.go
@@ -16,13 +16,13 @@ import (
 func TestCheckPermissionsSyncing(t *testing.T) {
 	for _, tt := range []struct {
 		name           string
-		instanceHealth Summary
+		instanceHealth Indicators
 
 		wantEmojis []string
 		wantErr    string
 	}{{
 		name: "no jobs",
-		instanceHealth: Summary{
+		instanceHealth: Indicators{
 			PermissionsSyncJobs: struct{ Nodes []permissionsSyncJob }{
 				Nodes: nil,
 			},
@@ -31,7 +31,7 @@ func TestCheckPermissionsSyncing(t *testing.T) {
 		wantErr:    "",
 	}, {
 		name: "healthy",
-		instanceHealth: Summary{
+		instanceHealth: Indicators{
 			PermissionsSyncJobs: struct{ Nodes []permissionsSyncJob }{
 				Nodes: []permissionsSyncJob{{
 					CompletedAt: time.Now(),
@@ -48,7 +48,7 @@ func TestCheckPermissionsSyncing(t *testing.T) {
 		wantErr:    "",
 	}, {
 		name: "unhealthy",
-		instanceHealth: Summary{
+		instanceHealth: Indicators{
 			PermissionsSyncJobs: struct{ Nodes []permissionsSyncJob }{
 				Nodes: []permissionsSyncJob{{
 					CompletedAt: time.Now(),

--- a/internal/instancehealth/summary.go
+++ b/internal/instancehealth/summary.go
@@ -9,7 +9,9 @@ import (
 	"github.com/sourcegraph/src-cli/internal/api"
 )
 
-type Summary struct {
+// Indicators are values from the Sourcegraph GraphQL API that help indicate the health of
+// and instance.
+type Indicators struct {
 	Site struct {
 		Configuration struct {
 			ValidationMessages []string
@@ -59,8 +61,8 @@ type permissionsProviderStatus struct {
 
 // GetIndicators retrieves summary data from a Sourcegraph instance's GraphQL API for
 // assessing instance health.
-func GetIndicators(ctx context.Context, client api.Client) (*Summary, error) {
-	var instanceHealth Summary
+func GetIndicators(ctx context.Context, client api.Client) (*Indicators, error) {
+	var instanceHealth Indicators
 	ok, err := client.NewQuery(`
 		query InstanceHealthSummary {
 			site {

--- a/internal/instancehealth/summary.go
+++ b/internal/instancehealth/summary.go
@@ -1,0 +1,117 @@
+package instancehealth
+
+import (
+	"context"
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+
+	"github.com/sourcegraph/src-cli/internal/api"
+)
+
+type Summary struct {
+	Site struct {
+		Configuration struct {
+			ValidationMessages []string
+		}
+		Alerts []struct {
+			Type    string
+			Message string
+		}
+		MonitoringStatistics struct {
+			Alerts []struct {
+				Name    string
+				Average float64
+			}
+		}
+	}
+	ExternalServices struct {
+		Nodes []struct {
+			Kind          string
+			ID            string
+			LastSyncError *string
+			SyncJobs      struct {
+				Nodes []struct {
+					State      string
+					FinishedAt time.Time
+				}
+			}
+		}
+	}
+	PermissionsSyncJobs struct {
+		Nodes []permissionsSyncJob
+	}
+}
+
+type permissionsSyncJob struct {
+	Status      string
+	Message     string
+	CompletedAt time.Time
+	Providers   []permissionsProviderStatus
+}
+
+type permissionsProviderStatus struct {
+	Type    string
+	ID      string
+	Status  string
+	Message string
+}
+
+// GetIndicators retrieves summary data from a Sourcegraph instance's GraphQL API for
+// assessing instance health.
+func GetIndicators(ctx context.Context, client api.Client) (*Summary, error) {
+	var instanceHealth Summary
+	ok, err := client.NewQuery(`
+		query InstanceHealthSummary {
+			site {
+				configuration {
+					validationMessages
+				}
+				alerts {
+					type
+					message
+				}
+				monitoringStatistics(days:1) {
+					alerts {
+						name
+						average
+					}
+				}
+			}
+
+			externalServices {
+				nodes {
+					kind
+					id
+					lastSyncError
+					syncJobs(first:100) {
+						nodes {
+							state
+							finishedAt
+						}
+					}
+				}
+			}
+
+			permissionsSyncJobs(first:500) {
+				nodes {
+					status
+					completedAt
+					message
+					providers {
+						type
+						id
+						status
+						message
+					}
+				}
+			}
+		}
+	`).Do(ctx, &instanceHealth)
+	if err != nil {
+		return nil, errors.Wrap(err, "get health data")
+	} else if !ok {
+		return nil, errors.New("received no data")
+	}
+	return &instanceHealth, nil
+}


### PR DESCRIPTION
These commands are tooling intended for use in on-prem-to-Cloud data migrations:

- `src snapshot summary` will generate a summary snapshot of an instance. APIs used here must be available in Sourcegraph 3.20 and later - see [RFC 760](https://docs.google.com/document/d/1IAgXmv2TbtU_rWXtph-KFc3qbqswREIAxO1rGALuoMQ/edit#bookmark=id.bc627wcztve6)
- `src snapshot test` will use the summary and other health indicators to try and show that the instance is healthy and in an expected state post-migration. APIs used here can be in the latest releases of Sourcegraph, because we will run a multi-version upgrade in Cloud to the latest version.
   - The instance health checking components of this can in the future be re-used in a different command

Closes https://github.com/sourcegraph/customer/issues/1612 , closes https://github.com/sourcegraph/customer/issues/1619

Also part of this tooling eventually will be other user-facing utilities like:

1. database dumping for common deployment setups
2. database dump and summary upload utilities to Sourcegraph-controlled GCS buckets

See https://github.com/sourcegraph/customer/issues/1525 for more details

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->

<img width="702" alt="image" src="https://user-images.githubusercontent.com/23356519/204053971-26a24f2c-653b-4f62-b490-34cf3ac79d92.png">

plus a wee bit of unit tests.