### PR TITLE
Batches: populate branch name during template resolution

### DIFF
--- a/internal/batches/executor/run_steps.go
+++ b/internal/batches/executor/run_steps.go
@@ -141,8 +141,12 @@ func RunSteps(ctx context.Context, opts *RunStepsOpts) (stepResults []execution.
 
 		stepContext := template.StepContext{
 			BatchChange: *opts.Task.BatchChangeAttributes,
-			Repository:  util.NewTemplatingRepo(opts.Task.Repository.Name, opts.Task.Repository.FileMatches),
-			Outputs:     lastOutputs,
+			Repository: util.NewTemplatingRepo(
+				opts.Task.Repository.Name,
+				opts.Task.Repository.Branch.Name,
+				opts.Task.Repository.FileMatches,
+			),
+			Outputs: lastOutputs,
 			Steps: template.StepsContext{
 				Path:    opts.Task.Path,
 				Changes: previousStepResult.ChangedFiles,

--- a/internal/batches/util/repo.go
+++ b/internal/batches/util/repo.go
@@ -10,13 +10,14 @@ import (
 
 // NewTemplatingRepo transforms a given *graphql.Repository into a
 // template.Repository.
-func NewTemplatingRepo(repoName string, fileMatches map[string]bool) template.Repository {
+func NewTemplatingRepo(repoName string, branch string, fileMatches map[string]bool) template.Repository {
 	matches := make([]string, 0, len(fileMatches))
 	for path := range fileMatches {
 		matches = append(matches, path)
 	}
 	return template.Repository{
 		Name:        repoName,
+		Branch:      branch,
 		FileMatches: matches,
 	}
 }


### PR DESCRIPTION
During batch execution, we were creating the template variable with no branch name set, which meant that steps would just get an empty string for the branch name if it is used in a step.

Fixes https://github.com/sourcegraph/sourcegraph/issues/59250

### Test plan

Ran a batch change that uses the `${{ repository.branch }}` template variable and ensured that the variable gets populated with a non-empty string. 