### PR TITLE
servegit: use more performant WalkDir

### DIFF
--- a/internal/servegit/serve.go
+++ b/internal/servegit/serve.go
@@ -5,10 +5,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"html/template"
+	"io/fs"
 	"log"
 	"net"
 	"net/http"
-	"os"
 	"os/exec"
 	pathpkg "path"
 	"path/filepath"
@@ -170,7 +170,7 @@ func (s *Serve) Repos() ([]Repo, error) {
 		return nil, nil
 	}
 
-	err = filepath.Walk(root, func(path string, fi os.FileInfo, fileErr error) error {
+	err = filepath.WalkDir(root, func(path string, fi fs.DirEntry, fileErr error) error {
 		if fileErr != nil {
 			s.Info.Printf("WARN: ignoring error searching %s: %v", path, fileErr)
 			return nil


### PR DESCRIPTION
WalkDir was introduced in go1.16 suits our use case while being more efficient.

Test Plan: go test