### PR TITLE
Add Snapshot Restore command

### DIFF
--- a/cmd/src/snapshot_databases.go
+++ b/cmd/src/snapshot_databases.go
@@ -113,7 +113,7 @@ TARGETS FILES
 					}
 				}
 
-				out.WriteLine(output.Emoji(output.EmojiSuccess, "Sucessfully completed dump commands"))
+				out.WriteLine(output.Emoji(output.EmojiSuccess, "Successfully completed dump commands"))
 			} else {
 				b := out.Block(output.Emoji(output.EmojiSuccess, "Run these commands to generate the required database dumps:"))
 				b.Write("\n" + strings.Join(commands, "\n"))

--- a/cmd/src/snapshot_databases.go
+++ b/cmd/src/snapshot_databases.go
@@ -85,9 +85,10 @@ TARGETS FILES
 				for _, c := range commands {
 					out.WriteLine(output.Emojif(output.EmojiInfo, "Running command: %q", c))
 					command := exec.Command("bash", "-c", c)
-					out, err := command.CombinedOutput()
+					output, err := command.CombinedOutput()
+					out.Write(string(output))
 					if err != nil {
-						return errors.Wrapf(err, "failed to run command: %q\n%q", c, string(out))
+						return errors.Wrapf(err, "failed to run command: %q", c)
 					}
 				}
 

--- a/cmd/src/snapshot_restore.go
+++ b/cmd/src/snapshot_restore.go
@@ -61,7 +61,7 @@ TARGETS FILES
 			case "pg_dump", "":
 				targetKey = "local"
 				commandBuilder = func(t pgdump.Target) (string, error) {
-					cmd := pgdump.RestoreCommad(t)
+					cmd := pgdump.RestoreCommand(t)
 					if t.Target != "" {
 						return fmt.Sprintf("%s --host=%s", cmd, t.Target), nil
 					}
@@ -69,12 +69,12 @@ TARGETS FILES
 				}
 			case "docker":
 				commandBuilder = func(t pgdump.Target) (string, error) {
-					return fmt.Sprintf("docker exec -i %s sh -c '%s'", t.Target, pgdump.RestoreCommad(t)), nil
+					return fmt.Sprintf("docker exec -i %s sh -c '%s'", t.Target, pgdump.RestoreCommand(t)), nil
 				}
 			case "kubectl":
 				targetKey = "k8s"
 				commandBuilder = func(t pgdump.Target) (string, error) {
-					return fmt.Sprintf("kubectl exec -i %s -- bash -c '%s'", t.Target, pgdump.RestoreCommad(t)), nil
+					return fmt.Sprintf("kubectl exec -i %s -- bash -c '%s'", t.Target, pgdump.RestoreCommand(t)), nil
 				}
 			default:
 				return errors.Newf("unknown or invalid template type %q", builder)
@@ -111,7 +111,7 @@ TARGETS FILES
 					}
 				}
 
