### PR TITLE
servegit: use error hook

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -1875,8 +1875,8 @@ def go_dependencies():
         name = "com_github_sourcegraph_sourcegraph_lib",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/sourcegraph/sourcegraph/lib",
-        sum = "h1:NJyyvyYU/DNZmNFui8ktnHke3hS/PYLmDUbWNHSHKuQ=",
-        version = "v0.0.0-20230316093010-26299ec302d0",
+        sum = "h1:0hAo7bbfcF3uujbq2eNl2DpN6zUrjacWAK3iSan5Q0k=",
+        version = "v0.0.0-20230914103605-e3a8bc516ddc",
     )
     go_repository(
         name = "com_github_spf13_afero",

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/sourcegraph/go-diff v0.6.2-0.20221123165719-f8cd299c40f3
 	github.com/sourcegraph/jsonx v0.0.0-20200629203448-1a936bd500cf
 	github.com/sourcegraph/scip v0.3.1-0.20230627154934-45df7f6d33fc
-	github.com/sourcegraph/sourcegraph/lib v0.0.0-20230822113036-acc34d9b2e95
+	github.com/sourcegraph/sourcegraph/lib v0.0.0-20230914103605-e3a8bc516ddc
 	github.com/stretchr/testify v1.8.4
 	golang.org/x/net v0.12.0
 	golang.org/x/sync v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -425,8 +425,8 @@ github.com/sourcegraph/log v0.0.0-20230711093019-40c57b632cca h1:VwYrG1+YNyOD3nS
 github.com/sourcegraph/log v0.0.0-20230711093019-40c57b632cca/go.mod h1:IDp09QkoqS8Z3CyN2RW6vXjgABkNpDbyjLIHNQwQ8P8=
 github.com/sourcegraph/scip v0.3.1-0.20230627154934-45df7f6d33fc h1:o+eq0cjVV3B5ngIBF04Lv3GwttKOuYFF5NTcfXWXzfA=
 github.com/sourcegraph/scip v0.3.1-0.20230627154934-45df7f6d33fc/go.mod h1:7ZKAtLIUmiMvOIgG5LMcBxdtBXVa0v2GWC4Hm1ASYQ0=
-github.com/sourcegraph/sourcegraph/lib v0.0.0-20230822113036-acc34d9b2e95 h1:xkoH/Vn4HMAga75N1YgTdv8nhjCXtbkw0BLY7+M3oyk=
-github.com/sourcegraph/sourcegraph/lib v0.0.0-20230822113036-acc34d9b2e95/go.mod h1:hhrNfT3eDxsAsjaWEn8vWjmrEFDa9v238tDf9TyEAHc=
+github.com/sourcegraph/sourcegraph/lib v0.0.0-20230914103605-e3a8bc516ddc h1:0hAo7bbfcF3uujbq2eNl2DpN6zUrjacWAK3iSan5Q0k=
+github.com/sourcegraph/sourcegraph/lib v0.0.0-20230914103605-e3a8bc516ddc/go.mod h1:r5UrJ7GztZRFu/LlF5lNS5XzAsnYdGphS4CJEm4Lnts=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
 github.com/spf13/cobra v1.7.0 h1:hyqWnYt1ZQShIddO5kBpj3vu05/++x6tJ6dg8EC572I=

--- a/internal/servegit/serve.go
+++ b/internal/servegit/serve.go
@@ -106,6 +106,9 @@ func (s *Serve) handler() http.Handler {
 		Dir: func(name string) string {
 			return filepath.Join(s.Root, filepath.FromSlash(name))
 		},
+		ErrorHook: func(err error, stderr string) {
+			s.Info.Printf("git-service error: %s\nstderr:\n%s", err.Error(), stderr)
+		},
 		Trace: func(ctx context.Context, svc, repo, protocol string) func(error) {
 			start := time.Now()
 			return func(err error) {


### PR DESCRIPTION
Before this if the git command failed we would nil panic since the Logger on gitservice.Handler was not set. This commit updates us to the latest version of lib which instead takes in an error hook so we can use the attached stdlib logger.

Corresponding PR at https://github.com/sourcegraph/sourcegraph/pull/56611

Test Plan: go test