### PR TITLE
version: Clarify origin of error

### DIFF
--- a/cmd/src/version.go
+++ b/cmd/src/version.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"net/http"
 
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+
 	"github.com/sourcegraph/src-cli/internal/api"
 	"github.com/sourcegraph/src-cli/internal/version"
 )
@@ -37,7 +39,7 @@ Examples:
 		client := cfg.apiClient(apiFlags, flagSet.Output())
 		recommendedVersion, err := getRecommendedVersion(context.Background(), client)
 		if err != nil {
-			return err
+			return errors.Wrap(err, "failed to get recommended version for Sourcegraph deployment")
 		}
 		if recommendedVersion == "" {
 			fmt.Println("Recommended version: <unknown>")


### PR DESCRIPTION
This could be confusing, it only says server error and prints details on that, so it sounds like src-cli just broke? At least it confused people at Sourcegraph. This prefixes it with some more context to help that.

### Test plan

Error shows correctly, tested manually.