### PR TITLE
Remove ro for locally mounted folders

### DIFF
--- a/internal/batches/executor/run_steps.go
+++ b/internal/batches/executor/run_steps.go
@@ -345,7 +345,7 @@ func executeSingleStep(
 		if err != nil {
 			return bytes.Buffer{}, bytes.Buffer{}, err
 		}
-		args = append(args, "--mount", fmt.Sprintf("type=bind,source=%s,target=%s,ro", workspaceFilePath, mount.Mountpoint))
+		args = append(args, "--mount", fmt.Sprintf("type=bind,source=%s,target=%s", workspaceFilePath, mount.Mountpoint))
 	}
 
 	for k, v := range env {


### PR DESCRIPTION
https://github.com/sourcegraph/src-cli/issues/1055

Remove read-only config from locally mounted folders. This gives more flexibility to locally run Batch Changes since more files can be shared as output for any step where the folder is mounted. 