### PR TITLE
codeintel: Fail fast on 401 failure in SCIP detection

### DIFF
--- a/cmd/src/code_intel_upload_flags.go
+++ b/cmd/src/code_intel_upload_flags.go
@@ -202,6 +202,9 @@ func isSCIPAvailable() (bool, error) {
 		return false, err
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusUnauthorized {
+		return false, upload.ErrUnauthorized
+	}
 
 	return resp.StatusCode == http.StatusOK, nil
 }


### PR DESCRIPTION
Don't convert SCIP to LSIF, don't attempt to upload the index

Fixes https://github.com/sourcegraph/src-cli/issues/1032

### Test plan

Manually tested with a bogus token