### PR TITLE
(feat) add "src repos {add|update|delete}-metadata -repo-name" flag support

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,5 +8,6 @@
   "go.useLanguageServer": true,
   "gopls": {
     "local": "github.com/sourcegraph/src-cli"
-  }
+  },
+  "cody.codebase": "github.com/sourcegraph/src-cli",
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to `src-cli` are documented in this file.
 ### Added
 - `src validate install` can check executor connections [#974](https://github.com/sourcegraph/src-cli/pull/974)
 - `src validate install` can send test SMTP message [#973](https://github.com/sourcegraph/src-cli/pull/973)
+- `src repos {add|update|delete}-metadata -repo-name` flag support [#977](https://github.com/sourcegraph/src-cli/pull/977)
 
 ### Changed
 - Renamed `src repo {add|update|delete}-kvp` to `repo {add|update|delete}-metadata` [#972](https://github.com/sourcegraph/src-cli/pull/972)

--- a/cmd/src/repos.go
+++ b/cmd/src/repos.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+
 	"github.com/sourcegraph/src-cli/internal/api"
 )
 
@@ -124,4 +126,14 @@ func fetchRepositoryID(ctx context.Context, client api.Client, repoName string) 
 		return "", fmt.Errorf("repository not found: %s", repoName)
 	}
 	return result.Repository.ID, nil
+}
+
+func getRepoIdOrError(ctx context.Context, client api.Client, id *string, repoName *string) (*string, error) {
+	if *id != "" {
+		return id, nil
+	} else if *repoName != "" {
+		repoID, err := fetchRepositoryID(ctx, client, *repoName)
+		return &repoID, err
+	}
+	return nil, errors.New("error: repo or repoName is required")
 }

--- a/cmd/src/repos_add_metadata.go
+++ b/cmd/src/repos_add_metadata.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+
 	"github.com/sourcegraph/src-cli/internal/api"
 )
 
@@ -29,18 +30,16 @@ Examples:
 		fmt.Println(usage)
 	}
 	var (
-		repoFlag  = flagSet.String("repo", "", `The ID of the repo to add the key-value pair metadata to (required)`)
-		keyFlag   = flagSet.String("key", "", `The name of the  metadata key to add (required)`)
-		valueFlag = flagSet.String("value", "", `The  metadata value associated with the  metadata key. Defaults to null.`)
-		apiFlags  = api.NewFlags(flagSet)
+		repoFlag     = flagSet.String("repo", "", `The ID of the repo to add the key-value pair metadata to (required)`)
+		repoNameFlag = flagSet.String("repo-name", "", `The ID of the repo to add the key-value pair metadata to (required)`)
+		keyFlag      = flagSet.String("key", "", `The name of the  metadata key to add (required)`)
+		valueFlag    = flagSet.String("value", "", `The  metadata value associated with the  metadata key. Defaults to null.`)
+		apiFlags     = api.NewFlags(flagSet)
 	)
 
 	handler := func(args []string) error {
 		if err := flagSet.Parse(args); err != nil {
 			return err
-		}
-		if *repoFlag == "" {
-			return errors.New("error: repo is required")
 		}
 
 		keyFlag = nil
@@ -61,6 +60,11 @@ Examples:
 		}
 
 		client := cfg.apiClient(apiFlags, flagSet.Output())
+		ctx := context.Background()
+		repoID, err := getRepoIdOrError(ctx, client, repoFlag, repoNameFlag)
+		if err != nil {
+			return err
+		}
 
 		query := `mutation addRepoMetadata(
   $repo: ID!,
@@ -77,10 +81,10 @@ Examples:
 }`
 
 		if ok, err := client.NewRequest(query, map[string]interface{}{
-			"repo":  *repoFlag,
+			"repo":  *repoID,
 			"key":   *keyFlag,
 			"value": valueFlag,
-		}).Do(context.Background(), nil); err != nil || !ok {
+		}).Do(ctx, nil); err != nil || !ok {
 			return err
 		}
 

