### PR TITLE
add output flag for advise

### DIFF
--- a/cmd/src/scout_advise.go
+++ b/cmd/src/scout_advise.go
@@ -23,17 +23,14 @@ func init() {
         Make recommendations for all pods in a kubernetes deployment of Sourcegraph.
         $ src scout advise
         
-        Make recommendations for all containers in a Docker deployment of Sourcegraph.
-        $ src scout advise
-        
         Make recommendations for specific pod:
         $ src scout advise --pod <podname>
 
-        Make recommendations for specific container:
-        $ src scout advise --container <containername>
-
         Add namespace if using namespace in a Kubernetes cluster
         $ src scout advise --namespace <namespace>
+
+        Output advice to file
+        $ src scout advise --o path/to/file
     `
 
 	flagSet := flag.NewFlagSet("advise", flag.ExitOnError)
@@ -48,6 +45,7 @@ func init() {
 		namespace  = flagSet.String("namespace", "", "(optional) specify the kubernetes namespace to use")
 		pod        = flagSet.String("pod", "", "(optional) specify a single pod")
 		container  = flagSet.String("container", "", "(optional) specify a single container")
+        output     = flagSet.String("o", "", "(optional) output advice to file")
 		docker     = flagSet.Bool("docker", false, "(optional) using docker deployment")
 	)
 
@@ -89,6 +87,9 @@ func init() {
 		if *pod != "" {
 			options = append(options, advise.WithPod(*pod))
 		}
+        if *output != "" {
+            options = append(options, advise.WithOutput(*output))
+        }
 		if *container != "" || *docker {
 			if *container != "" {
 				options = append(options, advise.WithContainer(*container))

--- a/internal/scout/advise/advise.go
+++ b/internal/scout/advise/advise.go
@@ -28,3 +28,9 @@ func WithContainer(containerName string) Option {
 		config.Container = containerName
 	}
 }
+
+func WithOutput(pathToFile string) Option {
+	return func(config *scout.Config) {
+		config.Output = pathToFile
+	}
+}

--- a/internal/scout/advise/k8s.go
+++ b/internal/scout/advise/k8s.go
@@ -3,6 +3,7 @@ package advise
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/src-cli/internal/scout"
@@ -24,6 +25,7 @@ func K8s(
 		Namespace:     "default",
 		Pod:           "",
 		Container:     "",
+		Output:        "",
 		Spy:           false,
 		Docker:        false,
 		RestConfig:    restConfig,
@@ -64,6 +66,11 @@ func K8s(
 	return nil
 }
 
+// Advise generates resource allocation advice for a Kubernetes pod.
+// The function fetches usage metrics for each container in the pod. It then 
+// checks the usage percentages against thresholds to determine if more or less 
+// of a resource is needed. Advice is generated and either printed to the console 
+// or output to a file depending on the cfg.Output field.
 func Advise(ctx context.Context, cfg *scout.Config, pod v1.Pod) error {
 	var advice []string
 	usageMetrics, err := getUsageMetrics(ctx, cfg, pod)
@@ -83,15 +90,39 @@ func Advise(ctx context.Context, cfg *scout.Config, pod v1.Pod) error {
 			advice = append(advice, storageAdvice)
 		}
 
-		fmt.Println(scout.EmojiFingerPointRight, pod.Name)
-		for _, msg := range advice {
-			fmt.Println(msg)
+		if cfg.Output != "" {
+			outputToFile(ctx, cfg, pod, advice)
+		} else {
+			for _, msg := range advice {
+				fmt.Println(msg)
+			}
 		}
 	}
 
 	return nil
 }
 
+// outputToFile writes resource allocation advice for a Kubernetes pod to a file.
+func outputToFile(ctx context.Context, cfg *scout.Config, pod v1.Pod, advice []string) error {
+	file, err := os.OpenFile(cfg.Output, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return errors.Wrap(err, "failed to open file")
+	}
+	defer file.Close()
+
+	if _, err := file.WriteString(fmt.Sprintf("- %s\n", pod.Name)); err != nil {
+		return errors.Wrap(err, "failed to write pod name to file")
+	}
+
+	for _, msg := range advice {
+		if _, err := file.WriteString(fmt.Sprintf("%s\n", msg)); err != nil {
+			return errors.Wrap(err, "failed to write container advice to file")
+		}
+	}
+	return nil
+}
+
+// getUsageMetrics generates resource usage statistics for containers in a Kubernetes pod.
 func getUsageMetrics(ctx context.Context, cfg *scout.Config, pod v1.Pod) ([]scout.UsageStats, error) {
 	var usages []scout.UsageStats
 	var usage scout.UsageStats

--- a/internal/scout/types.go
+++ b/internal/scout/types.go
@@ -12,6 +12,7 @@ type Config struct {
 	Namespace     string
 	Pod           string
 	Container     string
+	Output        string
 	Spy           bool
 	Docker        bool
 	RestConfig    *rest.Config


### PR DESCRIPTION
### Test plan
Manually test output command for single pod output and cluster wide.
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
