### PR TITLE
Fix windows installation

### DIFF
--- a/npm-distribution/.gitignore
+++ b/npm-distribution/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 src
 LICENSE
+README.md

--- a/npm-distribution/copy-files.js
+++ b/npm-distribution/copy-files.js
@@ -1,0 +1,8 @@
+const fs = require('fs')
+const path = require('path')
+
+const licensePath = path.join(__dirname, '..', 'LICENSE')
+const readmePath = path.join(__dirname, '..', 'README.md')
+
+fs.copyFileSync(licensePath, path.join(__dirname, 'LICENSE'))
+fs.copyFileSync(readmePath, path.join(__dirname, 'README.md'))

--- a/npm-distribution/install.js
+++ b/npm-distribution/install.js
@@ -56,9 +56,12 @@ get(assetURL, (response) => {
   }
   response
     .pipe(zlib.createGunzip())
-    .pipe(tar.x({ filter: (x) => x === "src" }))
-    .addListener("close", () => fs.chmodSync(executableName, "755"));
-});
+    .pipe(tar.x({ filter: (x) => x === executableName }))
+    .addListener("close", () => {
+      if (process.platform !== 'win32') {
+        fs.chmodSync(executableName, "755");
+      }
+    });});
 
 // Follow redirects.
 function get(url, callback) {

--- a/npm-distribution/package.json
+++ b/npm-distribution/package.json
@@ -7,7 +7,7 @@
   "license": "Apache-2.0",
   "scripts": {
     "install": "node install.js",
-    "prepack": "cp ../LICENSE . && cp ../README.md ."
+    "prepack": "node copy-files.js"
   },
   "main": "src.js",
   "bin": {


### PR DESCRIPTION
Fixes #1050. Previously, it was not possible to install src-cli via npm on Windows. It was also not possible to publish the npm package from a Windows computer. This PR fixes both problems. The second problem had to be solved so I could manually test the fix for this PR.:

### Test plan

Manually tested locally on a Windows computer

- Ran `verdaccio`
- Set package version to 5.4.0
- `pnpm unpublish --force`
- `pnpm publish`
- Created new project, ran `pnpm init`
- `pnpm add @sourcegraph/src`
- `pnpm exec src login`, confirmed it worked
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
