### PR TITLE
validate: add context to connection error

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,14 +17,19 @@ linters:
 
 linters-settings:
   depguard:
-    list-type: blacklist
-    include-go-root: true
-    packages-with-error-message:
-      - errors: 'Use github.com/sourcegraph/sourcegraph/lib/errors instead'
-      - github.com/pkg/errors: 'Use github.com/sourcegraph/sourcegraph/lib/errors instead'
-      - github.com/cockroachdb/errors: 'Use github.com/sourcegraph/sourcegraph/lib/errors instead'
-      - github.com/hashicorp/go-multierror: 'Use github.com/sourcegraph/sourcegraph/lib/errors instead'
-      - io/ioutil: 'The ioutil package has been deprecated'
+    rules:
+      main:
+        deny:
+          - pkg: "errors"
+            desc: "Use github.com/sourcegraph/sourcegraph/lib/errors instead"
+          - pkg: "github.com/pkg/errors"
+            desc: "Use github.com/sourcegraph/sourcegraph/lib/errors instead"
+          - pkg: "github.com/cockroachdb/errors"
+            desc: "Use github.com/sourcegraph/sourcegraph/lib/errors instead"
+          - pkg: "github.com/hashicorp/go-multierror"
+            desc: "Use github.com/sourcegraph/sourcegraph/lib/errors instead"
+          - pkg: "io/ioutil"
+            desc: "The ioutil package has been deprecated"
   gocritic:
     disabled-checks:
       - appendAssign # Too many false positives

--- a/dev/golangci-lint.sh
+++ b/dev/golangci-lint.sh
@@ -6,7 +6,7 @@ pushd "$(dirname "${BASH_SOURCE[0]}")/.." >/dev/null
 
 mkdir -p dev/.bin
 
-version="1.51.2"
+version="1.58.1"
 suffix="${version}-$(go env GOOS)-$(go env GOARCH)"
 target="$PWD/dev/.bin/golangci-lint-${suffix}"
 url="https://github.com/golangci/golangci-lint/releases/download/v${version}/golangci-lint-${suffix}.tar.gz"

--- a/internal/batches/ui/task_exec_tui_test.go
+++ b/internal/batches/ui/task_exec_tui_test.go
@@ -50,7 +50,7 @@ func TestTaskExecTUI_Integration(t *testing.T) {
 
 	buf := &ttyBuf{}
 
-    true_ := true
+	true_ := true
 	out := output.NewOutput(buf, output.OutputOpts{
 		ForceTTY:    &true_,
 		ForceColor:  true,
@@ -210,7 +210,7 @@ func TestProgressUpdateAfterComplete(t *testing.T) {
 	now := time.Now()
 	clock := func() time.Time { return now.UTC().Truncate(time.Millisecond) }
 
-    true_ := true
+	true_ := true
 	out := output.NewOutput(buf, output.OutputOpts{
 		ForceTTY:    &true_,
 		ForceColor:  true,

--- a/internal/validate/kube/kube.go
+++ b/internal/validate/kube/kube.go
@@ -494,7 +494,7 @@ func Connections(ctx context.Context, config *Config) ([]validate.Result, error)
 				Stderr: &stderr,
 			})
 			if err != nil {
-				return nil, err
+				return nil, errors.Wrapf(err, "connecting to %s", c.src.Name)
 			}
 
 			if stderr.String() != "" {


### PR DESCRIPTION
When src-validate fails to connect to a service, name that service in the error message.

### Test plan

There are no current automated tests for this error message, and this commit does not add any, admittedly. This is _arguably_ only a behavioral change if an external tool is parsing this particular error message.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
