### PR TITLE
Update to Go 1.19.8

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-golang 1.19.7
+golang 1.19.8
 shfmt 3.2.0
 shellcheck 0.7.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 #
 # Nothing fancy here: we copy in the source code and build on the Alpine Go
 # image. Refer to .dockerignore to get a sense of what we're not going to copy.
-FROM golang:1.17-alpine@sha256:1d4c7fcfd0c4c917383755ca3b6f6c1f797ec16b83cdebc672d9b08a79b64644 as builder
+FROM golang:1.19.8-alpine@sha256:841c160ed35923d96c95c52403c4e6db5decd9cbce034aa851e412ade5d4b74f as builder
 
 COPY . /src
 WORKDIR /src


### PR DESCRIPTION
Update to 1.19.8 because it fixes multiple vulnerabilities.

[_Created by Sourcegraph batch change `evict/update-to-go1.19.8`._](https://sourcegraph.sourcegraph.com/users/evict/batch-changes/update-to-go1.19.8)

## Test plan
Verify build locally.