### PR TITLE
permissions-center: use new `permissionSyncJobs` query.

### DIFF
--- a/cmd/src/cmd.go
+++ b/cmd/src/cmd.go
@@ -23,8 +23,8 @@ type command struct {
 	// handler is the function that is invoked to handle this command.
 	handler func(args []string) error
 
-	// flagSet.Usage function to invoke on e.g. -h flag. If nil, a default one
-	// one is used.
+	// flagSet.Usage function to invoke on e.g. -h flag. If nil, a default one is
+	// used.
 	usageFunc func()
 }
 
@@ -48,7 +48,7 @@ type commander []*command
 func (c commander) run(flagSet *flag.FlagSet, cmdName, usageText string, args []string) {
 	// Parse flags.
 	flagSet.Usage = func() {
-		fmt.Fprint(flag.CommandLine.Output(), usageText)
+		_, _ = fmt.Fprint(flag.CommandLine.Output(), usageText)
 	}
 	if !flagSet.Parsed() {
 		_ = flagSet.Parse(args)
@@ -68,7 +68,7 @@ func (c commander) run(flagSet *flag.FlagSet, cmdName, usageText string, args []
 			continue
 		}
 		cmd.flagSet.Usage = func() {
-			fmt.Fprintf(flag.CommandLine.Output(), "Usage of '%s %s':\n", cmdName, cmd.flagSet.Name())
+			_, _ = fmt.Fprintf(flag.CommandLine.Output(), "Usage of '%s %s':\n", cmdName, cmd.flagSet.Name())
 			cmd.flagSet.PrintDefaults()
 		}
 	}

--- a/cmd/src/snapshot_testcmd.go
+++ b/cmd/src/snapshot_testcmd.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/lib/output"
 
@@ -93,7 +94,7 @@ TEST DATA
 				"No critical issues found!"))
 			return nil
 		},
-		usageFunc: func() { fmt.Fprint(flag.CommandLine.Output(), usage) },
+		usageFunc: func() { _, _ = fmt.Fprint(flag.CommandLine.Output(), usage) },
 	})
 }
 
