### PR TITLE
Will/SBOM fetch dockerhub bugfixes

### DIFF
--- a/cmd/src/sbom_fetch.go
+++ b/cmd/src/sbom_fetch.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/base64"
 	"encoding/json"
 	"flag"
@@ -262,8 +263,14 @@ type attestation struct {
 }
 
 func extractSBOM(attestationBytes []byte) (string, error) {
+	// Ensure we only use the first line - occasionally Cosign includes multiple lines
+	lines := bytes.Split(attestationBytes, []byte("\n"))
+	if len(lines) == 0 {
+		return "", fmt.Errorf("attestation is empty")
+	}
+
 	var a attestation
-	if err := json.Unmarshal(attestationBytes, &a); err != nil {
+	if err := json.Unmarshal(lines[0], &a); err != nil {
 		return "", fmt.Errorf("failed to unmarshal attestation: %w", err)
 	}
 

--- a/cmd/src/sbom_utils.go
+++ b/cmd/src/sbom_utils.go
@@ -46,7 +46,7 @@ func getImageDigestDockerHub(image string, tag string) (string, error) {
 		return "", err
 	}
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token))
-	req.Header.Add("Accept", "Accept: application/vnd.docker.distribution.manifest.v2+json, application/vnd.oci.image.manifest.v1+json")
+	req.Header.Add("Accept", "application/vnd.docker.distribution.manifest.v2+json, application/vnd.oci.image.manifest.v1+json")
 
 	// Make the HTTP request
 	resp, err := http.DefaultClient.Do(req)


### PR DESCRIPTION
After today's release 5.8.1579, I've been able to retest `src sbom fetch` against attestations published on Docker Hub. This identified a few bugs I didn't run into during the original testing, and are fixed in this PR:

- Some images return the wrong digest due to a malformed Accept header
- In some cases Cosign publishes multiline attestations

### Test plan

- Local testing - fetched full set of published SBOMs from Docker Hub
- CI

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
