### PR TITLE
Fix #1105: Execute commands with zero arguments correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ All notable changes to `src-cli` are documented in this file.
 
 ## Unreleased
 
+## 5.8.1
+
+### Fixed
+
+- Fixed an issue preventing some commands from executing correctly when no arguments are passed [#1117](https://github.com/sourcegraph/src-cli/pull/1117)
+
 ## 5.8.0
 
 ### Added

--- a/cmd/src/cmd.go
+++ b/cmd/src/cmd.go
@@ -89,20 +89,21 @@ func (c commander) run(flagSet *flag.FlagSet, cmdName, usageText string, args []
 			log.Fatal("reading config: ", err)
 		}
 
-		// Parse subcommand flags.
-		args := flagSet.Args()[1:]
-		if err := cmd.flagSet.Parse(args); err != nil {
-			panic(fmt.Sprintf("all registered commands should use flag.ExitOnError: error: %s", err))
-		}
-
-		// Show usage examples for subcommand
+		// Print help to stdout if requested
 		if slices.IndexFunc(args, func(s string) bool {
-			return s == "help" || s == "--help"
+			return s == "--help"
 		}) >= 0 {
 			cmd.flagSet.SetOutput(os.Stdout)
 			flag.CommandLine.SetOutput(os.Stdout)
 			cmd.flagSet.Usage()
 			os.Exit(0)
+		}
+
+		// Parse subcommand flags.
+		args := flagSet.Args()[1:]
+		if err := cmd.flagSet.Parse(args); err != nil {
+			fmt.Printf("Error parsing subcommand flags: %s\n", err)
+			panic(fmt.Sprintf("all registered commands should use flag.ExitOnError: error: %s", err))
 		}
 
 		// Execute the subcommand.

--- a/cmd/src/cmd.go
+++ b/cmd/src/cmd.go
@@ -96,7 +96,7 @@ func (c commander) run(flagSet *flag.FlagSet, cmdName, usageText string, args []
 		}
 
 		// Show usage examples for subcommand
-		if len(args) == 0 || slices.IndexFunc(args, func(s string) bool {
+		if slices.IndexFunc(args, func(s string) bool {
 			return s == "help" || s == "--help"
 		}) >= 0 {
 			cmd.flagSet.SetOutput(os.Stdout)


### PR DESCRIPTION
#1105 introduced a bug spotted in https://sourcegraph.slack.com/archives/C05MW2TMYAV/p1728932051783959 where commands that can take no arguments wouldn't run:

```
❯ src login
'src login' helps you authenticate 'src' to access a Sourcegraph instance with your user credentials.

Usage:

    src login SOURCEGRAPH_URL
```

This was caused by `if len(args) == 0` which captured commands that didn't take arguments like `login`.

Reading through the original PR and discussion, I agree with [this logic](https://github.com/sourcegraph/src-cli/issues/689#issuecomment-1050014015) for choosing when to output to stdout/err.

There was another minor bug in the old code that I've fixed - `cmd.flagSet.Parse()` will print help to **stderr** and exit if passed a command that doesn't take subcommands and the `--help` flag, such as `src version --help`. This previously ran before the `--help` detection, so depending on the command some help output would still be written to stderr.

### Quick test cases
These make sense to me, following the logic suggested above - use `stdout` if help was requested, use `stderr` if help was triggered due to an invalid set of arguments.

`src` goes to stdout
`src help` goes to stdout (requesting help)
`src --help` goes to stderr (it's not a supported flag)

`src version` goes to stdout (correct usage of a zero-arg command)
`src version --help` goes to stdout (requesting help)

`src sbom` goes to stderr (missing args)
`src sbom --help` should go to stdout (requesting help)
`src sbom foobar` goes to stderr (invalid subcommand)
`src sbom fetch` goes to stderr (missing args)
`src sbom fetch --help` goes to stdout (requesting help)

This is a helpful little wrapper that will print stdout/stderr in front of each line:

`(go run ./cmd/src version --help 2>&1 1>&3 | sed 's/^/stderr: /' >&2) 3>&1 | sed 's/^/stdout: /`

### Test plan

- Manual testing
- CI

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