@@ -105,7 +106,7 @@ func compareSnapshotSummaries(out *output.Output, recordedSummary, newSummary sn
 	diff := cmp.Diff(recordedSummary, newSummary)
 	if diff != "" {
 		b.WriteLine(output.Line(output.EmojiFailure, output.StyleFailure, "Snapshot diff detected:"))
-		b.WriteCode("diff", diff)
+		_ = b.WriteCode("diff", diff)
 		return errors.New("snapshot mismatch")
 	}
 	b.WriteLine(output.Emoji(output.EmojiSuccess, "Snapshots match!"))

--- a/internal/instancehealth/checks.go
+++ b/internal/instancehealth/checks.go
@@ -139,7 +139,7 @@ func checkPermissionsSyncing(
 			continue
 		}
 		syncCount += 1
-		if sync.State == "ERROR" {
+		if sync.State == "ERROR" || sync.State == "FAILED" {
 			syncErrors = append(syncErrors, sync.FailureMessage)
 		}
 		for _, p := range sync.CodeHostStates {
@@ -149,9 +149,7 @@ func checkPermissionsSyncing(
 			}
 			// Just track one message per state for reference
 			seenProviders[key][p.Status] = p.Message
-			out.WriteLine(output.Linef(output.EmojiInfo, output.StyleBold, "%s %s %s %s", p.ProviderID, p.ProviderType, p.Message, p.Status))
 		}
-		out.WriteLine(output.Linef(output.EmojiInfo, output.StyleBold, "%s %s %s", sync.State, sync.FailureMessage, sync.FinishedAt.String()))
 	}
 
 	if syncCount == 0 {

--- a/internal/instancehealth/checks.go
+++ b/internal/instancehealth/checks.go
@@ -134,22 +134,24 @@ func checkPermissionsSyncing(
 	var syncCount int
 	var syncErrors []string
 	var seenProviders = make(map[string]map[string]string) // provider : state : message
-	for _, sync := range instanceHealth.PermissionsSyncJobs.Nodes {
-		if sync.CompletedAt.Before(time.Now().Add(-since)) {
+	for _, sync := range instanceHealth.PermissionSyncJobs.Nodes {
+		if sync.FinishedAt.Before(time.Now().Add(-since)) {
 			continue
 		}
 		syncCount += 1
-		if sync.Status == "ERROR" {
-			syncErrors = append(syncErrors, sync.Message)
+		if sync.State == "ERROR" {
+			syncErrors = append(syncErrors, sync.FailureMessage)
 		}
-		for _, p := range sync.Providers {
-			key := fmt.Sprintf("%s - %s", p.Type, p.ID)
+		for _, p := range sync.CodeHostStates {
+			key := fmt.Sprintf("%s - %s", p.ProviderType, p.ProviderID)
 			if _, ok := seenProviders[key]; !ok {
 				seenProviders[key] = make(map[string]string)
 			}
 			// Just track one message per state for reference
 			seenProviders[key][p.Status] = p.Message
+			out.WriteLine(output.Linef(output.EmojiInfo, output.StyleBold, "%s %s %s %s", p.ProviderID, p.ProviderType, p.Message, p.Status))
 		}
+		out.WriteLine(output.Linef(output.EmojiInfo, output.StyleBold, "%s %s %s", sync.State, sync.FailureMessage, sync.FinishedAt.String()))
 	}
 
 	if syncCount == 0 {

--- a/internal/instancehealth/checks_test.go
+++ b/internal/instancehealth/checks_test.go
@@ -7,9 +7,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sourcegraph/sourcegraph/lib/output"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/sourcegraph/sourcegraph/lib/output"
 )
 
 // run with -v for output
@@ -23,7 +24,7 @@ func TestCheckPermissionsSyncing(t *testing.T) {
 	}{{
 		name: "no jobs",
 		instanceHealth: Indicators{
-			PermissionsSyncJobs: struct{ Nodes []permissionsSyncJob }{
+			PermissionSyncJobs: struct{ Nodes []permissionSyncJob }{
 				Nodes: nil,
 			},
 		},
@@ -32,14 +33,14 @@ func TestCheckPermissionsSyncing(t *testing.T) {
 	}, {
 		name: "healthy",
 		instanceHealth: Indicators{
-			PermissionsSyncJobs: struct{ Nodes []permissionsSyncJob }{
-				Nodes: []permissionsSyncJob{{
-					CompletedAt: time.Now(),
-					Status:      "SUCCESS",
-					Providers: []permissionsProviderStatus{{
-						Type:   "github",
-						ID:     "https://github.com/",
-						Status: "SUCCESS",
+			PermissionSyncJobs: struct{ Nodes []permissionSyncJob }{
+				Nodes: []permissionSyncJob{{
+					FinishedAt: time.Now(),
+					State:      "SUCCESS",
+					CodeHostStates: []permissionsProviderStatus{{
+						ProviderType: "github",
+						ProviderID:   "https://github.com/",
+						Status:       "SUCCESS",
 					}},
 				}},
 			},
@@ -49,15 +50,15 @@ func TestCheckPermissionsSyncing(t *testing.T) {
 	}, {
 		name: "unhealthy",
 		instanceHealth: Indicators{
-			PermissionsSyncJobs: struct{ Nodes []permissionsSyncJob }{
-				Nodes: []permissionsSyncJob{{
-					CompletedAt: time.Now(),
-					Status:      "ERROR",
-					Message:     "oh no!",
-					Providers: []permissionsProviderStatus{{
-						Type:   "github",
-						ID:     "https://github.com/",
-						Status: "ERROR",
+			PermissionSyncJobs: struct{ Nodes []permissionSyncJob }{
+				Nodes: []permissionSyncJob{{
+					FinishedAt:     time.Now(),
+					State:          "ERROR",
+					FailureMessage: "oh no!",
+					CodeHostStates: []permissionsProviderStatus{{
+						ProviderType: "github",
+						ProviderID:   "https://github.com/",
+						Status:       "ERROR",
 					}},
 				}},
 			},

--- a/internal/instancehealth/summary.go
+++ b/internal/instancehealth/summary.go
@@ -40,23 +40,23 @@ type Indicators struct {
 			}
 		}
 	}
-	PermissionsSyncJobs struct {
-		Nodes []permissionsSyncJob
+	PermissionSyncJobs struct {
+		Nodes []permissionSyncJob
 	}
 }
 
-type permissionsSyncJob struct {
-	Status      string
-	Message     string
-	CompletedAt time.Time
-	Providers   []permissionsProviderStatus
+type permissionSyncJob struct {
+	State          string
+	FailureMessage string
+	FinishedAt     time.Time
+	CodeHostStates []permissionsProviderStatus
 }
 
 type permissionsProviderStatus struct {
-	Type    string
-	ID      string
-	Status  string
-	Message string
+	ProviderType string
+	ProviderID   string
+	Status       string
+	Message      string
 }
 
 // GetIndicators retrieves summary data from a Sourcegraph instance's GraphQL API for
@@ -95,14 +95,14 @@ func GetIndicators(ctx context.Context, client api.Client) (*Indicators, error) 
 				}
 			}
 
-			permissionsSyncJobs(first:500) {
+			permissionSyncJobs(first:500) {
 				nodes {
-					status
-					completedAt
-					message
-					providers {
-						type
-						id
+					state
+					finishedAt
+					failureMessage
+					codeHostStates {
+						providerType
+						providerID
 						status
 						message
 					}


### PR DESCRIPTION
Test plan:
`src snapshot test` runs successfully and fetches perms sync information from a local sg instance.

Follow-up to https://github.com/sourcegraph/sourcegraph/pull/47933