### PR TITLE
scout/usage: add `--container` flag to `src scout usage`

### DIFF
--- a/cmd/src/scout_usage.go
+++ b/cmd/src/scout_usage.go
@@ -47,6 +47,7 @@ func init() {
 		kubeConfig *string
 		namespace  = flagSet.String("namespace", "", "(optional) specify the kubernetes namespace to use")
 		pod        = flagSet.String("pod", "", "(optional) specify a single pod")
+		container  = flagSet.String("container", "", "(optional) specify a single container")
 		docker     = flagSet.Bool("docker", false, "(optional) using docker deployment")
 		spy        = flagSet.Bool("spy", false, "(optional) see resource usage in real time")
 	)
@@ -92,14 +93,17 @@ func init() {
 		if *pod != "" {
 			options = append(options, usage.WithPod(*pod))
 		}
+		if *container != "" || *docker {
+			if *container != "" {
+				options = append(options, usage.WithContainer(*container))
+			}
 
-		if *docker {
 			dockerClient, err := client.NewClientWithOpts(client.FromEnv)
 			if err != nil {
 				return errors.Wrap(err, "error creating docker client: ")
 			}
 
-			return usage.Docker(context.Background(), *dockerClient)
+			return usage.Docker(context.Background(), *dockerClient, options...)
 		}
 
 		return usage.K8s(

--- a/cmd/src/scout_usage.go
+++ b/cmd/src/scout_usage.go
@@ -29,6 +29,9 @@ func init() {
         Check usage for specific pod
         $ src scout usage --pod <podname>
 
+        Check usage for specific container (docker only)
+        $ src scout usage --container <containername>
+
         Add namespace if using namespace in a Kubernetes cluster
         $ src scout usage --namespace <namespace>
         

--- a/internal/scout/usage/docker.go
+++ b/internal/scout/usage/docker.go
@@ -90,7 +90,7 @@ func makeDockerUsageRow(ctx context.Context, cfg *Config, container types.Contai
 		errors.Wrap(err, "could not get container stats")
 		os.Exit(1)
 	}
-	defer stats.Body.Close()
+	defer func() { _ = stats.Body.Close() }()
 
 	var usage types.StatsJSON
 	if err := json.NewDecoder(stats.Body).Decode(&usage); err != nil {

--- a/internal/scout/usage/docker.go
+++ b/internal/scout/usage/docker.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/charmbracelet/bubbles/table"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -64,6 +65,18 @@ func renderDockerUsageTable(ctx context.Context, cfg *Config, containers []types
 
 		row := makeDockerUsageRow(ctx, cfg, containerInfo)
 		rows = append(rows, row)
+	}
+
+	if len(rows) == 0 {
+		msg := lipgloss.NewStyle().Foreground(lipgloss.Color("#FFA500"))
+		if cfg.container == "" {
+			fmt.Println(msg.Render(`No docker containers are running.`))
+			os.Exit(1)
+		}
+		fmt.Println(msg.Render(
+			fmt.Sprintf(`No container with name '%s' running.`, cfg.container),
+		))
+		os.Exit(1)
 	}
 
 	style.ResourceTable(columns, rows)


### PR DESCRIPTION
### Test plan
Test manually:
- with other sub commands in different orders
- on healthy and unhealthy docker deployments of sourcegraph

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
