### PR TITLE
add watchdog goroutine for docker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to `src-cli` are documented in this file.
 
 ### Added
 
+- Batch Changes: Watchdog that checks for docker responsiveness while running commands has been added. [#898](https://github.com/sourcegraph/src-cli/pull/898)
+
 ### Changed
 
 ### Fixed

--- a/cmd/src/batch_common.go
+++ b/cmd/src/batch_common.go
@@ -32,9 +32,12 @@ import (
 	"github.com/sourcegraph/src-cli/internal/batches/repozip"
 	"github.com/sourcegraph/src-cli/internal/batches/service"
 	"github.com/sourcegraph/src-cli/internal/batches/ui"
+	"github.com/sourcegraph/src-cli/internal/batches/watchdog"
 	"github.com/sourcegraph/src-cli/internal/batches/workspace"
 	"github.com/sourcegraph/src-cli/internal/cmderrors"
 )
+
+const dockerWatchDuration = 5 * time.Second
 
 // batchExecutionFlags are common to batch changes that are executed both
 // locally and remotely.
@@ -251,6 +254,15 @@ type executeBatchSpecOpts struct {
 	client api.Client
 }
 
+func createDockerWatchdog(ctx context.Context, execUI ui.ExecUI) watchdog.Watcher {
+	return watchdog.New(dockerWatchDuration, func() {
+		_, err := docker.CurrentContext(ctx)
+		if err != nil {
+			execUI.DockerWatchDogWarning(errors.Wrap(err, "docker watchdog"))
+		}
+	})
+}
+
 // executeBatchSpec performs all the steps required to upload the batch spec to
 // Sourcegraph, including execution as needed and applying the resulting batch
 // spec if specified.
@@ -263,7 +275,11 @@ func executeBatchSpec(ctx context.Context, opts executeBatchSpecOpts) (err error
 		execUI = &ui.TUI{Out: out}
 	}
 
+	w := createDockerWatchdog(ctx, execUI)
+	go w.Start()
+
 	defer func() {
+		w.Stop()
 		if err != nil {
 			execUI.ExecutionError(err)
 		}

--- a/cmd/src/batch_common.go
+++ b/cmd/src/batch_common.go
@@ -37,7 +37,8 @@ import (
 	"github.com/sourcegraph/src-cli/internal/cmderrors"
 )
 
-const dockerWatchDuration = 5 * time.Second
+// We check for docker responsiveness every minute
+const dockerWatchDuration = 1 * time.Minute
 
 // batchExecutionFlags are common to batch changes that are executed both
 // locally and remotely.
@@ -254,7 +255,7 @@ type executeBatchSpecOpts struct {
 	client api.Client
 }
 
-func createDockerWatchdog(ctx context.Context, execUI ui.ExecUI) watchdog.Watcher {
+func createDockerWatchdog(ctx context.Context, execUI ui.ExecUI) *watchdog.WatchDog {
 	return watchdog.New(dockerWatchDuration, func() {
 		_, err := docker.CurrentContext(ctx)
 		if err != nil {

--- a/cmd/src/batch_common.go
+++ b/cmd/src/batch_common.go
@@ -257,7 +257,7 @@ type executeBatchSpecOpts struct {
 
 func createDockerWatchdog(ctx context.Context, execUI ui.ExecUI) *watchdog.WatchDog {
 	return watchdog.New(dockerWatchDuration, func() {
-		_, err := docker.CurrentContext(ctx)
+		_, err := docker.NCPU(ctx)
 		if err != nil {
 			execUI.DockerWatchDogWarning(errors.Wrap(err, "docker watchdog"))
 		}

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/sourcegraph/go-diff v0.6.1
 	github.com/sourcegraph/jsonx v0.0.0-20200629203448-1a936bd500cf
 	github.com/sourcegraph/scip v0.2.3
-	github.com/sourcegraph/sourcegraph/lib v0.0.0-20221129022201-2804729b069c
+	github.com/sourcegraph/sourcegraph/lib v0.0.0-20221207201520-eeeaf1f74c51
 	github.com/stretchr/testify v1.8.0
 	golang.org/x/net v0.2.0
 	golang.org/x/sync v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -378,8 +378,8 @@ github.com/sourcegraph/log v0.0.0-20220901143117-fc0516a694c9 h1:JjFyvx9hCD5+Jpu
 github.com/sourcegraph/log v0.0.0-20220901143117-fc0516a694c9/go.mod h1:UxiwB6C3xk3xOySJpW1R0MDUyfGuJRFS5Z8C+SA5p2I=
 github.com/sourcegraph/scip v0.2.3 h1:6nRsTlNTELn+1V7JxLrDVbBpb9H1gAbUF48N7x5B8Y4=
 github.com/sourcegraph/scip v0.2.3/go.mod h1:3D/RLCMvrrSam85RtFmC67SE/jhV9++hpCR5MTDzbA0=
-github.com/sourcegraph/sourcegraph/lib v0.0.0-20221129022201-2804729b069c h1:bjTcIdEx6FvUXIbD1Ckjp7SfvV4jTyJ7RozZH/HVj9M=
-github.com/sourcegraph/sourcegraph/lib v0.0.0-20221129022201-2804729b069c/go.mod h1:PmWmo2ysXWCHcbtp08cDXKGD+8NQzrkj2UjdRBu9H0k=
+github.com/sourcegraph/sourcegraph/lib v0.0.0-20221207201520-eeeaf1f74c51 h1:G9XMyQ0SKC53PP9WPSkQqRFvwkZNYRdMHvdm5K3b8Lw=
+github.com/sourcegraph/sourcegraph/lib v0.0.0-20221207201520-eeeaf1f74c51/go.mod h1:pLXoYrwkmERkPVv1dpLcq0Epo21Kh4EgrdZXdnafmyQ=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=

--- a/internal/batches/ui/exec_ui.go
+++ b/internal/batches/ui/exec_ui.go
@@ -52,4 +52,6 @@ type ExecUI interface {
 	UploadingWorkspaceFiles()
 	UploadingWorkspaceFilesWarning(error)
 	UploadingWorkspaceFilesSuccess()
+
+	DockerWatchDogWarning(error)
 }

--- a/internal/batches/ui/json_lines.go
+++ b/internal/batches/ui/json_lines.go
@@ -178,7 +178,11 @@ func (ui *JSONLines) WriteAfterStepResult(key string, value execution.AfterStepR
 }
 
 func (ui *JSONLines) DockerWatchDogWarning(err error) {
-	logOperationFailure(batcheslib.LogEventOperationDockerWatchDog, &batcheslib.DockerWatchDogMetadata{Error: err.Error()})
+	message := fmt.Sprintf(`Your Docker engine might be frozen.
+If there's no progress in the next couple minutes, you may want to try restarting Docker and running the command again.
+Error: %s
+`, err.Error())
+	logOperationFailure(batcheslib.LogEventOperationDockerWatchDog, &batcheslib.DockerWatchDogMetadata{Error: message})
 }
 
 type taskExecutionJSONLines struct {

--- a/internal/batches/ui/json_lines.go
+++ b/internal/batches/ui/json_lines.go
@@ -177,6 +177,11 @@ func (ui *JSONLines) WriteAfterStepResult(key string, value execution.AfterStepR
 	})
 }
 
+func (ui *JSONLines) DockerWatchDogWarning(err error) {
+	fmt.Println("docker warning")
+	// logOperationFailure(batcheslib.LogEventOperationDockerWatchDog, &batcheslib.DockerWatchDogMetadata{Error: err.Error()})
+}
+
 type taskExecutionJSONLines struct {
 	linesTasks  map[*executor.Task]batcheslib.JSONLinesTask
 	binaryDiffs bool

--- a/internal/batches/ui/json_lines.go
+++ b/internal/batches/ui/json_lines.go
@@ -178,8 +178,7 @@ func (ui *JSONLines) WriteAfterStepResult(key string, value execution.AfterStepR
 }
 
 func (ui *JSONLines) DockerWatchDogWarning(err error) {
-	fmt.Println("docker warning")
-	// logOperationFailure(batcheslib.LogEventOperationDockerWatchDog, &batcheslib.DockerWatchDogMetadata{Error: err.Error()})
+	logOperationFailure(batcheslib.LogEventOperationDockerWatchDog, &batcheslib.DockerWatchDogMetadata{Error: err.Error()})
 }
 
 type taskExecutionJSONLines struct {

--- a/internal/batches/ui/json_lines.go
+++ b/internal/batches/ui/json_lines.go
@@ -178,7 +178,7 @@ func (ui *JSONLines) WriteAfterStepResult(key string, value execution.AfterStepR
 }
 
 func (ui *JSONLines) DockerWatchDogWarning(err error) {
-	message := fmt.Sprintf(`Your Docker engine might be frozen.
+	message := fmt.Sprintf(`It seems your Docker engine might be frozen.
 If there's no progress in the next couple minutes, you may want to try restarting Docker and running the command again.
 Error: %s
 `, err.Error())

--- a/internal/batches/ui/tui.go
+++ b/internal/batches/ui/tui.go
@@ -221,6 +221,10 @@ func (ui *TUI) CreatingBatchSpecError(err error) error {
 	return prettyPrintBatchUnlicensedError(ui.Out, err)
 }
 
+func (ui *TUI) DockerWatchDogWarning(err error) {
+	dockerWatchDogWarning(ui.Out, err)
+}
+
 func (ui *TUI) PreviewBatchSpec(batchSpecURL string) {
 	ui.Out.Write("")
 	block := ui.Out.Block(output.Line(batchSuccessEmoji, batchSuccessColor, "To preview or apply the batch spec, go to:"))
@@ -448,4 +452,11 @@ func batchCompletePending(p output.Pending, message string) {
 
 func batchCompleteWarning(p output.Pending, message string) {
 	p.Complete(output.Line(batchWarningEmoji, batchWarningColor, message))
+}
+
+func dockerWatchDogWarning(out *output.Output, err error) {
+	block := out.Block(output.Line("🐳", output.StyleWarning, "Hey there, Your docker engine might be frozen."))
+	block.WriteLine(output.Line("", output.StyleWarning, "If there's no progress in the next couple minutes, you can try rebooting docker and running the command again."))
+	block.Write("")
+	block.Close()
 }

--- a/internal/batches/ui/tui.go
+++ b/internal/batches/ui/tui.go
@@ -455,7 +455,7 @@ func batchCompleteWarning(p output.Pending, message string) {
 }
 
 func dockerWatchDogWarning(out *output.Output, err error) {
-	block := out.Block(output.Line("🐳", output.StyleWarning, "Your Docker engine might be frozen."))
+	block := out.Block(output.Line("🐳", output.StyleWarning, "It seems your Docker engine might be frozen."))
 	block.WriteLine(output.Line("", output.StyleWarning, "If there's no progress in the next couple minutes, you may want to try restarting Docker and running the command again."))
 	block.WriteLine(output.Linef("", output.StyleWarning, "Error: %s", err.Error()))
 	block.Write("")

--- a/internal/batches/ui/tui.go
+++ b/internal/batches/ui/tui.go
@@ -455,8 +455,9 @@ func batchCompleteWarning(p output.Pending, message string) {
 }
 
 func dockerWatchDogWarning(out *output.Output, err error) {
-	block := out.Block(output.Line("🐳", output.StyleWarning, "Hey there, Your docker engine might be frozen."))
-	block.WriteLine(output.Line("", output.StyleWarning, "If there's no progress in the next couple minutes, you can try rebooting docker and running the command again."))
+	block := out.Block(output.Line("🐳", output.StyleWarning, "Your Docker engine might be frozen."))
+	block.WriteLine(output.Line("", output.StyleWarning, "If there's no progress in the next couple minutes, you may want to try restarting Docker and running the command again."))
+	block.WriteLine(output.Linef("", output.StyleWarning, "Error: %s", err.Error()))
 	block.Write("")
 	block.Close()
 }

--- a/internal/batches/watchdog/watchdog.go
+++ b/internal/batches/watchdog/watchdog.go
@@ -4,23 +4,18 @@ import (
 	"time"
 )
 
-type Watcher interface {
-	Start()
-	Stop()
-}
-
-type watchDog struct {
+type WatchDog struct {
 	interval time.Duration
 	ticker   *time.Ticker
-	done     chan bool
+	done     chan struct{}
 	callback func()
 }
 
-func New(interval time.Duration, callback func()) Watcher {
+func New(interval time.Duration, callback func()) *WatchDog {
 	t := time.NewTicker(interval)
-	done := make(chan bool)
+	done := make(chan struct{}, 1)
 
-	return &watchDog{
+	return &WatchDog{
 		interval: interval,
 		ticker:   t,
 		done:     done,
@@ -28,11 +23,11 @@ func New(interval time.Duration, callback func()) Watcher {
 	}
 }
 
-func (w *watchDog) Stop() {
+func (w *WatchDog) Stop() {
 	close(w.done)
 }
 
-func (w *watchDog) Start() {
+func (w *WatchDog) Start() {
 	for {
 		select {
 		case <-w.ticker.C:

--- a/internal/batches/watchdog/watchdog.go
+++ b/internal/batches/watchdog/watchdog.go
@@ -1,0 +1,44 @@
+package watchdog
+
+import (
+	"time"
+)
+
+type Watcher interface {
+	Start()
+	Stop()
+}
+
+type watchDog struct {
+	interval time.Duration
+	ticker   *time.Ticker
+	done     chan bool
+	callback func()
+}
+
+func New(interval time.Duration, callback func()) Watcher {
+	t := time.NewTicker(interval)
+	done := make(chan bool)
+
+	return &watchDog{
+		interval: interval,
+		ticker:   t,
+		done:     done,
+		callback: callback,
+	}
+}
+
+func (w *watchDog) Stop() {
+	close(w.done)
+}
+
+func (w *watchDog) Start() {
+	for {
+		select {
+		case <-w.ticker.C:
+			go w.callback()
+		case <-w.done:
+			w.ticker.Stop()
+		}
+	}
+}

--- a/internal/batches/watchdog/watchdog.go
+++ b/internal/batches/watchdog/watchdog.go
@@ -2,38 +2,29 @@ package watchdog
 
 import (
 	"time"
+
+	"github.com/derision-test/glock"
 )
 
 type WatchDog struct {
-	interval time.Duration
-	ticker   *time.Ticker
-	done     chan struct{}
+	ticker   glock.Ticker
 	callback func()
 }
 
 func New(interval time.Duration, callback func()) *WatchDog {
-	t := time.NewTicker(interval)
-	done := make(chan struct{}, 1)
-
+	ticker := glock.NewRealTicker(interval)
 	return &WatchDog{
-		interval: interval,
-		ticker:   t,
-		done:     done,
+		ticker:   ticker,
 		callback: callback,
 	}
 }
 
 func (w *WatchDog) Stop() {
-	close(w.done)
+	w.ticker.Stop()
 }
 
 func (w *WatchDog) Start() {
-	for {
-		select {
-		case <-w.ticker.C:
-			go w.callback()
-		case <-w.done:
-			w.ticker.Stop()
-		}
+	for _ = range w.ticker.Chan() {
+		go w.callback()
 	}
 }

--- a/internal/batches/watchdog/watchdog_test.go
+++ b/internal/batches/watchdog/watchdog_test.go
@@ -1,0 +1,39 @@
+package watchdog
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/derision-test/glock"
+)
+
+func TestWatchDog(t *testing.T) {
+	ticker := glock.NewMockTicker(5 * time.Minute)
+	var count uint32
+	expectedCount := 100
+	var wg sync.WaitGroup
+
+	mockCallback := func() {
+		atomic.AddUint32(&count, 1)
+		wg.Done()
+	}
+
+	w := &WatchDog{
+		ticker:   ticker,
+		callback: mockCallback,
+	}
+
+	go w.Start()
+	for i := 0; i < expectedCount; i++ {
+		wg.Add(1)
+		ticker.BlockingAdvance(5 * time.Minute)
+	}
+	wg.Wait()
+	w.Stop()
+
+	if count != uint32(expectedCount) {
+		t.Errorf("expected mock callback to be called %d times, got %d", expectedCount, count)
+	}
+}

--- a/internal/batches/watchdog/watchdog_test.go
+++ b/internal/batches/watchdog/watchdog_test.go
@@ -23,6 +23,7 @@ func TestWatchDog(t *testing.T) {
 	w := &WatchDog{
 		ticker:   ticker,
 		callback: mockCallback,
+		done:     make(chan struct{}, 1),
 	}
 
 	go w.Start()


### PR DESCRIPTION
Part 2 [#44432](https://github.com/sourcegraph/sourcegraph/issues/44432)
Closes [#44432](https://github.com/sourcegraph/sourcegraph/issues/44432)

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->

Manually tested that the banner shows up when there's an error from getting the current context for docker. 

<img width="1360" alt="CleanShot 2022-12-07 at 19 26 03@2x" src="https://user-images.githubusercontent.com/25608335/206265595-e8d76f36-2431-4c17-829a-ca0982cc2da6.png">
