### PR TITLE
fix go-generate command in goreleaser config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,7 +10,7 @@ before:
   hooks:
     - go mod download
     - go mod tidy
-    - go generate ./schema
+    - go generate ./...
 builds:
 -
   main: ./cmd/src/


### PR DESCRIPTION
https://github.com/golang/go/issues/60079 changed the behavior of go-generate when the target package does not exist. It used to silently succeeed, now it errors. The schema package was removed in 2021.

### Test plan

Manually ran `go generate`.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
