### PR TITLE
Add SBOM command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ bazel-zoekt
 bazel-src-cli
 .DS_Store
 samples
+sourcegraph-sboms/

--- a/cmd/src/main.go
+++ b/cmd/src/main.go
@@ -43,6 +43,7 @@ The commands are:
 	orgs,org        manages organizations
 	teams,team      manages teams
 	repos,repo      manages repositories
+	sbom			manages SBOM (Software Bill of Materials) data
 	search          search for results on Sourcegraph
 	serve-git       serves your local git repositories over HTTP for Sourcegraph to pull
 	users,user      manages users

--- a/cmd/src/main.go
+++ b/cmd/src/main.go
@@ -43,7 +43,7 @@ The commands are:
 	orgs,org        manages organizations
 	teams,team      manages teams
 	repos,repo      manages repositories
-	sbom			manages SBOM (Software Bill of Materials) data
+	sbom            manages SBOM (Software Bill of Materials) data
 	search          search for results on Sourcegraph
 	serve-git       serves your local git repositories over HTTP for Sourcegraph to pull
 	users,user      manages users

--- a/cmd/src/sbom.go
+++ b/cmd/src/sbom.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+)
+
+var sbomCommands commander
+
+func init() {
+	usage := `'src sbom' fetches and verified SBOM (Software Bill of Materials) data for Sourcegraph containers.
+
+Usage:
+
+	src sbom command [command options]
+
+The commands are:
+
+	fetch                 fetch SBOMs for a released version of Sourcegraph
+`
+	flagSet := flag.NewFlagSet("sbom", flag.ExitOnError)
+	handler := func(args []string) error {
+		sbomCommands.run(flagSet, "src sbom", usage, args)
+		return nil
+	}
+
+	// Register the command.
+	commands = append(commands, &command{
+		flagSet: flagSet,
+		aliases: []string{"sbom"},
+		handler: handler,
+		usageFunc: func() {
+			fmt.Println(usage)
+		},
+	})
+}

--- a/cmd/src/sbom_fetch.go
+++ b/cmd/src/sbom_fetch.go
@@ -89,7 +89,6 @@ Examples:
 		}
 
 		out := output.NewOutput(flagSet.Output(), output.OutputOpts{Verbose: *verbose})
-		// ui := &ui.TUI{Out: out}
 
 		if err := verifyCosign(); err != nil {
 			return cmderrors.ExitCode(1, err)

--- a/cmd/src/sbom_fetch.go
+++ b/cmd/src/sbom_fetch.go
@@ -133,7 +133,7 @@ Examples:
 		}
 
 		out.Writef("\nFetched and validated SBOMs have been written to `%s`.\n", c.outputDir)
