### PR TITLE
Do not override executor queue endpoints

### DIFF
--- a/cmd/src/code_intel_upload.go
+++ b/cmd/src/code_intel_upload.go
@@ -148,7 +148,7 @@ func codeintelUploadOptions(out *output.Output, isSCIPAvailable bool) upload.Upl
 	path := codeintelUploadFlags.uploadRoute
 	if isSCIPAvailable && filepath.Ext(codeintelUploadFlags.file) == ".scip" {
 		cfg.AdditionalHeaders["Content-Type"] = "application/x-protobuf+scip"
-		path = "/.api/scip/upload"
+		path = strings.ReplaceAll(path, "lsif", "scip")
 	}
 
 	logger := upload.NewRequestLogger(

--- a/cmd/src/code_intel_upload_flags.go
+++ b/cmd/src/code_intel_upload_flags.go
@@ -185,7 +185,7 @@ func codeintelUploadOutput() (out *output.Output) {
 
 func isSCIPAvailable() (bool, error) {
 	client := cfg.apiClient(codeintelUploadFlags.apiFlags, codeintelUploadFlagSet.Output())
-	req, err := client.NewHTTPRequest(context.Background(), "HEAD", "/.api/scip/upload", nil)
+	req, err := client.NewHTTPRequest(context.Background(), "HEAD", strings.ReplaceAll(codeintelUploadFlags.uploadRoute, "lsif", "scip"), nil)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
Diff is pretty self-explanatory. See https://github.com/sourcegraph/sourcegraph/pull/47532.

### Test plan

Going to create a local docker image and test the auto-indexing flow locally to make sure we don't continue to clobber the `/.executor` route prefix.