### PR TITLE
Return an error when additional headers conflicts

### DIFF
--- a/cmd/src/main.go
+++ b/cmd/src/main.go
@@ -58,6 +58,9 @@ var (
 	// The following arguments are deprecated which is why they are no longer documented
 	configPath = flag.String("config", "", "")
 	endpoint   = flag.String("endpoint", "", "")
+
+	errConfigMerge                 = errors.New("when using a configuration file, zero or all environment variables must be set")
+	errConfigAuthorizationConflict = errors.New("when passing an 'Authorization' additional headers, SRC_ACCESS_TOKEN must never be set")
 )
 
 // commands contains all registered subcommands.
@@ -154,6 +157,11 @@ func readConfig() (*config, error) {
 	}
 
 	cfg.AdditionalHeaders = parseAdditionalHeaders()
+	// Ensure that we're not clashing additonal headers
+	_, hasAuthorizationAdditonalHeader := cfg.AdditionalHeaders["authorization"]
+	if cfg.AccessToken != "" && hasAuthorizationAdditonalHeader {
+		return nil, errConfigAuthorizationConflict
+	}
 
 	// Lastly, apply endpoint flag if set
 	if endpoint != nil && *endpoint != "" {
@@ -168,5 +176,3 @@ func readConfig() (*config, error) {
 func cleanEndpoint(urlStr string) string {
 	return strings.TrimSuffix(urlStr, "/")
 }
-
-var errConfigMerge = errors.New("when using a configuration file, zero or all environment variables must be set")

--- a/cmd/src/main_test.go
+++ b/cmd/src/main_test.go
@@ -151,6 +151,13 @@ func TestReadConfig(t *testing.T) {
 				AdditionalHeaders: map[string]string{"foo-bar": "bar-baz", "foo": "bar"},
 			},
 		},
+		{
+			name:        "additional headers SRC_HEADERS_AUTHORIZATION and SRC_ACCESS_TOKEN",
+			envToken:    "abc",
+			envEndpoint: "https://override.com",
+			envHeaders:  "Authorization:Bearer",
+			wantErr:     errConfigAuthorizationConflict.Error(),
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Passing `SRC_ADDITIONAL_HEADERS_AUTHORIZATION=...` and `SRC_ACCESS_TOKEN` at the same time leads to the latter overriding the former silently, making it quite difficult to spot. 

This PR surfaces the conflict as an error explictly advising to never set `SRC_ACCESS_TOKEN` in conjunction with the additional header.

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->

Unit test + local run: 

```
# OK:

~/work/src-cli/cmd  jh/fix-authorization-header-conflict $ SRC_HEADER_AUTHORIZATION="sourcegraph" SRC_ENDPOINT=https://sourcegraph.test:3443 go run ./... api -query='query { currentUser { username } }'
{
  "data": {
    "currentUser": {
      "username": "sourcegraph"
    }
  }
}

# Prints an error because that's doomed to fail: 

~/work/src-cli/cmd  jh/fix-authorization-header-conflict $ SRC_ACCESS_TOKEN="foobar" SRC_HEADER_AUTHORIZATION="sourcegraph" SRC_ENDPOINT=https://sourcegraph.test:3443 go run ./... api -query='query { currentUser { username } }'
reading config: when passing an 'Authorization' additional headers, SRC_ACCESS_TOKEN must never be set
exit status 1
~/work/src-cli/cmd  jh/fix-authorization-header-conflict $ 
```