-		out.WriteLine(output.Linef("", output.StyleBold, "Your Sourcegraph deployment may not use all of these image. Please check your deployment to confirm which images are used.\n"))
+		out.WriteLine(output.Linef("", output.StyleBold, "Your Sourcegraph deployment may not use all of these images. Please check your deployment to confirm which images are used.\n"))
 
 		if failureCount > 0 || successCount == 0 {
 			return cmderrors.ExitCode1

--- a/cmd/src/sbom_fetch.go
+++ b/cmd/src/sbom_fetch.go
@@ -112,12 +112,12 @@ Examples:
 
 		fmt.Printf("\n")
 		if failureCount == 0 && successCount == 0 {
-			out.WriteLine(output.Line(output.EmojiFailure, output.StyleWarning, "Failed to fetch SBOMs for any images"))
+			out.WriteLine(output.Line("🔴", output.StyleWarning, "Failed to fetch SBOMs for any images"))
 		}
 		if failureCount > 0 {
 			out.WriteLine(output.Line("🟠", output.StyleOrange, fmt.Sprintf("Fetched verified SBOMs for %d images, but failed to fetch SBOMs for %d images", successCount, failureCount)))
 		} else if successCount > 0 {
-			out.WriteLine(output.Line("\u2705", output.StyleSuccess, fmt.Sprintf("Fetched verified SBOMs for %d images", successCount)))
+			out.WriteLine(output.Line("🟢", output.StyleSuccess, fmt.Sprintf("Fetched verified SBOMs for %d images", successCount)))
 		}
 
 		fmt.Printf("\nFetched and validated SBOMs have been written to `%s`\n", c.outputDir)
@@ -164,11 +164,6 @@ func verifyCosign() error {
 }
 
 func (c sbomConfig) getImageList() ([]string, error) {
-	return []string{
-		"us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/pings",
-		"us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/syntax-highlighter",
-	}, nil
-
 	imageReleaseListURL := c.getImageReleaseListURL()
 
 	resp, err := http.Get(imageReleaseListURL)

--- a/cmd/src/sbom_fetch.go
+++ b/cmd/src/sbom_fetch.go
@@ -100,7 +100,8 @@ Examples:
 		out.Writef("Fetching SBOMs and validating signatures for all %d images in the Sourcegraph %s release...\n", len(images), c.version)
 
 		if c.insecureIgnoreTransparencyLog {
-			out.WriteLine(output.Line("⚠️", output.StyleWarning, "WARNING: Transparency log verification is disabled, increasing the risk that SBOMs may have been tampered with.\nThis setting should only be used for testing or under explicit instruction from Sourcegraph.\n"))
+			out.WriteLine(output.Line("⚠️", output.StyleWarning, "WARNING: Transparency log verification is disabled, increasing the risk that SBOMs may have been tampered with."))
+			out.WriteLine(output.Line("️", output.StyleWarning, "         This setting should only be used for testing or under explicit instruction from Sourcegraph.\n"))
 		}
 
 		var successCount, failureCount int

--- a/cmd/src/sbom_fetch.go
+++ b/cmd/src/sbom_fetch.go
@@ -177,9 +177,6 @@ func verifyCosign() error {
 }
 
 func (c sbomConfig) getImageList() ([]string, error) {
-
-	return []string{"sourcegraph/gitserver"}, nil
-
 	imageReleaseListURL := c.getImageReleaseListURL()
 
 	resp, err := http.Get(imageReleaseListURL)

--- a/cmd/src/sbom_fetch.go
+++ b/cmd/src/sbom_fetch.go
@@ -95,17 +95,23 @@ Examples:
 			return err
 		}
 
-		fmt.Printf("Fetching SBOMs and validating signatures for all %d images in the Sourcegraph %s deployment...\n", len(images), c.version)
+		fmt.Printf("Fetching SBOMs and validating signatures for all %d images in the Sourcegraph %s release...\n", len(images), c.version)
 
 		var successCount, failureCount int
 		for _, image := range images {
+			stopSpinner := make(chan bool)
+			go spinner(image, stopSpinner)
+
 			_, err = c.getSBOMForImageVersion(image, c.version)
+
+			stopSpinner <- true
+
 			if err != nil {
 				out.WriteLine(output.Line(output.EmojiFailure, output.StyleWarning,
-					fmt.Sprintf("%s: error fetching and validating SBOM:\n    %v", image, err)))
+					fmt.Sprintf("\r%s: error fetching and validating SBOM:\n    %v", image, err)))
 				failureCount += 1
 			} else {
-				out.WriteLine(output.Line("\u2705", output.StyleSuccess, image))
+				out.WriteLine(output.Line("\r\u2705", output.StyleSuccess, image))
 				successCount += 1
 			}
 		}

--- a/cmd/src/sbom_fetch.go
+++ b/cmd/src/sbom_fetch.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os/exec"
+
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/output"
+
+	"github.com/sourcegraph/src-cli/internal/cmderrors"
+)
+
+func init() {
+	usage := `
+'src sbom fetch' fetches and verifies SBOMs for the given release version of Sourcegraph.
+
+Usage:
+
+    src sbom fetch -v <version>
+
+Examples:
+
+    $ src sbom fetch 5.8.0
+`
+
+	flagSet := flag.NewFlagSet("fetch", flag.ExitOnError)
+	versionFlag := flagSet.String("v", "", "The version of Sourcegraph to fetch SBOMs for.")
+
+	handler := func(args []string) error {
+		// ctx := context.Background()
+
+		if err := flagSet.Parse(args); err != nil {
+			return err
+		}
+
+		if len(flagSet.Args()) != 0 {
+			return cmderrors.Usage("additional arguments not allowed")
+		}
+
+		if versionFlag == nil || *versionFlag == "" {
+			return cmderrors.Usage("version is required")
+		}
+
+		out := output.NewOutput(flagSet.Output(), output.OutputOpts{Verbose: *verbose})
+		// ui := &ui.TUI{Out: out}
+
+		fmt.Printf("Version is %s\n", *versionFlag)
+
+		out.WriteLine(output.Line("\u2705", output.StyleSuccess, "Doing some sbom stuff!."))
+
+		if err := verifyCosign(); err != nil {
+			return cmderrors.ExitCode(1, err)
+		}
+
+		images, err := getImageList()
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("Verifying SBOM for images: %v\n", images)
+
+		return nil
+	}
+
+	sbomCommands = append(sbomCommands, &command{
+		flagSet: flagSet,
+		handler: handler,
+		usageFunc: func() {
+			fmt.Fprintf(flag.CommandLine.Output(), "Usage of 'src sbom %s':\n", flagSet.Name())
+			flagSet.PrintDefaults()
+			fmt.Println(usage)
+		},
+	})
+}
+
+func verifyCosign() error {
+	_, err := exec.LookPath("cosign")
+	if err != nil {
+		return errors.New("SBOM verification requires 'cosign' to be installed and available in $PATH. See https://docs.sigstore.dev/cosign/system_config/installation/")
+	}
+	return nil
+}
+
+func getImageList() ([]string, error) {
+	return []string{"gitserver", "frontend", "worker"}, nil
+}

