### PR TITLE
help text: remove 'upload' command that does not exist

### DIFF
--- a/cmd/src/main.go
+++ b/cmd/src/main.go
@@ -45,7 +45,6 @@ The commands are:
 	repos,repo      manages repositories
 	search          search for results on Sourcegraph
 	serve-git       serves your local git repositories over HTTP for Sourcegraph to pull
-	upload          upload an index to a Sourcegraph instance
 	users,user      manages users
 	codeowners      manages code ownership information
 	version         display and compare the src-cli version against the recommended version for your instance


### PR DESCRIPTION
There is no `src upload` command. So let's remove it from the help text.

Test Plan:

```
φ go run ./cmd/src upload
src: unknown subcommand "upload"
Run 'src help' for usage.
exit status 1
```