--- a/cmd/src/repos_add_metadata.go
+++ b/cmd/src/repos_add_metadata.go
@@ -30,8 +30,8 @@ Examples:
 		fmt.Println(usage)
 	}
 	var (
-		repoFlag     = flagSet.String("repo", "", `The ID of the repo to add the key-value pair metadata to (required)`)
-		repoNameFlag = flagSet.String("repo-name", "", `The ID of the repo to add the key-value pair metadata to (required)`)
+		repoFlag     = flagSet.String("repo", "", `The ID of the repo to add the key-value pair metadata to (required if -repo-name is not specified)`)
+		repoNameFlag = flagSet.String("repo-name", "", `The name of the repo to add the key-value pair metadata to (required if -repo is not specified)`)
 		keyFlag      = flagSet.String("key", "", `The name of the  metadata key to add (required)`)
 		valueFlag    = flagSet.String("value", "", `The  metadata value associated with the  metadata key. Defaults to null.`)
 		apiFlags     = api.NewFlags(flagSet)

--- a/cmd/src/repos_delete_metadata.go
+++ b/cmd/src/repos_delete_metadata.go
@@ -28,8 +28,8 @@ Examples:
 		fmt.Println(usage)
 	}
 	var (
-		repoFlag     = flagSet.String("repo", "", `The ID of the repo with the key-value pair metadata to be deleted (required)`)
-		repoNameFlag = flagSet.String("repo-name", "", `The ID of the repo to add the key-value pair metadata to (required)`)
+		repoFlag     = flagSet.String("repo", "", `The ID of the repo with the key-value pair metadata to be deleted (required if -repo-name is not specified)`)
+		repoNameFlag = flagSet.String("repo-name", "", `The name of the repo to add the key-value pair metadata to (required if -repo is not specified)`)
 		keyFlag      = flagSet.String("key", "", `The name of the  metadata key to be deleted (required)`)
 		apiFlags     = api.NewFlags(flagSet)
 	)

--- a/cmd/src/repos_delete_metadata.go
+++ b/cmd/src/repos_delete_metadata.go
@@ -28,17 +28,15 @@ Examples:
 		fmt.Println(usage)
 	}
 	var (
-		repoFlag = flagSet.String("repo", "", `The ID of the repo with the key-value pair metadata to be deleted (required)`)
-		keyFlag  = flagSet.String("key", "", `The name of the  metadata key to be deleted (required)`)
-		apiFlags = api.NewFlags(flagSet)
+		repoFlag     = flagSet.String("repo", "", `The ID of the repo with the key-value pair metadata to be deleted (required)`)
+		repoNameFlag = flagSet.String("repo-name", "", `The ID of the repo to add the key-value pair metadata to (required)`)
+		keyFlag      = flagSet.String("key", "", `The name of the  metadata key to be deleted (required)`)
+		apiFlags     = api.NewFlags(flagSet)
 	)
 
 	handler := func(args []string) error {
 		if err := flagSet.Parse(args); err != nil {
 			return err
-		}
-		if *repoFlag == "" {
-			return errors.New("error: repo is required")
 		}
 
 		keyFlag = nil
@@ -53,6 +51,11 @@ Examples:
 		}
 
 		client := cfg.apiClient(apiFlags, flagSet.Output())
+		ctx := context.Background()
+		repoID, err := getRepoIdOrError(ctx, client, repoFlag, repoNameFlag)
+		if err != nil {
+			return err
+		}
 
 		query := `mutation deleteRepoMetadata(
   $repo: ID!,
@@ -67,9 +70,9 @@ Examples:
 }`
 
 		if ok, err := client.NewRequest(query, map[string]interface{}{
-			"repo": *repoFlag,
+			"repo": *repoID,
 			"key":  *keyFlag,
-		}).Do(context.Background(), nil); err != nil || !ok {
+		}).Do(ctx, nil); err != nil || !ok {
 			return err
 		}
 

--- a/cmd/src/repos_update_metadata.go
+++ b/cmd/src/repos_update_metadata.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+
 	"github.com/sourcegraph/src-cli/internal/api"
 )
 
