### PR TITLE
Fix URL for SCIP upload progress

### DIFF
--- a/cmd/src/code_intel_upload.go
+++ b/cmd/src/code_intel_upload.go
@@ -99,7 +99,7 @@ func handleCodeIntelUpload(args []string) error {
 		return handleUploadError(out, err)
 	}
 
-	uploadURL, err := makeCodeIntelUploadURL(uploadID)
+	uploadURL, err := makeCodeIntelUploadURL(uploadID, isSCIPAvailable)
 	if err != nil {
 		return err
 	}
@@ -207,14 +207,20 @@ func printInferredArguments(out *output.Output) {
 
 // makeCodeIntelUploadURL constructs a URL to the upload with the given internal identifier.
 // The base of the URL is constructed from the configured Sourcegraph instance.
-func makeCodeIntelUploadURL(uploadID int) (string, error) {
+func makeCodeIntelUploadURL(uploadID int, isSCIPAvailable bool) (string, error) {
 	url, err := url.Parse(cfg.Endpoint)
 	if err != nil {
 		return "", err
 	}
 
 	graphqlID := base64.URLEncoding.EncodeToString([]byte(fmt.Sprintf(`LSIFUpload:%d`, uploadID)))
-	url.Path = codeintelUploadFlags.repo + "/-/code-intelligence/uploads/" + graphqlID
+
+	codeGraphPart := "code-graph"
+	if !isSCIPAvailable {
+		codeGraphPart = "code-intelligence"
+	}
+
+	url.Path = codeintelUploadFlags.repo + "/-/" + codeGraphPart + "/uploads/" + graphqlID
 	url.User = nil
 	return url.String(), nil
 }


### PR DESCRIPTION
Previously, when running `src code-intel upload` it printed out a URL to `/code-intelligence/uploads/..` that returned a 404 in newer Sourcegraph instances since the URL has changed to `/code-graph/`. This commit fixes the issue by using `/code-graph` for newer Sourcegraph instances.

### Test plan

N/A

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
