### PR TITLE
Validate: add fix for `src validate install` failure with Sourcegraph v5.0.0

### DIFF
--- a/internal/validate/install/install.go
+++ b/internal/validate/install/install.go
@@ -147,9 +147,10 @@ func repoCloneTimeout(ctx context.Context, client api.Client, repo string, srv E
 func listClonedRepos(ctx context.Context, client api.Client, names []string) ([]string, error) {
 	q := clientQuery{
 		opName: "ListRepos",
-		query: `query ListRepos($names: [String!]) {
+		query: `query ListRepos($names: [String!], $first: Int) {
 			  repositories(
 				names: $names
+				first: $first
 			  ) {
 				nodes {
 				  name
@@ -161,6 +162,7 @@ func listClonedRepos(ctx context.Context, client api.Client, names []string) ([]
 			}`,
 		variables: jsonVars{
 			"names": names,
+			"first": 5,
 		},
 	}
 


### PR DESCRIPTION
Add fix to `src validate install` command.

### Test plan

- Ran `go test ./...` with all tests passing.
- Ran `staticcheck ./...` with no new warnings returned.
- Validated changes work with Sourcegraph 5.0.0 (see below)
<img width="811" alt="Screenshot 2023-03-27 at 5 26 35 PM" src="https://user-images.githubusercontent.com/1760552/228070506-a925d4e2-c532-4cc7-98ac-00b8c062feba.png">

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
