### PR TITLE
changelog entry for codeintel upload concurrency flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to `src-cli` are documented in this file.
 
 ### Added
 
+- Added flag to configure the concurrency of uploading multipart code-intel indexes, for when limited upload bandwidth causes individual parts to timeout. [#1023](https://github.com/sourcegraph/src-cli/pull/1023)
+
 ### Changed
 
 ### Fixed


### PR DESCRIPTION
Changelog entry for https://github.com/sourcegraph/src-cli/pull/1023

### Test plan

N/A changelog entry
