### PR TITLE
Chore: fix deprecated field

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -41,7 +41,7 @@ brews:
       name: homebrew-src-cli
     # Folder inside the repository to put the formula.
     # Default is the root folder.
-    folder: Formula
+    directory: Formula
     # We need to set this so that goreleaser doesn't think the binary is called
     # `src-cli`
     install: |


### PR DESCRIPTION
After bumping the goreleaser version, a CI step is failing because we are using a field that was deprecated. [Example](https://github.com/sourcegraph/src-cli/actions/runs/8542214451/job/23403373409?pr=1065). This just follows the deprecation instructions to fix it. 

### Test plan

Goreleaser step passes.


<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
