### PR TITLE
batches: File upload error handling

### DIFF
--- a/cmd/src/batch_common.go
+++ b/cmd/src/batch_common.go
@@ -535,7 +535,7 @@ func executeBatchSpec(ctx context.Context, opts executeBatchSpecOpts) (err error
 	}
 	if hasWorkspaceFiles {
 		execUI.UploadingWorkspaceFiles()
-		if err = svc.UploadBatchSpecWorkspaceFiles(ctx, batchSpecDir, string(id), batchSpec.Steps); err != nil {
+		if err := svc.UploadBatchSpecWorkspaceFiles(ctx, batchSpecDir, string(id), batchSpec.Steps); err != nil {
 			// Since failing to upload workspace files should not stop processing, just warn
 			execUI.UploadingWorkspaceFilesWarning(errors.Wrap(err, "uploading workspace files"))
 		} else {

--- a/internal/batches/service/remote.go
+++ b/internal/batches/service/remote.go
@@ -213,7 +213,7 @@ func createFormFile(w *multipart.Writer, workingDir string, mountPath string) er
 		return err
 	}
 	if fileStat.Size() > maxFileSize {
-		return errors.New("file exceeds limit of 10MB")
+		return errors.Newf("file %q exceeds limit of 10MB", mountPath)
 	}
 
 	filePath, fileName := filepath.Split(mountPath)


### PR DESCRIPTION
Two recent issues were found.
* When a file exceeded the size limit, the file name was not in the error. This made it hard to tell which file is causing the issue
* The error being returned was still set after logging as a warn. This made it so the program still errored out

[Thread](https://sourcegraph.slack.com/archives/C04M9JE73E1/p1691434360532449) of context.

### Test plan

Existing tests cover changes.

![Screenshot 2023-08-07 at 13 41 54](https://github.com/sourcegraph/src-cli/assets/38407415/43ba4aca-124b-4137-97cf-8d6c94ed1f60)