### PR TITLE
actions: fix job name conflict

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -2,7 +2,7 @@ name: Go CI
 
 on:
   - push
-  - pull-request
+  - pull_request
 
 jobs:
   go-test:

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -2,8 +2,6 @@ name: Go CI
 
 on:
   - push
-  - pull_request:
-      types: [synchronize]
 
 jobs:
   go-test:

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -2,6 +2,7 @@ name: Go CI
 
 on:
   - push
+  - pull-request
 
 jobs:
   go-test:

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -2,7 +2,8 @@ name: Go CI
 
 on:
   - push
-  - pull_request
+  - pull_request:
+      types: [synchronize]
 
 jobs:
   go-test:

--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -4,7 +4,7 @@ on:
   - push
 
 jobs:
-  go-test:
+  go-lint:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
The Go Lint and Go Test workflows named their jobs `go-test`, which prohibited the Go Test workflow from running - specifically the ubuntu one, as the `go-test` job on ubuntu-latest also exists in the Go Lint workflow. Updated the name and now the Go Test Ubuntu latest action is running again.
### Test plan
Go Test actions are running
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
