### PR TITLE
npm: add readme when prepacking

### DIFF
--- a/npm-distribution/package.json
+++ b/npm-distribution/package.json
@@ -7,7 +7,7 @@
   "license": "Apache-2.0",
   "scripts": {
     "install": "node install.js",
-    "prepack": "cp ../LICENSE ."
+    "prepack": "cp ../LICENSE . && cp ../README.md ."
   },
   "main": "src.js",
   "bin": {


### PR DESCRIPTION
### Test plan

Next release should include a README in `npmjs.com`


![CleanShot 2024-02-21 at 11 36 30@2x](https://github.com/sourcegraph/src-cli/assets/25608335/413900b7-6e2e-44bc-a130-021e24528012)
