### PR TITLE
sboms: Update changelog and improve error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ All notable changes to `src-cli` are documented in this file.
 
 ## 5.8.0
 
+### Added
+
+- SBOM support: Software Bill of Materials (SBOMs) can now be fetched for Sourcegraph releases after 5.8.0 using `src sbom fetch -v <release>`. [#1115](https://github.com/sourcegraph/src-cli/pull/1115)
+
 ### Changed
 
 - Update Go to 1.22.8

--- a/cmd/src/sbom_fetch.go
+++ b/cmd/src/sbom_fetch.go
@@ -187,7 +187,6 @@ func (c sbomConfig) getImageList() ([]string, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-
 		// Compare version number against a regex that matches versions up to and including 5.8.0
 		versionRegex := regexp.MustCompile(`^v?[0-5]\.([0-7]\.[0-9]+|8\.0)$`)
 		if versionRegex.MatchString(c.version) {

--- a/cmd/src/sbom_fetch.go
+++ b/cmd/src/sbom_fetch.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"unicode"
 
+	"github.com/grafana/regexp"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/lib/output"
 
@@ -186,6 +187,12 @@ func (c sbomConfig) getImageList() ([]string, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
+
+		// Compare version number against a regex that matches versions up to and including 5.8.0
+		versionRegex := regexp.MustCompile(`^v?[0-5]\.([0-7]\.[0-9]+|8\.0)$`)
+		if versionRegex.MatchString(c.version) {
+			return nil, fmt.Errorf("unsupported version %s: SBOMs are only available for Sourcegraph releases after 5.8.0", c.version)
+		}
 		return nil, fmt.Errorf("failed to fetch list of images - check that %s is a valid Sourcegraph release: HTTP status %d", c.version, resp.StatusCode)
 	}
 


### PR DESCRIPTION
Add missing changelog entry for https://github.com/sourcegraph/src-cli/pull/1115.

Also improve the error message when an unsupported version is passed:

Unsupported version <=5.8.0:
```
> go run ./cmd/src sbom fetch -v 5.8.0 --internal --insecure-ignore-tlog
unsupported version 5.8.0: SBOMs are only available for Sourcegraph releases after 5.8.0
```

Supported version >5.8.0:
```
>  go run ./cmd/src sbom fetch -v 5.8.287 --internal --insecure-ignore-tlog
Fetching SBOMs and validating signatures for all 55 images in the Sourcegraph 5.8.287 release...

⚠️ WARNING: Transparency log verification is disabled, increasing the risk that SBOMs may have been tampered with.
️          This setting should only be used for testing or under explicit instruction from Sourcegraph.

✅ us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/appliance
✅ us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/batcheshelper
[...]
```

### Test plan

- Tested change locally
- CI

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