--- a/cmd/src/sbom_fetch.go
+++ b/cmd/src/sbom_fetch.go
@@ -28,7 +28,6 @@ type sbomConfig struct {
 	insecureIgnoreTransparencyLog bool
 }
 
-// TODO: Figure out versioning
 const publicKey = "https://storage.googleapis.com/sourcegraph-release-sboms/keys/cosign_keyring-cosign-1.pub"
 const imageListBaseURL = "https://storage.googleapis.com/sourcegraph-release-sboms"
 const imageListFilename = "release-image-list.txt"

--- a/cmd/src/sbom_fetch.go
+++ b/cmd/src/sbom_fetch.go
@@ -95,7 +95,7 @@ Examples:
 			return err
 		}
 
-		fmt.Printf("Fetching SBOMs and validating signatures for all %d images in the Sourcegraph %s release...\n", len(images), c.version)
+		fmt.Printf("Fetching SBOMs and validating signatures for all %d images in the Sourcegraph %s release...\n\n", len(images), c.version)
 
 		var successCount, failureCount int
 		for _, image := range images {

--- a/cmd/src/sbom_fetch.go
+++ b/cmd/src/sbom_fetch.go
@@ -54,8 +54,6 @@ Examples:
 	insecureIgnoreTransparencyLogFlag := flagSet.Bool("insecure-ignore-tlog", false, "Disable transparency log verification. Defaults to false.")
 
 	handler := func(args []string) error {
-		// ctx := context.Background()
-
 		c := sbomConfig{
 			publicKey: publicKey,
 		}
@@ -99,7 +97,7 @@ Examples:
 			return err
 		}
 
-		fmt.Printf("Fetching SBOMs and validating signatures for all %d images in the Sourcegraph %s release...\n\n", len(images), c.version)
+		out.Writef("Fetching SBOMs and validating signatures for all %d images in the Sourcegraph %s release...\n", len(images), c.version)
 
 		if c.insecureIgnoreTransparencyLog {
 			out.WriteLine(output.Line("⚠️", output.StyleWarning, "WARNING: Transparency log verification is disabled, increasing the risk that SBOMs may have been tampered with.\nThis setting should only be used for testing or under explicit instruction from Sourcegraph.\n"))
@@ -124,7 +122,7 @@ Examples:
 			}
 		}
 
-		fmt.Printf("\n")
+		out.Write("")
 		if failureCount == 0 && successCount == 0 {
 			out.WriteLine(output.Line("🔴", output.StyleWarning, "Failed to fetch SBOMs for any images"))
 		}
@@ -134,8 +132,8 @@ Examples:
 			out.WriteLine(output.Line("🟢", output.StyleSuccess, fmt.Sprintf("Fetched verified SBOMs for %d images", successCount)))
 		}
 
