### PR TITLE
Validate: add `deleteWhenDone` option to insights

### DIFF
--- a/internal/validate/install/install.go
+++ b/internal/validate/install/install.go
@@ -56,8 +56,9 @@ type GitHub struct {
 }
 
 type Insight struct {
-	Title      string           `yaml:"title"`
-	DataSeries []map[string]any `yaml:"dataSeries"`
+	Title          string           `yaml:"title"`
+	DataSeries     []map[string]any `yaml:"dataSeries"`
+	DeleteWhenDone bool             `yaml:"deleteWhenDone"`
 }
 
 type ValidationSpec struct {
@@ -114,6 +115,7 @@ func DefaultConfig() *ValidationSpec {
 					"timeScopeValue":  1,
 				},
 			},
+			DeleteWhenDone: true,
 		},
 	}
 }
@@ -171,7 +173,7 @@ func Validate(ctx context.Context, client api.Client, config *ValidationSpec) er
 
 	cloned, err := repoCloneTimeout(ctx, client, config.ExternalService)
 	if err != nil {
-		return err //TODO make sure errors are wrapped once
+		return err
 	}
 	if !cloned {
 		return errors.Newf("%s validate failed, repo did not clone\n", validate.FailureEmoji)
@@ -207,7 +209,7 @@ func Validate(ctx context.Context, client api.Client, config *ValidationSpec) er
 		log.Printf("%s insight successfully added", validate.SuccessEmoji)
 
 		defer func() {
-			if insightId != "" {
+			if insightId != "" && config.Insight.DeleteWhenDone {
 				_ = removeInsight(ctx, client, insightId)
 				log.Printf("%s insight %s has been removed", validate.SuccessEmoji, config.Insight.Title)
 


### PR DESCRIPTION
Insights were automatically deleted, add option to keep insight created during validation via `deleteWhenDone`:

```yaml
externalService:
  kind: GITHUB
  displayName: srcgraph-test
  deleteWhenDone: true
  maxRetries: 5
  retryTimeoutSeconds: 5
  config:
    gitHub:
      url: https://github.com
      orgs: []
      repos:
        - sourcegraph-testing/zap

searchQuery:
  - repo:^github.com/sourcegraph-testing/zap$ test
  - repo:^github.com/sourcegraph-testing/zap$@v1.14.1 test

insight:
  title: "Javascript to Typescript migration"
  dataSeries:
    [ {
      "query": "lang:javascript",
      "label": "javascript",
      "repositoryScope": [
        "github.com/sourcegraph/sourcegraph"
      ],
      "lineColor": "#6495ED",
      "timeScopeUnit": "MONTH",
      "timeScopeValue": 1
    },
      {
        "query": "lang:typescript",
        "label": "typescript",
        "lineColor": "#DE3163",
        "repositoryScope": [
          "github.com/sourcegraph/sourcegraph"
        ],
        "timeScopeUnit": "MONTH",
        "timeScopeValue": 1
      }
    ]
  deleteWhenDone: true
```

### Test plan

Locally tested changes using latest Sourcegraph Helm install. Tested default configuration if no YAML is provided, YAML configuration provided, and JSON configuration provided.

ran `go test ./...` - all tests passing
ran `staticcheck ./...` - no issues found in new code

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