-				out.WriteLine(output.Emoji(output.EmojiSuccess, "Sucessfully completed restore commands"))
+				out.WriteLine(output.Emoji(output.EmojiSuccess, "Successfully completed restore commands"))
 				out.WriteLine(output.Styledf(output.StyleSuggestion, "It may be necessary to restart your Sourcegraph instance after restoring"))
 			} else {
 				b := out.Block(output.Emoji(output.EmojiSuccess, "Run these commands to restore the databases:"))

--- a/cmd/src/snapshot_restore.go
+++ b/cmd/src/snapshot_restore.go
@@ -83,9 +83,10 @@ TARGETS FILES
 				for _, c := range commands {
 					out.WriteLine(output.Emojif(output.EmojiInfo, "Running command: %q", c))
 					command := exec.Command("bash", "-c", c)
-					out, err := command.CombinedOutput()
+					output, err := command.CombinedOutput()
+					out.Write(string(output))
 					if err != nil {
-						return errors.Wrapf(err, "failed to run command: %q\n%q", c, string(out))
+						return errors.Wrapf(err, "failed to run command: %q", c)
 					}
 				}
 

--- a/cmd/src/snapshot_restore.go
+++ b/cmd/src/snapshot_restore.go
@@ -15,11 +15,11 @@ import (
 )
 
 func init() {
-	usage := `'src snapshot databases' generates commands to export Sourcegraph database dumps.
+	usage := `'src snapshot restore' restores a Sourcegraph instance using Sourcegraph database dumps.
 Note that these commands are intended for use as reference - you may need to adjust the commands for your deployment.
 
 USAGE
-	src [-v] snapshot databases [--targets=<docker|k8s|"targets.yaml">] [--run] <pg_dump|docker|kubectl> 
+	src [-v] snapshot restore [--targets<docker|k8s|"targets.yaml">] [--run] <pg_dump|docker|kubectl>
 
 TARGETS FILES
 	Predefined targets are available based on default Sourcegraph configurations ('docker', 'k8s').
@@ -37,7 +37,8 @@ TARGETS FILES
 
 	See the pgdump.Targets type for more details.
 `
-	flagSet := flag.NewFlagSet("databases", flag.ExitOnError)
+
+	flagSet := flag.NewFlagSet("restore", flag.ExitOnError)
 	targetsKeyFlag := flagSet.String("targets", "auto", "predefined targets ('docker' or 'k8s'), or a custom targets.yaml file")
 	run := flagSet.Bool("run", false, "Automatically run the commands")
 
@@ -60,7 +61,7 @@ TARGETS FILES
 			case "pg_dump", "":
 				targetKey = "local"
 				commandBuilder = func(t pgdump.Target) (string, error) {
-					cmd := pgdump.DumpCommand(t)
+					cmd := pgdump.RestoreCommad(t)
 					if t.Target != "" {
 						return fmt.Sprintf("%s --host=%s", cmd, t.Target), nil
 					}
@@ -68,12 +69,12 @@ TARGETS FILES
 				}
 			case "docker":
 				commandBuilder = func(t pgdump.Target) (string, error) {
-					return fmt.Sprintf("docker exec -i %s sh -c '%s'", t.Target, pgdump.DumpCommand(t)), nil
+					return fmt.Sprintf("docker exec -i %s sh -c '%s'", t.Target, pgdump.RestoreCommad(t)), nil
 				}
 			case "kubectl":
 				targetKey = "k8s"
 				commandBuilder = func(t pgdump.Target) (string, error) {
-					return fmt.Sprintf("kubectl exec -i %s -- bash -c '%s'", t.Target, pgdump.DumpCommand(t)), nil
+					return fmt.Sprintf("kubectl exec -i %s -- bash -c '%s'", t.Target, pgdump.RestoreCommad(t)), nil
 				}
 			default:
 				return errors.Newf("unknown or invalid template type %q", builder)
@@ -96,13 +97,10 @@ TARGETS FILES
 				out.WriteLine(output.Emojif(output.EmojiInfo, "Using predefined targets for %s environments", targetKey))
 			}
 
-			commands, err := pgdump.BuildCommands(srcSnapshotDir, commandBuilder, targets, true)
+			commands, err := pgdump.BuildCommands(srcSnapshotDir, commandBuilder, targets, false)
 			if err != nil {
 				return errors.Wrap(err, "failed to build commands")
 			}
-
-			_ = os.MkdirAll(srcSnapshotDir, os.ModePerm)
-
 			if *run {
 				for _, c := range commands {
 					out.WriteLine(output.Emojif(output.EmojiInfo, "Running command: %q", c))
@@ -113,77 +111,19 @@ TARGETS FILES
 					}
 				}
 
-				out.WriteLine(output.Emoji(output.EmojiSuccess, "Sucessfully completed dump commands"))
+				out.WriteLine(output.Emoji(output.EmojiSuccess, "Sucessfully completed restore commands"))
+				out.WriteLine(output.Styledf(output.StyleSuggestion, "It may be necessary to restart your Sourcegraph instance after restoring"))
 			} else {
-				b := out.Block(output.Emoji(output.EmojiSuccess, "Run these commands to generate the required database dumps:"))
+				b := out.Block(output.Emoji(output.EmojiSuccess, "Run these commands to restore the databases:"))
 				b.Write("\n" + strings.Join(commands, "\n"))
 				b.Close()
 
 				out.WriteLine(output.Styledf(output.StyleSuggestion, "Note that you may need to do some additional setup, such as authentication, beforehand."))
 			}
+
 			return nil
 		},
+
 		usageFunc: func() { fmt.Fprint(flag.CommandLine.Output(), usage) },
 	})
-}
-
-// predefinedDatabaseDumpTargets is based on default Sourcegraph configurations.
-var predefinedDatabaseDumpTargets = map[string]pgdump.Targets{
-	"local": {
-		Primary: pgdump.Target{
-			DBName:   "sg",
-			Username: "sg",
-			Password: "sg",
-		},
-		CodeIntel: pgdump.Target{
-			DBName:   "sg",
-			Username: "sg",
-			Password: "sg",
-		},
-		CodeInsights: pgdump.Target{
-			DBName:   "postgres",
-			Username: "postgres",
-			Password: "password",
-		},
-	},
-	"docker": { // based on deploy-sourcegraph-managed
-		Primary: pgdump.Target{
-			Target:   "pgsql",
-			DBName:   "sg",
-			Username: "sg",
-			Password: "sg",
-		},
-		CodeIntel: pgdump.Target{
-			Target:   "codeintel-db",
-			DBName:   "sg",
-			Username: "sg",
-			Password: "sg",
-		},
-		CodeInsights: pgdump.Target{
-			Target:   "codeinsights-db",
-			DBName:   "postgres",
-			Username: "postgres",
-			Password: "password",
-		},
-	},
-	"k8s": { // based on deploy-sourcegraph-helm
-		Primary: pgdump.Target{
-			Target:   "statefulset/pgsql",
-			DBName:   "sg",
-			Username: "sg",
-			Password: "sg",
-		},
-		CodeIntel: pgdump.Target{
-			Target:   "statefulset/codeintel-db",
-			DBName:   "sg",
-			Username: "sg",
-			Password: "sg",
-		},
-		CodeInsights: pgdump.Target{
-			Target:   "statefulset/codeinsights-db",
-			DBName:   "postgres",
-			Username: "postgres",
-			Password: "password",
-		},
-	},
 }

--- a/cmd/src/snapshot_restore.go
+++ b/cmd/src/snapshot_restore.go
@@ -50,35 +50,13 @@ TARGETS FILES
 			}
 			out := output.NewOutput(flagSet.Output(), output.OutputOpts{Verbose: *verbose})
 
-			var builder string
-			if len(args) > 0 {
-				builder = args[len(args)-1]
-			}
+			builder := flagSet.Arg(0)
 
-			targetKey := "docker"
-			var commandBuilder pgdump.CommandBuilder
-			switch builder {
-			case "pg_dump", "":
-				targetKey = "local"
-				commandBuilder = func(t pgdump.Target) (string, error) {
-					cmd := pgdump.RestoreCommand(t)
-					if t.Target != "" {
-						return fmt.Sprintf("%s --host=%s", cmd, t.Target), nil
-					}
-					return cmd, nil
-				}
-			case "docker":
-				commandBuilder = func(t pgdump.Target) (string, error) {
-					return fmt.Sprintf("docker exec -i %s sh -c '%s'", t.Target, pgdump.RestoreCommand(t)), nil
-				}
-			case "kubectl":
-				targetKey = "k8s"
-				commandBuilder = func(t pgdump.Target) (string, error) {
-					return fmt.Sprintf("kubectl exec -i %s -- bash -c '%s'", t.Target, pgdump.RestoreCommand(t)), nil
-				}
-			default:
+			commandBuilder, targetKey := pgdump.Builder(builder, pgdump.RestoreCommand)
+			if targetKey == "" {
 				return errors.Newf("unknown or invalid template type %q", builder)
 			}
+
 			if *targetsKeyFlag != "auto" {
 				targetKey = *targetsKeyFlag
 			}

--- a/internal/pgdump/pgdump.go
+++ b/internal/pgdump/pgdump.go
@@ -31,7 +31,7 @@ type Target struct {
 }
 
 // RestoreCommand generates a psql command that can be used for migrations.
-func RestoreCommad(t Target) string {
+func RestoreCommand(t Target) string {
 	dump := fmt.Sprintf("psql --username=%s --dbname=%s",
 		t.Username, t.DBName)
 	if t.Password == "" {

--- a/internal/pgdump/pgdump.go
+++ b/internal/pgdump/pgdump.go
@@ -30,9 +30,19 @@ type Target struct {
 	Password string `yaml:"password"`
 }
 
-// Command generates a pg_dump command that can be used for on-prem-to-Cloud migrations.
-func Command(t Target) string {
-	dump := fmt.Sprintf("pg_dump --no-owner --format=p --no-acl --username=%s --dbname=%s",
+// RestoreCommand generates a psql command that can be used for migrations.
+func RestoreCommad(t Target) string {
+	dump := fmt.Sprintf("psql --username=%s --dbname=%s",
+		t.Username, t.DBName)
+	if t.Password == "" {
+		return dump
+	}
+	return fmt.Sprintf("PGPASSWORD=%s %s", t.Password, dump)
+}
+
+// DumpCommand generates a pg_dump command that can be used for on-prem-to-Cloud migrations.
+func DumpCommand(t Target) string {
+	dump := fmt.Sprintf("pg_dump --no-owner --format=p --no-acl --clean --if-exists --username=%s --dbname=%s",
 		t.Username, t.DBName)
 	if t.Password == "" {
 		return dump
@@ -64,14 +74,19 @@ type CommandBuilder func(Target) (string, error)
 
 // BuildCommands generates commands that output Postgres dumps and sends them to predefined
 // files for each target database.
-func BuildCommands(outDir string, commandBuilder CommandBuilder, targets Targets) ([]string, error) {
+func BuildCommands(outDir string, commandBuilder CommandBuilder, targets Targets, dump bool) ([]string, error) {
 	var commands []string
 	for _, t := range Outputs(outDir, targets) {
 		c, err := commandBuilder(t.Target)
 		if err != nil {
 			return nil, errors.Wrapf(err, "generating command for %q", t.Output)
 		}
-		commands = append(commands, fmt.Sprintf("%s > %s", c, t.Output))
+
+		if dump {
+			commands = append(commands, fmt.Sprintf("%s > %s", c, t.Output))
+		} else {
+			commands = append(commands, fmt.Sprintf("%s < %s", c, t.Output))
+		}
 	}
 	return commands, nil
 }

--- a/internal/pgdump/pgdump.go
+++ b/internal/pgdump/pgdump.go
@@ -32,7 +32,7 @@ type Target struct {
 
 // RestoreCommand generates a psql command that can be used for migrations.
 func RestoreCommand(t Target) string {
-	dump := fmt.Sprintf("psql --username=%s --dbname=%s",
+	dump := fmt.Sprintf("psql --username=%s --dbname=%s 1>/dev/null",
 		t.Username, t.DBName)
 	if t.Password == "" {
 		return dump


### PR DESCRIPTION
Snapshot Restore generates commands to restore dumped snapshots to a Sourcegraph instance

Usage:
After generating a dump the restore commands can be generated with
```
src snapshot restore <docker|kubectlpg_dump>
```
The `--run` command can be used to attempt to automatically run these commands. Useful e.g. in the AMIs e.g.
```
src snapshot restore --run <docker|kubectlpg_dump>
```


- Changed snapshot args ordering
  - To get the --run flag to work it was necessary to change arg ordering as Go's flag package requires all flags come before non flag args
```
src snapshot databases docker --run
# changes to
src snapshot databases --run docker
```
- Removed the -t flags from <docker|kubectl> exec
  - afaik only -i should be necessary for input/output redirection. Without -t we get better compatibility (prevents `device is not a TTY error`) 

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
- Generated snapshots using the snapshot tool and then restored them to another instance (running the same Sourcegraph version)
