### PR TITLE
use --clean instead of --rm-dist

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -194,7 +194,7 @@ jobs:
           # we want to update the main (unversioned) Homebrew formula. For releasing a
           # patch on an older version, we want to publish a new versioned formula and
           # leave the main formula untouched.
-          args: release --rm-dist --config=${{ env.config_file }}
+          args: release --clean --config=${{ env.config_file }}
         env:
           # Use separate access token, because we need a scope:repo token to publish the brew formula.
           GITHUB_TOKEN: ${{ secrets.GH_PAT }}


### PR DESCRIPTION
This command is deprecated and I suspect is causing an error in the release.

### Test plan
N/A
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
