### PR TITLE
codeintel: handle -insecure-skip-verify in SCIP endpoint detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ All notable changes to `src-cli` are documented in this file.
 
 ### Fixed
 
+- Fixed `src code-intel upload` not respecting `-insecure-skip-verify`. [#1012](https://github.com/sourcegraph/src-cli/pull/1012)
+
 ### Removed
 
 ## 5.1.0

--- a/cmd/src/code_intel_upload.go
+++ b/cmd/src/code_intel_upload.go
@@ -71,12 +71,7 @@ Examples:
 func handleCodeIntelUpload(args []string) error {
 	ctx := context.Background()
 
-	isSCIPAvailable, err := isSCIPAvailable()
-	if err != nil {
-		return err
-	}
-
-	out, err := parseAndValidateCodeIntelUploadFlags(args, isSCIPAvailable)
+	out, isSCIPAvailable, err := parseAndValidateCodeIntelUploadFlags(args)
 	if !codeintelUploadFlags.json {
 		if out != nil {
 			printInferredArguments(out)


### PR DESCRIPTION
Previously, we were doing SCIP detection before parsing cli flags. As SCIP detection makes a HTTP request, this meant it wasnt configured with the (global :grimacing:) API client flags

### Test plan

Ran manually to confirm flag is picked up at the correct time with :sparkles: print statements :sparkles: 
