### PR TITLE
snapshot: trim extension statements from pgdump when uploading

### DIFF
--- a/internal/pgdump/extensions.go
+++ b/internal/pgdump/extensions.go
@@ -4,6 +4,8 @@ import (
 	"bufio"
 	"bytes"
 	"io"
+
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 // PartialCopyWithoutExtensions will perform a partial copy of a SQL database dump from
@@ -17,23 +19,24 @@ import (
 // Filtering requires reading entire lines into memory - this can be a very expensive
 // operation, so when filtering is complete the more efficient io.Copy should be used
 // to perform the remainder of the copy from src to dst.
-func PartialCopyWithoutExtensions(dst io.Writer, src io.ReadSeeker, progressFn func(int64)) (written int64, err error) {
+func PartialCopyWithoutExtensions(dst io.Writer, src io.ReadSeeker, progressFn func(int64)) (int64, error) {
 	var (
 		reader = bufio.NewReader(src)
 		// position we have consumed up to, track separately because bufio.Reader may have
 		// read ahead on src. This allows us to reset src later.
 		consumed int64
+		// number of bytes we have actually written to dst - it should always be returned.
+		written int64
 		// set to true when we have done all our filtering
 		noMoreExtensions bool
 	)
 
 	for !noMoreExtensions {
 		// Read up to a line, keeping track of our position in src
-		var line []byte
-		line, err = reader.ReadBytes('\n')
+		line, err := reader.ReadBytes('\n')
 		consumed += int64(len(line))
 		if err != nil {
-			return
+			return written, err
 		}
 
 		// Once we start seeing table creations, we are definitely done with extensions,
@@ -47,17 +50,18 @@ func PartialCopyWithoutExtensions(dst io.Writer, src io.ReadSeeker, progressFn f
 		}
 
 		// Write this line and update our progress before returning on error
-		var lineWritten int
-		lineWritten, err = dst.Write(line)
+		lineWritten, err := dst.Write(line)
 		written += int64(lineWritten)
 		progressFn(written)
 		if err != nil {
-			return
+			return written, err
 		}
 	}
 
 	// No more extensions - reset src to the last actual consumed position
-	_, err = src.Seek(consumed, io.SeekStart)
-
-	return
+	_, err := src.Seek(consumed, io.SeekStart)
+	if err != nil {
+		return written, errors.Wrap(err, "reset src position")
+	}
+	return written, nil
 }

--- a/internal/pgdump/extensions.go
+++ b/internal/pgdump/extensions.go
@@ -1,0 +1,63 @@
+package pgdump
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+)
+
+// PartialCopyWithoutExtensions will perform a partial copy of a SQL database dump from
+// src to dst while commenting out EXTENSIONs-related statements. When it determines there
+// are no more EXTENSIONs-related statements, it will return, resetting src to the position
+// of the last contents written to dst.
+//
+// This is needed for import to Google Cloud Storage, which does not like many EXTENSION
+// statements. For more details, see https://cloud.google.com/sql/docs/postgres/import-export/import-export-dmp
+//
+// Filtering requires reading entire lines into memory - this can be a very expensive
+// operation, so when filtering is complete the more efficient io.Copy should be used
+// to perform the remainder of the copy from src to dst.
+func PartialCopyWithoutExtensions(dst io.Writer, src io.ReadSeeker, progressFn func(int64)) (written int64, err error) {
+	var (
+		reader = bufio.NewReader(src)
+		// position we have consumed up to, track separately because bufio.Reader may have
+		// read ahead on src. This allows us to reset src later.
+		consumed int64
+		// set to true when we have done all our filtering
+		noMoreExtensions bool
+	)
+
+	for !noMoreExtensions {
+		// Read up to a line, keeping track of our position in src
+		var line []byte
+		line, err = reader.ReadBytes('\n')
+		consumed += int64(len(line))
+		if err != nil {
+			return
+		}
+
+		// Once we start seeing table creations, we are definitely done with extensions,
+		// so we can hand off the rest to the superior io.Copy implementation.
+		if bytes.HasPrefix(line, []byte("CREATE TABLE")) {
+			// we are done with extensions
+			noMoreExtensions = true
+		} else if bytes.HasPrefix(line, []byte("COMMENT ON EXTENSION")) {
+			// comment out this line
+			line = append([]byte("-- "), line...)
+		}
+
+		// Write this line and update our progress before returning on error
+		var lineWritten int
+		lineWritten, err = dst.Write(line)
+		written += int64(lineWritten)
+		progressFn(written)
+		if err != nil {
+			return
+		}
+	}
+
+	// No more extensions - reset src to the last actual consumed position
+	_, err = src.Seek(consumed, io.SeekStart)
+
+	return
+}

--- a/internal/pgdump/extensions_test.go
+++ b/internal/pgdump/extensions_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/hexops/autogold"
@@ -13,6 +14,10 @@ import (
 )
 
 func TestPartialCopyWithoutExtensions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Test doesn't work on Windows of weirdness with t.TempDir() handling")
+	}
+
 	// Create test data - there is no stdlib in-memory io.ReadSeeker implementation
 	src, err := os.Create(filepath.Join(t.TempDir(), t.Name()))
 	require.NoError(t, err)


### PR DESCRIPTION
When uploading a snapshot, trim extension statements unsupported by Google Cloud SQL. We do this on upload so that the customer's copy of the dump remains unmodified (in case something goes wrong, we still have the original to work with - trimming can be disabled with `trim-extensions=false`).

Closes https://github.com/sourcegraph/customer/issues/1613

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->

```
go run ./cmd/src snapshot upload -credentials='../cloud-data-migrations/misc/credential.json' -bucket='sourcegraph-cloud-data-migration-7ec798d67ff4'
```

See uploaded data