@@ -29,18 +30,16 @@ Examples:
 		fmt.Println(usage)
 	}
 	var (
-		repoFlag  = flagSet.String("repo", "", `The ID of the repo with the metadata key to be updated (required)`)
-		keyFlag   = flagSet.String("key", "", `The name of the metadata key to be updated (required)`)
-		valueFlag = flagSet.String("value", "", `The new metadata value of the metadata key to be set. Defaults to null.`)
-		apiFlags  = api.NewFlags(flagSet)
+		repoFlag     = flagSet.String("repo", "", `The ID of the repo with the metadata key to be updated (required)`)
+		repoNameFlag = flagSet.String("repo-name", "", `The ID of the repo to add the key-value pair metadata to (required)`)
+		keyFlag      = flagSet.String("key", "", `The name of the metadata key to be updated (required)`)
+		valueFlag    = flagSet.String("value", "", `The new metadata value of the metadata key to be set. Defaults to null.`)
+		apiFlags     = api.NewFlags(flagSet)
 	)
 
 	handler := func(args []string) error {
 		if err := flagSet.Parse(args); err != nil {
 			return err
-		}
-		if *repoFlag == "" {
-			return errors.New("error: repo is required")
 		}
 
 		keyFlag = nil
@@ -61,6 +60,11 @@ Examples:
 		}
 
 		client := cfg.apiClient(apiFlags, flagSet.Output())
+		ctx := context.Background()
+		repoID, err := getRepoIdOrError(ctx, client, repoFlag, repoNameFlag)
+		if err != nil {
+			return err
+		}
 
 		query := `mutation updateMetadata(
   $repo: ID!,
@@ -77,10 +81,10 @@ Examples:
 }`
 
 		if ok, err := client.NewRequest(query, map[string]interface{}{
-			"repo":  *repoFlag,
+			"repo":  *repoID,
 			"key":   *keyFlag,
 			"value": valueFlag,
-		}).Do(context.Background(), nil); err != nil || !ok {
+		}).Do(ctx, nil); err != nil || !ok {
 			return err
 		}
 

--- a/cmd/src/repos_update_metadata.go
+++ b/cmd/src/repos_update_metadata.go
@@ -30,8 +30,8 @@ Examples:
 		fmt.Println(usage)
 	}
 	var (
-		repoFlag     = flagSet.String("repo", "", `The ID of the repo with the metadata key to be updated (required)`)
-		repoNameFlag = flagSet.String("repo-name", "", `The ID of the repo to add the key-value pair metadata to (required)`)
+		repoFlag     = flagSet.String("repo", "", `The ID of the repo with the metadata key to be updated (required if -repo-name is not specified)`)
+		repoNameFlag = flagSet.String("repo-name", "", `The name of the repo to add the key-value pair metadata to (required if -repo is not specified)`)
 		keyFlag      = flagSet.String("key", "", `The name of the metadata key to be updated (required)`)
 		valueFlag    = flagSet.String("value", "", `The new metadata value of the metadata key to be set. Defaults to null.`)
 		apiFlags     = api.NewFlags(flagSet)


### PR DESCRIPTION
Part of https://github.com/sourcegraph/pr-faqs/issues/96.

This PR adds `src repos {add|update|delete}-metadata -repo-name` flag support

**NOTE**: When using `repo-name` flag, it makes an extra GQL query to get a repo ID. This is made for back compat purposes instead of introducing breaking change and updating underlying add/update/delete repo metadata GQL query.

### Test plan
- Add/update/delete using `repo` flag as previously
  - `go run ./cmd/src repos add-metadata -repo=$repoID -key=test`
  - `go run ./cmd/src repos update-metadata -repo=$repoID -key=test -value=value`
  - `go run ./cmd/src repos delete-metadata -repo=$repoID -key=test`
- Add/update/delete using `repo-name` flag as previously
  - `go run ./cmd/src repos add-metadata -repo-name=$repoName -key=test`
  - `go run ./cmd/src repos update-metadata -repo-name=$repoName -key=test -value=value`
  - `go run ./cmd/src repos delete-metadata -repo-name=$repoName -key=test`
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
