### PR TITLE
Admin: fix `src admin create` outputting token to stderr instead of stdout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ All notable changes to `src-cli` are documented in this file.
 
 ### Fixed
 
+- Fixed `src admin create` returning token to stderr instead of stdout.
+
 ### Removed
 
 ## 5.0.2

--- a/cmd/src/admin_create.go
+++ b/cmd/src/admin_create.go
@@ -83,10 +83,7 @@ Environmental variables
 				return err
 			}
 
-			_, err = fmt.Fprintf(flag.CommandLine.Output(), "%s\n", token)
-			if err != nil {
-				return err
-			}
+			fmt.Println(token)
 		}
 
 		return nil


### PR DESCRIPTION
Fix issue where token output for `src admin create --token` would output to `stderr` instead of `stdout`.

### Test plan
Tested on latest Sourcegraph install locally.
Ran `go test ./...` with all tests passing.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
