### PR TITLE
chore(security): Update go version to 1.22.8

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -7,7 +7,7 @@ jobs:
   go-test:
     strategy:
       matrix:
-        go-version: [1.22.5]
+        go-version: [1.22.8]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -12,5 +12,5 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.5
+          go-version: 1.22.8
       - run: ./dev/go-lint.sh

--- a/.github/workflows/goreleaser-check.yml
+++ b/.github/workflows/goreleaser-check.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.5
+          go-version: 1.22.8
       - name: Check GoReleaser config
         uses: goreleaser/goreleaser-action@v5
         with:

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -177,7 +177,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.5
+          go-version: 1.22.8
       - run: go test ./...
       - run: go test -race -v ./...
       - run: echo "${DOCKER_PASSWORD}" | docker login -u=$DOCKER_USERNAME --password-stdin

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-golang 1.22.5
+golang 1.22.8
 shfmt 3.8.0
 shellcheck 0.10.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ All notable changes to `src-cli` are documented in this file.
 
 ## Unreleased
 
+## 5.8.0
+
+### Changed
+
+- Update Go to 1.22.8
+
 ## 5.5.0
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 #
 # Nothing fancy here: we copy in the source code and build on the Alpine Go
 # image. Refer to .dockerignore to get a sense of what we're not going to copy.
-FROM golang:1.22.3-alpine@sha256:4707c052e5bd90c1c6ae16d1825e3ea5076ec1b06de30e34596b1e6f6b9916cf as builder
+FROM golang:1.22.8-alpine@sha256:f56a8a4a1aea41bc4694728b69c219af1523aea15690cbbed82dc9bac81e6603 as builder
 
 COPY . /src
 WORKDIR /src

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/sourcegraph/src-cli
 
 go 1.22
 
-toolchain go1.22.5
+toolchain go1.22.8
 
 require (
 	cloud.google.com/go/storage v1.30.1


### PR DESCRIPTION
Update to latest 1.22 version of Go

Can we cut a new release of src-cli for the release today as this fixes a CVE.

### Test plan

- CI
- Build src-cli locally and run govulncheck
- Build docker image locally - **this fails, but also fails on `main`. Is this expected to work?** See comment below for output.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
