### PR TITLE
chore(security) : upgrade golang to 1.22.5 to fix CVE

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -7,7 +7,7 @@ jobs:
   go-test:
     strategy:
       matrix:
-        go-version: [1.22.2]
+        go-version: [1.22.5]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -12,5 +12,5 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.2
+          go-version: 1.22.5
       - run: ./dev/go-lint.sh

--- a/.github/workflows/goreleaser-check.yml
+++ b/.github/workflows/goreleaser-check.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.2
+          go-version: 1.22.5
       - name: Check GoReleaser config
         uses: goreleaser/goreleaser-action@v5
         with:

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -177,7 +177,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22
+          go-version: 1.22.5
       - run: go test ./...
       - run: go test -race -v ./...
       - run: echo "${DOCKER_PASSWORD}" | docker login -u=$DOCKER_USERNAME --password-stdin

--- a/.github/workflows/pr-auditor.yml
+++ b/.github/workflows/pr-auditor.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           repository: 'sourcegraph/pr-auditor'
       - uses: actions/setup-go@v5
-        with: { go-version: '1.22.2' }
+        with: { go-version: '1.22.5' }
 
       - run: './check-pr.sh'
         env:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-golang 1.22.3
+golang 1.22.5
 shfmt 3.8.0
 shellcheck 0.10.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 #
 # Nothing fancy here: we copy in the source code and build on the Alpine Go
 # image. Refer to .dockerignore to get a sense of what we're not going to copy.
-FROM golang:1.22.3-alpine@sha256:df479aa7d1298917c7de7fd56c7231ec450149f1e63d960ea96aebf9ff9240c5 as builder
+FROM golang:1.22.3-alpine@sha256:4707c052e5bd90c1c6ae16d1825e3ea5076ec1b06de30e34596b1e6f6b9916cf as builder
 
 COPY . /src
 WORKDIR /src

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/sourcegraph/src-cli
 
 go 1.22
 
-toolchain go1.22.2
+toolchain go1.22.5
 
 require (
 	cloud.google.com/go/storage v1.30.1


### PR DESCRIPTION
Needed for fixing CVE in executor-* (executor, executor-kubernetes, bundled-executor) docker images

https://github.com/advisories/GHSA-49gw-vxvf-fc2g, https://github.com/advisories/GHSA-2jwv-jmq4-4j3r

ref: https://github.com/sourcegraph/sourcegraph/issues/63796

### Test plan

- CI 

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
