### PR TITLE
Rename users clean or prune -- use aggregated user statistics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,11 @@ All notable changes to `src-cli` are documented in this file.
 
 ### Changed
 
+- Renamed `src users clean` command to `src users prune` [#901](https://github.com/sourcegraph/src-cli/pull/901)
+
 ### Fixed
+
+- Fix network timeout in `src users clean` occuring in instances with many users  [#901](https://github.com/sourcegraph/src-cli/pull/901)
 
 ### Removed
 

--- a/cmd/src/users.go
+++ b/cmd/src/users.go
@@ -90,3 +90,12 @@ type UserUsageStatistics struct {
 	LastActiveTime                    string
 	LastActiveCodeHostIntegrationTime string
 }
+
+type SiteUser struct {
+	ID string
+	Username string
+	Email string
+	SiteAdmin bool
+	LastActiveAt string
+}
+	

--- a/cmd/src/users.go
+++ b/cmd/src/users.go
@@ -20,7 +20,7 @@ The commands are:
 	get        gets a user
 	create     creates a user account
 	delete     deletes a user account
-	clean      deletes inactive users
+	prune      deletes inactive users
 	tag        add/remove a tag on a user
 
 Use "src users [command] -h" for more information about a command.

--- a/cmd/src/users.go
+++ b/cmd/src/users.go
@@ -92,10 +92,9 @@ type UserUsageStatistics struct {
 }
 
 type SiteUser struct {
-	ID string
-	Username string
-	Email string
-	SiteAdmin bool
+	ID           string
+	Username     string
+	Email        string
+	SiteAdmin    bool
 	LastActiveAt string
 }
-	

--- a/cmd/src/users_clean.go
+++ b/cmd/src/users_clean.go
@@ -94,7 +94,6 @@ query getInactiveUsers {
 		if ok, err := client.NewRequest(getInactiveUsersQuery, nil).Do(ctx, &usersResult); err != nil || !ok {
 			return err
 		}
-		fmt.Printf("\n request returns -- \n\n%v\n\n", usersResult)
 
 		usersToDelete := make([]UserToDelete, 0)
 		for _, user := range usersResult.Site.Users.Nodes {

--- a/cmd/src/users_clean.go
+++ b/cmd/src/users_clean.go
@@ -84,17 +84,20 @@ query getInactiveUsers {
 `
 
 		var usersResult struct {
+			Site struct {
 			Users struct {
 				Nodes []SiteUser 
+			}
 			}
 		}
 
 		if ok, err := client.NewRequest(getInactiveUsersQuery, nil).Do(ctx, &usersResult); err != nil || !ok {
 			return err
 		}
+		fmt.Printf("\n request returns -- \n\n%v\n\n", usersResult)
 
 		usersToDelete := make([]UserToDelete, 0)
-		for _, user := range usersResult.Users.Nodes {
+		for _, user := range usersResult.Site.Users.Nodes {
 			daysSinceLastUse, hasLastActive, err := computeDaysSinceLastUse(user)
 			if err != nil {
 				return err

--- a/cmd/src/users_prune.go
+++ b/cmd/src/users_prune.go
@@ -21,7 +21,7 @@ Examples:
 
 	$ src users prune -days 182
 	
-	$ src users prune -remove-admin -remove-never-active 
+	$ src users prune -remove-admin -remove-null-users
 `
 
 	flagSet := flag.NewFlagSet("prune", flag.ExitOnError)
@@ -33,7 +33,7 @@ Examples:
 	var (
 		daysToDelete       = flagSet.Int("days", 60, "Days threshold on which to remove users, must be 60 days or greater and defaults to this value ")
 		removeAdmin        = flagSet.Bool("remove-admin", false, "prune admin accounts")
-		removeNoLastActive = flagSet.Bool("remove-never-active", false, "removes users with no events registered in the database")
+		removeNoLastActive = flagSet.Bool("remove-null-users", false, "removes users with no last active value")
 		skipConfirmation   = flagSet.Bool("force", false, "skips user confirmation step allowing programmatic use")
 		apiFlags           = api.NewFlags(flagSet)
 	)

--- a/cmd/src/users_prune.go
+++ b/cmd/src/users_prune.go
@@ -19,12 +19,12 @@ This command removes users from a Sourcegraph instance who have been inactive fo
 	
 Examples:
 
-	$ src users clean -days 182
+	$ src users prune -days 182
 	
-	$ src users clean -remove-admin -remove-never-active 
+	$ src users prune -remove-admin -remove-never-active 
 `
 
-	flagSet := flag.NewFlagSet("clean", flag.ExitOnError)
+	flagSet := flag.NewFlagSet("prune", flag.ExitOnError)
 	usageFunc := func() {
 		fmt.Fprintf(flag.CommandLine.Output(), "Usage of 'src users %s':\n", flagSet.Name())
 		flagSet.PrintDefaults()
@@ -32,7 +32,7 @@ Examples:
 	}
 	var (
 		daysToDelete       = flagSet.Int("days", 60, "Days threshold on which to remove users, must be 60 days or greater and defaults to this value ")
-		removeAdmin        = flagSet.Bool("remove-admin", false, "clean admin accounts")
+		removeAdmin        = flagSet.Bool("remove-admin", false, "prune admin accounts")
 		removeNoLastActive = flagSet.Bool("remove-never-active", false, "removes users with no events registered in the database")
 		skipConfirmation   = flagSet.Bool("force", false, "skips user confirmation step allowing programmatic use")
 		apiFlags           = api.NewFlags(flagSet)

--- a/cmd/src/users_prune.go
+++ b/cmd/src/users_prune.go
@@ -85,9 +85,9 @@ query getInactiveUsers {
 
 		var usersResult struct {
 			Site struct {
-			Users struct {
-				Nodes []SiteUser 
-			}
+				Users struct {
+					Nodes []SiteUser
+				}
 			}
 		}
 


### PR DESCRIPTION
This PR refactors use of the `usageStatistics` `lastActiveUsage` table which caused the command to timeout during execution on instances with a sufficiently large number of users. See #848 

Instead the `aggregated_user_statistics` [table](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/internal/database/schema.md?subtree=true) is used via the `site` graphQL endpoint
```graphql
query getInactiveUsers {
  site {
    users {
      nodes {
        id
        username
        email
        siteAdmin
        lastActiveAt
      }
    }
  }
}
```

This has two benefits 
1. The backend to query `lastActiveAt` from the `site` graphQL endpoint is much more efficient than `usageStatistics`, and eliminates timeout concerns on many users instances
2. `aggregated_user_statistics` persists the date `lastActiveAt` eliminating the concern of `null` `lastActiveUsage` values which are misleading. `lastActiveUsage` is computed by reference to the `event_logs` table which only persists event entries for 93 days, when 93 days pass if a user had no entries in `event_logs` `lastActiveUsage` was set to `null` -- previously `src users clean` interpreted a `null` value as a user never having used the instance. _A flag `-remove-null-users` is provided to remove `null` lastActiveAt` users_



This PR also changes the name of the `src users clean` command renaming it to `src users prune` which follows the `docker` and `kubectl` cleanup command convention

Closes #848

### Test plan
Tested on local machine

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
