### PR TITLE
batches: update limit in unlicensed alert

### DIFF
--- a/internal/batches/ui/tui.go
+++ b/internal/batches/ui/tui.go
@@ -328,7 +328,7 @@ func prettyPrintBatchUnlicensedError(out *output.Output, err error) error {
 				// characters: having automatic wrapping some day would be nice,
 				// but this should be sufficient for now.
 				block := out.Block(output.Line("🪙", output.StyleWarning, "Batch Changes is a paid feature of Sourcegraph. All users can create sample"))
-				block.WriteLine(output.Linef("", output.StyleWarning, "batch changes with up to 5 changesets without a license. Contact Sourcegraph"))
+				block.WriteLine(output.Linef("", output.StyleWarning, "batch changes with up to 10 changesets without a license. Contact Sourcegraph"))
 				block.WriteLine(output.Linef("", output.StyleWarning, "sales at %shttps://about.sourcegraph.com/contact/sales/%s to obtain a trial", output.StyleSearchLink, output.StyleWarning))
 				block.WriteLine(output.Linef("", output.StyleWarning, "license."))
 				block.Write("")


### PR DESCRIPTION
The limit for changesets Batch Changes can create on unlicensed instances was increased from 5 to 10. This was accidentally reverted but is now [restored](https://github.com/sourcegraph/sourcegraph/pull/45688). This updates the TUI alert when running src-cli to create batch changes on an unlicensed instance.

### Test plan

N/A, just a string change.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