-		fmt.Printf("\nFetched and validated SBOMs have been written to `%s`\n", c.outputDir)
-		fmt.Printf("\nYour Sourcegraph deployment may not use all of these image. Please check your deployment to confirm which images are used.\n\n")
+		out.Writef("\nFetched and validated SBOMs have been written to `%s`.\n", c.outputDir)
+		out.WriteLine(output.Linef("", output.StyleBold, "Your Sourcegraph deployment may not use all of these image. Please check your deployment to confirm which images are used.\n"))
 
 		if failureCount > 0 || successCount == 0 {
 			return cmderrors.ExitCode1
@@ -178,6 +176,9 @@ func verifyCosign() error {
 }
 
 func (c sbomConfig) getImageList() ([]string, error) {
+
+	return []string{"sourcegraph/gitserver"}, nil
+
 	imageReleaseListURL := c.getImageReleaseListURL()
 
 	resp, err := http.Get(imageReleaseListURL)

--- a/cmd/src/sbom_utils.go
+++ b/cmd/src/sbom_utils.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os/exec"
 	"strings"
+	"time"
 )
 
 // Manifest represents a simplified structure of the Docker manifest response
@@ -190,4 +191,20 @@ func getGcloudAccessToken() (string, error) {
 	// Trim any extra whitespace or newlines
 	token := strings.TrimSpace(string(out))
 	return token, nil
+}
+
+var spinnerChars = []rune{'⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'}
+
+func spinner(name string, stop chan bool) {
+	i := 0
+	for {
+		select {
+		case <-stop:
+			return
+		default:
+			fmt.Printf("\r%s  %s", string(spinnerChars[i%len(spinnerChars)]), name)
+			i++
+			time.Sleep(100 * time.Millisecond)
+		}
+	}
 }

--- a/cmd/src/sbom_utils.go
+++ b/cmd/src/sbom_utils.go
@@ -49,8 +49,7 @@ func getImageDigestDockerHub(image string, tag string) (string, error) {
 	req.Header.Add("Accept", "Accept: application/vnd.docker.distribution.manifest.v2+json, application/vnd.oci.image.manifest.v1+json")
 
 	// Make the HTTP request
-	client := &http.Client{}
-	resp, err := client.Do(req)
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("failed to fetch image manifest: %v", err)
 	}
@@ -141,8 +140,7 @@ func getImageDigestGcloud(image string, tag string) (string, error) {
 	req.Header.Add("Accept", "application/vnd.docker.distribution.manifest.v2+json, application/vnd.oci.image.manifest.v1+json")
 
 	// Perform the HTTP request
-	client := &http.Client{}
-	resp, err := client.Do(req)
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("failed to fetch manifest: %v", err)
 	}

--- a/cmd/src/sbom_utils.go
+++ b/cmd/src/sbom_utils.go
@@ -29,7 +29,6 @@ func getImageDigest(image string, tag string) (string, error) {
 		return getImageDigestDockerHub(image, tag)
 	} else if strings.HasPrefix(image, "us-central1-docker.pkg.dev/") {
 		return getImageDigestGcloud(image, tag)
-		return "", fmt.Errorf("GCP Artifact Registry not yet supported: %s", image)
 	} else {
 		return "", fmt.Errorf("unsupported image registry: %s", image)
 	}

--- a/cmd/src/sbom_utils.go
+++ b/cmd/src/sbom_utils.go
@@ -1,0 +1,193 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os/exec"
+	"strings"
+)
+
+// Manifest represents a simplified structure of the Docker manifest response
+type dockerHubManifest struct {
+	Config struct {
+		Digest string `json:"digest"`
+	} `json:"config"`
+}
+
+// TokenResponse represents the JSON response from dockerHub's token service
+type dockerHubTokenResponse struct {
+	Token string `json:"token"`
+}
+
+// getImageDigest returns the sha256 hash for the given image and tag
+// It supports multiple registries
+func getImageDigest(image string, tag string) (string, error) {
+	if strings.HasPrefix(image, "sourcegraph/") {
+		return getImageDigestDockerHub(image, tag)
+	} else if strings.HasPrefix(image, "us-central1-docker.pkg.dev/") {
+		return getImageDigestGcloud(image, tag)
+		return "", fmt.Errorf("GCP Artifact Registry not yet supported: %s", image)
+	} else {
+		return "", fmt.Errorf("unsupported image registry: %s", image)
+	}
+}
+
+//
+// Implement functionality for Docker Hub
+
+// getImageDigestDockerHub returns the sha256 digest for the given image and tag from DockerHub
+func getImageDigestDockerHub(image string, tag string) (string, error) {
+	// Construct the DockerHub manifest URL
+	url := fmt.Sprintf("https://registry-1.docker.io/v2/%s/manifests/%s", image, tag)
+
+	token, err := getDockerHubAuthToken(image)
+	if err != nil {
+		return "", err
+	}
+
+	// Create a new HTTP request with the authorization header
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token))
+	req.Header.Add("Accept", "Accept: application/vnd.docker.distribution.manifest.v2+json, application/vnd.oci.image.manifest.v1+json")
+
+	// Make the HTTP request
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch image manifest: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// Check for a successful response
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("failed to get manifest - check %s is a valid Sourcegraph release, status code: %d", tag, resp.StatusCode)
+	}
+
+	// Read the response body
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read manifest body: %v", err)
+	}
+
+	// Parse the manifest JSON to extract the digest
+	var manifest dockerHubManifest
+	err = json.Unmarshal(body, &manifest)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse manifest: %v", err)
+	}
+
+	// Return the image's digest (hash)
+	return manifest.Config.Digest, nil
+}
+
+// getDockerHubAuthToken returns an auth token with scope to pull the given image
+// Note that the token has a short validity so it should be used immediately
+func getDockerHubAuthToken(image string) (string, error) {
+	// Set the DockerHub authentication URL
+	url := fmt.Sprintf("https://auth.docker.io/token?service=registry.docker.io&scope=repository:%s:pull", image)
+
+	// Create a new HTTP request
+	resp, err := http.Get(url)
+	if err != nil {
+		return "", fmt.Errorf("failed to get token: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// Check if the response status is 200 OK
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("failed to get token, status code: %d", resp.StatusCode)
+	}
+
+	// Read the response body
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read response body: %v", err)
+	}
+
+	// Unmarshal the JSON response
+	var tokenResponse dockerHubTokenResponse
+	if err := json.Unmarshal(body, &tokenResponse); err != nil {
+		return "", fmt.Errorf("failed to parse token response: %v", err)
+	}
+
+	// Return the token
+	return tokenResponse.Token, nil
+}
+
+//
+// Implement functionality for GCP Artifact Registry
+
+// getImageDigestGcloud fetches the OCI image manifest from GCP Artifact Registry and returns the image digest
+func getImageDigestGcloud(image string, tag string) (string, error) {
+	// Validate image path to ensure it's a valid GCP Artifact Registry image
+	if !strings.HasPrefix(image, "us-central1-docker.pkg.dev/") {
+		return "", fmt.Errorf("invalid image format: %s", image)
+	}
+
+	// Get the GCP access token
+	token, err := getGcloudAccessToken()
+	if err != nil {
+		return "", fmt.Errorf("error getting access token: %v", err)
+	}
+
+	parts := strings.SplitN(image, "/", 2)
+	if len(parts) != 2 {
+		return "", fmt.Errorf("invalid image format: %s", image)
+	}
+	domain := parts[0]
+	repositoryPath := parts[1]
+
+	// Create the URL to fetch the manifest for the specific image and tag
+	url := fmt.Sprintf("https://%s/v2/%s/manifests/%s", domain, repositoryPath, tag)
+
+	// Create a new HTTP GET request
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to create HTTP request: %v", err)
+	}
+
+	// Add the Authorization and Accept headers
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token))
+	req.Header.Add("Accept", "application/vnd.docker.distribution.manifest.v2+json, application/vnd.oci.image.manifest.v1+json")
+
+	// Perform the HTTP request
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch manifest: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// Check if the request was successful
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("failed to get manifest, status code: %d, response: %s", resp.StatusCode, string(body))
+	}
+
+	// Get the image digest from the `Docker-Content-Digest` header
+	digest := resp.Header.Get("Docker-Content-Digest")
+	if digest == "" {
+		return "", fmt.Errorf("digest not found in response headers")
+	}
+
+	return digest, nil
+}
+
+// getGcloudAccessToken runs 'gcloud auth print-access-token' and returns the access token
+func getGcloudAccessToken() (string, error) {
+	// Execute the gcloud command to get the access token
+	cmd := exec.Command("gcloud", "auth", "print-access-token")
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to retrieve access token using `gcloud auth`. Ensure that gcloud is installed and you have authenticated: %v", err)
+	}
+
+	// Trim any extra whitespace or newlines
+	token := strings.TrimSpace(string(out))
+	return token, nil
+}


### PR DESCRIPTION
Add new `src sbom` command to allow customers to fetch and verify [SBOMs](https://github.com/sourcegraph/sourcegraph/pull/566/commits).

This command will fetch SBOMs from our container registry, and validate them against a published public key.

To test this out locally:

```
$ go run ./cmd/src sbom fetch -v 5.8.287 --internal --insecure-ignore-tlog

Fetching SBOMs and validating signatures for all 55 images in the Sourcegraph 5.8.287 release...

⚠️ WARNING: Transparency log verification is disabled, increasing the risk that SBOMs may have been tampered with.
This setting should only be used for testing or under explicit instruction from Sourcegraph.

✅ us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/appliance
✅ us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/batcheshelper
✅ us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/bundled-executor
[...]
```

This will be followed by customer-facing docs around using this command.

### Test plan

- Relying on CI
- Manual testing. This command is very reliant on external services, so building full testing seems disproportionate to the complexity.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
