### PR TITLE
Clean up volumes if workspace preparation fails

### DIFF
--- a/internal/batches/workspace/volume_workspace_test.go
+++ b/internal/batches/workspace/volume_workspace_test.go
@@ -211,6 +211,10 @@ func TestVolumeWorkspaceCreator(t *testing.T) {
 					DockerVolumeWorkspaceImage,
 					"sh", "-c", "touch /work/*; chown -R 0:0 /work",
 				),
+				expect.NewGlob(
+					expect.Behaviour{ExitCode: 0},
+					"docker", "volume", "rm", volumeID,
+				),
 			},
 			steps: []batcheslib.Step{
 				{},
@@ -253,6 +257,10 @@ func TestVolumeWorkspaceCreator(t *testing.T) {
 					DockerVolumeWorkspaceImage,
 					"sh", "/run.sh",
 				),
+				expect.NewGlob(
+					expect.Behaviour{ExitCode: 0},
+					"docker", "volume", "rm", volumeID,
+				),
 			},
 			steps: []batcheslib.Step{
 				{},
@@ -285,6 +293,10 @@ func TestVolumeWorkspaceCreator(t *testing.T) {
 					"--mount", "type=volume,source="+volumeID+",target=/work",
 					DockerVolumeWorkspaceImage,
 					"sh", "-c", "unzip /tmp/zip; rm /work/*",
+				),
+				expect.NewGlob(
+					expect.Behaviour{ExitCode: 0},
+					"docker", "volume", "rm", volumeID,
 				),
 			},
 			steps: []batcheslib.Step{


### PR DESCRIPTION
If workspace preparation fails, the temporary Docker volume is not cleaned up.

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->

I'll need help filling in this bit. Apart from manually inducing an error with the workspace process, how else? I could possibly build locally a broken batch-change container image that doesn't have Git nor unzip?