### PR TITLE
Allow empty commits in copy pre-release step

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -133,7 +133,7 @@ jobs:
           git config user.name sourcegraph-bot
           git config user.email sourcegraph-bot-github@sourcegraph.com
           git add .
-          git commit -m "Copy previous release"
+          git commit --allow-empty -m "Copy previous release"
           git push
 
   # goreleaser runs tests before building, then uses goreleaser to publish to Homebrew and


### PR DESCRIPTION
To make the pre-release step `Copy previous release` idempotent in case of failures, we will allow empty commits to the homebrew tap repo. That way, even if the step already ran and succeeded, it can successfully be re-run with no change.

### Test plan

About to test with an actual release.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
