### PR TITLE
Add proxy support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ All notable changes to `src-cli` are documented in this file.
 
 ## Unreleased
 
+### Added
+
+- Support HTTP(S), SOCKS5, and UNIX Domain Socket proxies via SRC_PROXY environment variable. [#1120](https://github.com/sourcegraph/src-cli/pull/1120)
+
 ## 5.8.1
 
 ### Fixed

--- a/cmd/src/login.go
+++ b/cmd/src/login.go
@@ -81,7 +81,7 @@ func loginCmd(ctx context.Context, cfg *config, client api.Client, endpointArg s
 
 	if cfg.ConfigFilePath != "" {
 		fmt.Fprintln(out)
-		fmt.Fprintf(out, "⚠️  Warning: Configuring src with a JSON file is deprecated. Please migrate to using the env vars SRC_ENDPOINT and SRC_ACCESS_TOKEN instead, and then remove %s. See https://github.com/sourcegraph/src-cli#readme for more information.\n", cfg.ConfigFilePath)
+		fmt.Fprintf(out, "⚠️  Warning: Configuring src with a JSON file is deprecated. Please migrate to using the env vars SRC_ENDPOINT, SRC_ACCESS_TOKEN, and SRC_PROXY_ENDPOINT instead, and then remove %s. See https://github.com/sourcegraph/src-cli#readme for more information.\n", cfg.ConfigFilePath)
 	}
 
 	noToken := cfg.AccessToken == ""

--- a/cmd/src/login.go
+++ b/cmd/src/login.go
@@ -81,7 +81,7 @@ func loginCmd(ctx context.Context, cfg *config, client api.Client, endpointArg s
 
 	if cfg.ConfigFilePath != "" {
 		fmt.Fprintln(out)
-		fmt.Fprintf(out, "⚠️  Warning: Configuring src with a JSON file is deprecated. Please migrate to using the env vars SRC_ENDPOINT, SRC_ACCESS_TOKEN, and SRC_PROXY_ENDPOINT instead, and then remove %s. See https://github.com/sourcegraph/src-cli#readme for more information.\n", cfg.ConfigFilePath)
+		fmt.Fprintf(out, "⚠️  Warning: Configuring src with a JSON file is deprecated. Please migrate to using the env vars SRC_ENDPOINT, SRC_ACCESS_TOKEN, and SRC_PROXY instead, and then remove %s. See https://github.com/sourcegraph/src-cli#readme for more information.\n", cfg.ConfigFilePath)
 	}
 
 	noToken := cfg.AccessToken == ""

--- a/cmd/src/login_test.go
+++ b/cmd/src/login_test.go
@@ -49,7 +49,7 @@ func TestLogin(t *testing.T) {
 		if err != cmderrors.ExitCode1 {
 			t.Fatal(err)
 		}
-		wantOut := "⚠️  Warning: Configuring src with a JSON file is deprecated. Please migrate to using the env vars SRC_ENDPOINT, SRC_ACCESS_TOKEN, and SRC_PROXY_ENDPOINT instead, and then remove f. See https://github.com/sourcegraph/src-cli#readme for more information.\n\n❌ Problem: No access token is configured.\n\n🛠  To fix: Create an access token at https://example.com/user/settings/tokens, then set the following environment variables:\n\n   SRC_ENDPOINT=https://example.com\n   SRC_ACCESS_TOKEN=(the access token you just created)\n\n   To verify that it's working, run this command again."
+		wantOut := "⚠️  Warning: Configuring src with a JSON file is deprecated. Please migrate to using the env vars SRC_ENDPOINT, SRC_ACCESS_TOKEN, and SRC_PROXY instead, and then remove f. See https://github.com/sourcegraph/src-cli#readme for more information.\n\n❌ Problem: No access token is configured.\n\n🛠  To fix: Create an access token at https://example.com/user/settings/tokens, then set the following environment variables:\n\n   SRC_ENDPOINT=https://example.com\n   SRC_ACCESS_TOKEN=(the access token you just created)\n\n   To verify that it's working, run this command again."
 		if out != wantOut {
 			t.Errorf("got output %q, want %q", out, wantOut)
 		}

--- a/cmd/src/login_test.go
+++ b/cmd/src/login_test.go
@@ -49,7 +49,7 @@ func TestLogin(t *testing.T) {
 		if err != cmderrors.ExitCode1 {
 			t.Fatal(err)
 		}
-		wantOut := "⚠️  Warning: Configuring src with a JSON file is deprecated. Please migrate to using the env vars SRC_ENDPOINT and SRC_ACCESS_TOKEN instead, and then remove f. See https://github.com/sourcegraph/src-cli#readme for more information.\n\n❌ Problem: No access token is configured.\n\n🛠  To fix: Create an access token at https://example.com/user/settings/tokens, then set the following environment variables:\n\n   SRC_ENDPOINT=https://example.com\n   SRC_ACCESS_TOKEN=(the access token you just created)\n\n   To verify that it's working, run this command again."
+		wantOut := "⚠️  Warning: Configuring src with a JSON file is deprecated. Please migrate to using the env vars SRC_ENDPOINT, SRC_ACCESS_TOKEN, and SRC_PROXY_ENDPOINT instead, and then remove f. See https://github.com/sourcegraph/src-cli#readme for more information.\n\n❌ Problem: No access token is configured.\n\n🛠  To fix: Create an access token at https://example.com/user/settings/tokens, then set the following environment variables:\n\n   SRC_ENDPOINT=https://example.com\n   SRC_ACCESS_TOKEN=(the access token you just created)\n\n   To verify that it's working, run this command again."
 		if out != wantOut {
 			t.Errorf("got output %q, want %q", out, wantOut)
 		}

--- a/cmd/src/main.go
+++ b/cmd/src/main.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"net"
 	"os"
-	"os/user"
 	"path/filepath"
 	"strings"
 
@@ -229,11 +228,11 @@ func expandHomeDir(filePath string) (string, error) {
 		if testHomeDir != "" {
 			homeDir = testHomeDir
 		} else {
-			u, err := user.Current()
+			hd, err := os.UserHomeDir()
 			if err != nil {
 				return "", err
 			}
-			homeDir = u.HomeDir
+			homeDir = hd
 		}
 
 		if strings.HasPrefix(filePath, "~/") {

--- a/cmd/src/main.go
+++ b/cmd/src/main.go
@@ -264,7 +264,7 @@ func isValidUnixSocket(path string) (bool, error) {
 		if os.IsNotExist(err) {
 			return false, nil
 		}
-		return false, errors.Newf("Not a UNIX Domain Socket: %v: %v", path, err)
+		return false, errors.Newf("Not a UNIX Domain Socket: %v: %w", path, err)
 	}
 	defer conn.Close()
 

--- a/cmd/src/main.go
+++ b/cmd/src/main.go
@@ -220,6 +220,18 @@ func isValidUnixSocket(path string) (bool, error) {
 
 var testHomeDir string // used by tests to mock the user's $HOME
 
+// expandHomeDir expands to the user's home directory a tilde (~) or %USERPROFILE% at the beginning of a file path.
+//
+// Parameters:
+//   - filePath: A string representing the file path that may start with "~/" or "%USERPROFILE%\".
+//
+// Returns:
+//   - string: The expanded file path with the home directory resolved.
+//   - error: An error if the user's home directory cannot be determined.
+//
+// The function handles both Unix-style paths starting with "~/" and Windows-style paths starting with "%USERPROFILE%\".
+// It uses the testHomeDir variable for testing purposes if set, otherwise it uses os.UserHomeDir() to get the user's home directory.
+// If the input path doesn't start with either prefix, it returns the original path unchanged.
 func expandHomeDir(filePath string) (string, error) {
 	if strings.HasPrefix(filePath, "~/") || strings.HasPrefix(filePath, "%USERPROFILE%\\") {
 		var homeDir string

--- a/cmd/src/main.go
+++ b/cmd/src/main.go
@@ -25,6 +25,9 @@ Usage:
 Environment variables
 	SRC_ACCESS_TOKEN  Sourcegraph access token
 	SRC_ENDPOINT      endpoint to use, if unset will default to "https://sourcegraph.com"
+	SRC_PROXY_SOCKET  path to a unix domain socket to use for proxying requests to the
+                      Sourcegraph instance. Can be either a full path, or contain the prefix
+                      ~/ or %USERPROFILE%\ to indicate a path in the user's home directory.
 
 The options are:
 
@@ -84,7 +87,6 @@ type config struct {
 	AccessToken       string            `json:"accessToken"`
 	AdditionalHeaders map[string]string `json:"additionalHeaders"`
 	ProxySocket       string            `json:"proxySocket"`
-	ProxyURL          string            `json:"proxyURL"`
 
 	ConfigFilePath string
 }
@@ -129,7 +131,6 @@ func readConfig() (*config, error) {
 	envToken := os.Getenv("SRC_ACCESS_TOKEN")
 	envEndpoint := os.Getenv("SRC_ENDPOINT")
 	envProxySocket := os.Getenv("SRC_PROXY_SOCKET")
-	envProxyURL := os.Getenv("SRC_PROXY_URL")
 
 	if userSpecified {
 		// If a config file is present, either zero or both environment variables must be present.
@@ -154,9 +155,6 @@ func readConfig() (*config, error) {
 	}
 	if envProxySocket != "" {
 		cfg.ProxySocket = envProxySocket
-	}
-	if envProxyURL != "" {
-		cfg.ProxyURL = envProxyURL
 	}
 
 	if cfg.ProxySocket != "" {

--- a/cmd/src/main.go
+++ b/cmd/src/main.go
@@ -213,7 +213,7 @@ func readConfig() (*config, error) {
 			}
 			isValidUDS, err := isValidUnixSocket(path)
 			if err != nil {
-				return nil, errors.Newf("Invalid proxy configuration: %v", err)
+				return nil, errors.Newf("Invalid proxy configuration: %w", err)
 			}
 			if !isValidUDS {
 				return nil, errors.Newf("invalid proxy socket: %s", path)

--- a/cmd/src/main.go
+++ b/cmd/src/main.go
@@ -31,8 +31,8 @@ Environment variables
 					  If a UNIX Domain Socket, the path can be either an absolute path, 
 					  or can start with ~/ or %USERPROFILE%\ for a path in the user's home directory.
 					  Examples:
-					    - https://localhost:3080
-					    - https://<user>:<password>localhost:8080
+						- https://localhost:3080
+						- https://<user>:<password>localhost:8080
 						- socks5h://localhost:1080
 						- socks5://<username>:<password>@localhost:1080
 						- unix://~/src-proxy.sock

--- a/cmd/src/main.go
+++ b/cmd/src/main.go
@@ -148,8 +148,9 @@ func readConfig() (*config, error) {
 	envProxyEndpoint := os.Getenv("SRC_PROXY_ENDPOINT")
 
 	if userSpecified {
-		// If a config file is present, either zero or both environment variables must be present.
+		// If a config file is present, either zero or both required environment variables must be present.
 		// We don't want to partially apply environment variables.
+		// Note that SRC_PROXY_ENDPOINT is optional so we don't test for it.
 		if envToken == "" && envEndpoint != "" {
 			return nil, errConfigMerge
 		}

--- a/cmd/src/main_test.go
+++ b/cmd/src/main_test.go
@@ -175,13 +175,52 @@ func TestReadConfig(t *testing.T) {
 			},
 		},
 		{
-			name:             "UNIX Domain Socket proxy using unix scheme and absolute unix path",
+			name:             "UNIX Domain Socket proxy using scheme and absolute path",
 			envProxyEndpoint: "unix://" + socketPath,
 			want: &config{
 				Endpoint:          "https://sourcegraph.com",
 				ProxyEndpoint:     "unix://" + socketPath,
 				ProxyEndpointPath: socketPath,
 				ProxyEndpointURL:  nil,
+				AdditionalHeaders: map[string]string{},
+			},
+		},
+		{
+			name:             "UNIX Domain Socket proxy with absolute path",
+			envProxyEndpoint: socketPath,
+			want: &config{
+				Endpoint:          "https://sourcegraph.com",
+				ProxyEndpoint:     socketPath,
+				ProxyEndpointPath: socketPath,
+				ProxyEndpointURL:  nil,
+				AdditionalHeaders: map[string]string{},
+			},
+		},
+		{
+			name:             "socks --> socks5",
+			envProxyEndpoint: "socks://localhost:1080",
+			want: &config{
+				Endpoint:          "https://sourcegraph.com",
+				ProxyEndpoint:     "socks://localhost:1080",
+				ProxyEndpointPath: "",
+				ProxyEndpointURL: &url.URL{
+					Scheme: "socks5",
+					Host:   "localhost:1080",
+				},
+				AdditionalHeaders: map[string]string{},
+			},
+		},
+		{
+			name:             "socks5h",
+			envProxyEndpoint: "socks5h://localhost:1080",
+			want: &config{
+				Endpoint:          "https://sourcegraph.com",
+				ProxyEndpoint:     "socks5h://localhost:1080",
+				ProxyEndpointPath: "",
+				ProxyEndpointURL: &url.URL{
+					Scheme: "socks5h",
+					Host:   "localhost:1080",
+				},
 				AdditionalHeaders: map[string]string{},
 			},
 		},

--- a/cmd/src/main_test.go
+++ b/cmd/src/main_test.go
@@ -13,6 +13,9 @@ import (
 )
 
 func TestReadConfig(t *testing.T) {
+	// UNIX Domain Sockets have a max path length: 104 on BSD/macOS, 108 on Linux.
+	// Including a prefix and suffix was causing the path to be too long
+	// with t.TempDir() (os.TempDir() is a shorter path) so we don't use them.
 	socketPath, err := api.CreateTempFile(t.TempDir(), "", "")
 	if err != nil {
 		t.Fatal(err)

--- a/cmd/src/main_test.go
+++ b/cmd/src/main_test.go
@@ -13,8 +13,7 @@ import (
 )
 
 func TestReadConfig(t *testing.T) {
-	socketPath, err := api.CreateTempFile(os.TempDir(), "TestReadConfig_", ".sock")
-	t.Log(socketPath)
+	socketPath, err := api.CreateTempFile(t.TempDir(), "", "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/dev/test-proxies.sh
+++ b/dev/test-proxies.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+
+# A test script to help manually test permutations of the proxy settings.
+# Before running this script,you'll need five terminal windows:
+# One for `socat`, two for `mitmproxy` (non-auth  and auth),
+# and two for a socks proxy (none-auth and auth).
+# If you're on macOS, run `brew install socat mitmproxy`.
+# To avoid the need to use insecure TLS settings, import mitmproxy's CA certificate into your keychain.
+# On macOS: `sudo security add-trusted-cert -d -p ssl -p basic -k /Library/Keychains/System.keychain ~/.mitmproxy/mitmproxy-ca-cert.pem`
+# For a socks proxy, I use the Docker image serjs/go-socks5-proxy.
+# Note that `mitmproxy` is not a tunneling proxy - it uses a self-signed certificate
+# to authenticate clients, which is good and bad. Good because we can inspect requests coming through
+# if we want, and bad because we need to use insecure TLS settings to use it.
+# It also works with `socat`, where `tinyproxy` and even `devproxy.sgdev.org` don't.
+# Terminal 1:
+# `socat -d -d unix-listen:${HOME}/socat-proxy.sock,fork tcp:localhost:8080`
+# Terminal 2:
+# `mitmproxy -v -p 8080`
+# Terminal 3:
+# `mitmproxy -v -p 8081 --proxyauth user:pass`
+# Terminal 4:
+# `docker run --rm -p 1080:1080 serjs/go-socks5-proxy`
+# Terminal 5:
+# `docker run --rm -p 1081:1080 -e PROXY_USER=user -e PROXY_PASSWORD=pass serjs/go-socks5-proxy`
+# when you kick off this script, keep all of the windows in view so you can see that the output
+# shows successful connections being made.
+
+SRC_PATH=${SRC_PATH:-~/go/bin/src}
+
+export SRC_ENDPOINT=${SRC_ENDPOINT:-https://sourcegraph.com}
+export SRC_ACCESS_TOKEN=${SRC_ACCESS_TOKEN}
+
+socket=~/socat-proxy.sock
+
+# UNIX Domain Socket test
+# You should see connection output in both the `socat` and `mitmproxy` terminals.
+echo "UNIX Domain Socket test"
+SRC_PROXY=${socket} \
+${SRC_PATH} login
+
+# HTTP test
+# You should see connection output in the `mitmproxy` terminal.
+echo "HTTP proxy test"
+SRC_PROXY=http://localhost:8080 \
+${SRC_PATH} login
+
+# HTTPS with auth test
+# You should see connection output in the `mitmproxy` with auth terminal.
+echo "HTTP proxy with auth test"
+SRC_PROXY=http://user:pass@localhost:8081 \
+${SRC_PATH} login
+
+# HTTPS test
+# You should see connection output in the `mitmproxy` terminal.
+echo "HTTPS proxy test"
+SRC_PROXY=https://localhost:8080 \
+${SRC_PATH} login
+
+# HTTPS with auth test
+# You should see connection output in the `mitmproxy` with auth terminal.
+echo "HTTPS proxy with auth test"
+SRC_PROXY=https://user:pass@localhost:8081 \
+${SRC_PATH} login
+
+# SOCKS test
+# You should see connection output in the socks terminal.
+echo "SOCKS proxy test"
+SRC_PROXY=socks5://localhost:1080 \
+${SRC_PATH} login
+
+# SOCKS with auth test
+# You should see connection output in the socks terminal.
+echo "SOCKS proxy with auth test"
+SRC_PROXY=socks5://user:pass@localhost:1081 \
+${SRC_PATH} login
+
+# HTTPS using insecure TLS code path
+# You should see connection output in the `mitmproxy` terminal.
+echo "HTTPS proxy insecure TLS path test"
+SRC_PROXY=https://localhost:8080 \
+${SRC_PATH} login --insecure-skip-verify=true
+
+
+# test a search using a proxy
+echo "Search test"
+SRC_PROXY=https://localhost:8080 \
+${SRC_PATH} search -json 'repo:github.com/sourcegraph/src-cli foobar'
+
+
+# test with the system proxy set to something else
+echo "Ignoring system proxy test"
+https_proxy=http://localhost:12345 \
+SRC_PROXY=https://localhost:8080 \
+${SRC_PATH} login

--- a/internal/api/BUILD.bazel
+++ b/internal/api/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "gzip.go",
         "nullable.go",
         "proxy.go",
+        "test_unix_socket_server.go",
     ],
     importpath = "github.com/sourcegraph/src-cli/internal/api",
     visibility = ["//:__subpackages__"],

--- a/internal/api/BUILD.bazel
+++ b/internal/api/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
         "flags.go",
         "gzip.go",
         "nullable.go",
+        "proxy.go",
     ],
     importpath = "github.com/sourcegraph/src-cli/internal/api",
     visibility = ["//:__subpackages__"],

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -83,7 +83,6 @@ type ClientOpts struct {
 	// curl commands when -get-curl is enabled.
 	Out io.Writer
 
-	ProxyURL    string // URL of the proxy server
 	ProxySocket string // Path to the Unix socket for proxy
 }
 

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -81,6 +81,9 @@ type ClientOpts struct {
 	// Out is the writer that will be used when outputting diagnostics, such as
 	// curl commands when -get-curl is enabled.
 	Out io.Writer
+
+	ProxyURL    string // URL of the proxy server
+	ProxySocket string // Path to the Unix socket for proxy
 }
 
 // NewClient creates a new API client.

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -2,17 +2,22 @@
 package api
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"crypto/tls"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"runtime"
 	"strings"
+
+	"golang.org/x/net/proxy"
 
 	ioaux "github.com/jig/teereadcloser"
 	"github.com/kballard/go-shellquote"
@@ -83,7 +88,8 @@ type ClientOpts struct {
 	// curl commands when -get-curl is enabled.
 	Out io.Writer
 
-	ProxySocket string // Path to the Unix socket for proxy
+	ProxyEndpointURL  *url.URL
+	ProxyEndpointPath string
 }
 
 // NewClient creates a new API client.
@@ -99,23 +105,133 @@ func NewClient(opts ClientOpts) Client {
 
 	httpClient := http.DefaultClient
 
-	transport := &http.Transport{}
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	customTransport := false
 
 	if flags.insecureSkipVerify != nil && *flags.insecureSkipVerify {
+		customTransport = true
 		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 	}
 
-	// Add support for UNIX Domain Socket
-	if opts.ProxySocket != "" {
-		dial := func(_ context.Context, _, _ string) (net.Conn, error) {
-			return net.Dial("unix", opts.ProxySocket)
+	handshakeTLS := func(conn net.Conn, addr string) (net.Conn, error) {
+		// Extract the hostname (without the port) for TLS SNI
+		host, _, err := net.SplitHostPort(addr)
+		if err != nil {
+			return nil, err
 		}
-		transport.DialContext = dial
-		transport.DialTLSContext = dial
-		transport.DisableKeepAlives = true
+		// Be sure to clone TLS-specific config settings from the transport,
+		// like InsecureSkipVerify.
+		tlsConn := tls.Client(conn, &tls.Config{
+			ServerName:         host,
+			InsecureSkipVerify: transport.TLSClientConfig.InsecureSkipVerify,
+		})
+		if err := tlsConn.Handshake(); err != nil {
+			return nil, err
+		}
+		return tlsConn, nil
 	}
 
-	if transport.TLSClientConfig != nil || transport.DialContext != nil {
+	var dial func(ctx context.Context, network, addr string) (net.Conn, error)
+	var dialTLS func(ctx context.Context, network, addr string) (net.Conn, error)
+
+	if opts.ProxyEndpointPath != "" {
+		dial = func(_ context.Context, _, _ string) (net.Conn, error) {
+			return net.Dial("unix", opts.ProxyEndpointPath)
+		}
+		dialTLS = func(ctx context.Context, network, addr string) (net.Conn, error) {
+			conn, err := dial(ctx, network, addr)
+			if err != nil {
+				return nil, err
+			}
+			return handshakeTLS(conn, addr)
+		}
+	} else if opts.ProxyEndpointURL != nil {
+		if opts.ProxyEndpointURL.Scheme == "socks5" ||
+			opts.ProxyEndpointURL.Scheme == "socks5h" {
+			dial = func(_ context.Context, network, addr string) (net.Conn, error) {
+				// figure out the proxy every dial because we have error handling here.
+				// In NewClient, we don't have error handling; all we can do there is panic.
+
+				// FromURL really only handles SOCKS5 (unless other schemes have ben registered),
+				// but since it also handles credentials,
+				// we'll use it instead of manually handling any credentials embedded in the URL,
+				// and calling SOCKS5 ourself.
+				dialer, err := proxy.FromURL(opts.ProxyEndpointURL, proxy.Direct)
+				if err != nil {
+					return nil, err
+				}
+				return dialer.Dial(network, addr)
+			}
+			dialTLS = func(ctx context.Context, network, addr string) (net.Conn, error) {
+				// Dial the underlying connection through the proxy
+				conn, err := dial(ctx, network, addr)
+				if err != nil {
+					return nil, err
+				}
+				return handshakeTLS(conn, addr)
+			}
+		} else if opts.ProxyEndpointURL.Scheme == "http" || opts.ProxyEndpointURL.Scheme == "https" {
+			dial = func(ctx context.Context, network, addr string) (net.Conn, error) {
+				// separate the host from the port for the Host header
+				host, _, err := net.SplitHostPort(addr)
+				if err != nil {
+					return nil, err
+				}
+
+				// Dial the proxy
+				conn, err := net.Dial("tcp", opts.ProxyEndpointURL.Host)
+				if err != nil {
+					return nil, err
+				}
+
+				connectReq := fmt.Sprintf("CONNECT %s HTTP/1.1\r\nHost: %s\r\n", addr, host)
+
+				// use authentication if proxy credentials are present
+				if opts.ProxyEndpointURL.User != nil {
+					password, _ := opts.ProxyEndpointURL.User.Password()
+					auth := base64.StdEncoding.EncodeToString([]byte(opts.ProxyEndpointURL.User.Username() + ":" + password))
+					connectReq += "Proxy-Authorization: Basic " + auth + "\r\n"
+				}
+
+				connectReq += "\r\n"
+
+				// Send the CONNECT request to the proxy to establish the tunnel
+				if _, err := conn.Write([]byte(connectReq)); err != nil {
+					conn.Close()
+					return nil, err
+				}
+
+				// Read and check the response from the proxy
+				resp, err := http.ReadResponse(bufio.NewReader(conn), nil)
+				if err != nil {
+					conn.Close()
+					return nil, err
+				}
+				if resp.StatusCode != http.StatusOK {
+					conn.Close()
+					return nil, fmt.Errorf("failed to connect to proxy %v: %v", opts.ProxyEndpointURL, resp.Status)
+				}
+
+				return conn, nil
+			}
+			dialTLS = func(ctx context.Context, network, addr string) (net.Conn, error) {
+				// Dial the underlying connection through the proxy
+				conn, err := dial(ctx, network, addr)
+				if err != nil {
+					return nil, err
+				}
+				return handshakeTLS(conn, addr)
+			}
+		}
+	}
+
+	if dial != nil && dialTLS != nil {
+		customTransport = true
+		transport.DialContext = dial
+		transport.DialTLSContext = dialTLS
+	}
+
+	if customTransport {
 		httpClient.Transport = transport
 	}
 

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -2,22 +2,17 @@
 package api
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"crypto/tls"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
 	"net/url"
 	"os"
 	"runtime"
 	"strings"
-
-	"golang.org/x/net/proxy"
 
 	ioaux "github.com/jig/teereadcloser"
 	"github.com/kballard/go-shellquote"
@@ -113,125 +108,9 @@ func NewClient(opts ClientOpts) Client {
 		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 	}
 
-	handshakeTLS := func(conn net.Conn, addr string) (net.Conn, error) {
-		// Extract the hostname (without the port) for TLS SNI
-		host, _, err := net.SplitHostPort(addr)
-		if err != nil {
-			return nil, err
-		}
-		// Be sure to clone TLS-specific config settings from the transport,
-		// like InsecureSkipVerify.
-		tlsConn := tls.Client(conn, &tls.Config{
-			ServerName:         host,
-			InsecureSkipVerify: transport.TLSClientConfig.InsecureSkipVerify,
-		})
-		if err := tlsConn.Handshake(); err != nil {
-			return nil, err
-		}
-		return tlsConn, nil
-	}
+	proxyApplied := applyProxy(transport, opts.ProxyEndpointURL, opts.ProxyEndpointPath)
 
-	var dial func(ctx context.Context, network, addr string) (net.Conn, error)
-	var dialTLS func(ctx context.Context, network, addr string) (net.Conn, error)
-
-	if opts.ProxyEndpointPath != "" {
-		dial = func(_ context.Context, _, _ string) (net.Conn, error) {
-			return net.Dial("unix", opts.ProxyEndpointPath)
-		}
-		dialTLS = func(ctx context.Context, network, addr string) (net.Conn, error) {
-			conn, err := dial(ctx, network, addr)
-			if err != nil {
-				return nil, err
-			}
-			return handshakeTLS(conn, addr)
-		}
-	} else if opts.ProxyEndpointURL != nil {
-		if opts.ProxyEndpointURL.Scheme == "socks5" ||
-			opts.ProxyEndpointURL.Scheme == "socks5h" {
-			dial = func(_ context.Context, network, addr string) (net.Conn, error) {
-				// figure out the proxy every dial because we have error handling here.
-				// In NewClient, we don't have error handling; all we can do there is panic.
-
-				// FromURL really only handles SOCKS5 (unless other schemes have ben registered),
-				// but since it also handles credentials,
-				// we'll use it instead of manually handling any credentials embedded in the URL,
-				// and calling SOCKS5 ourself.
-				dialer, err := proxy.FromURL(opts.ProxyEndpointURL, proxy.Direct)
-				if err != nil {
-					return nil, err
-				}
-				return dialer.Dial(network, addr)
-			}
-			dialTLS = func(ctx context.Context, network, addr string) (net.Conn, error) {
-				// Dial the underlying connection through the proxy
-				conn, err := dial(ctx, network, addr)
-				if err != nil {
-					return nil, err
-				}
-				return handshakeTLS(conn, addr)
-			}
-		} else if opts.ProxyEndpointURL.Scheme == "http" || opts.ProxyEndpointURL.Scheme == "https" {
-			dial = func(ctx context.Context, network, addr string) (net.Conn, error) {
-				// separate the host from the port for the Host header
-				host, _, err := net.SplitHostPort(addr)
-				if err != nil {
-					return nil, err
-				}
-
-				// Dial the proxy
-				conn, err := net.Dial("tcp", opts.ProxyEndpointURL.Host)
-				if err != nil {
-					return nil, err
-				}
-
-				connectReq := fmt.Sprintf("CONNECT %s HTTP/1.1\r\nHost: %s\r\n", addr, host)
-
-				// use authentication if proxy credentials are present
-				if opts.ProxyEndpointURL.User != nil {
-					password, _ := opts.ProxyEndpointURL.User.Password()
-					auth := base64.StdEncoding.EncodeToString([]byte(opts.ProxyEndpointURL.User.Username() + ":" + password))
-					connectReq += "Proxy-Authorization: Basic " + auth + "\r\n"
-				}
-
-				connectReq += "\r\n"
-
-				// Send the CONNECT request to the proxy to establish the tunnel
-				if _, err := conn.Write([]byte(connectReq)); err != nil {
-					conn.Close()
-					return nil, err
-				}
-
-				// Read and check the response from the proxy
-				resp, err := http.ReadResponse(bufio.NewReader(conn), nil)
-				if err != nil {
-					conn.Close()
-					return nil, err
-				}
-				if resp.StatusCode != http.StatusOK {
-					conn.Close()
-					return nil, fmt.Errorf("failed to connect to proxy %v: %v", opts.ProxyEndpointURL, resp.Status)
-				}
-
-				return conn, nil
-			}
-			dialTLS = func(ctx context.Context, network, addr string) (net.Conn, error) {
-				// Dial the underlying connection through the proxy
-				conn, err := dial(ctx, network, addr)
-				if err != nil {
-					return nil, err
-				}
-				return handshakeTLS(conn, addr)
-			}
-		}
-	}
-
-	if dial != nil && dialTLS != nil {
-		customTransport = true
-		transport.DialContext = dial
-		transport.DialTLSContext = dialTLS
-	}
-
-	if customTransport {
+	if customTransport || proxyApplied {
 		httpClient.Transport = transport
 	}
 

--- a/internal/api/proxy.go
+++ b/internal/api/proxy.go
@@ -11,8 +11,8 @@ import (
 	"net/url"
 )
 
-func applyProxy(transport *http.Transport, ProxyURL *url.URL, ProxyPath string) (applied bool) {
-	if ProxyURL == nil && ProxyPath == "" {
+func applyProxy(transport *http.Transport, proxyURL *url.URL, proxyPath string) (applied bool) {
+	if proxyURL == nil && proxyPath == "" {
 		return false
 	}
 
@@ -36,10 +36,10 @@ func applyProxy(transport *http.Transport, ProxyURL *url.URL, ProxyPath string) 
 
 	proxyApplied := false
 
-	if ProxyPath != "" {
+	if proxyPath != "" {
 		dial := func(ctx context.Context, _, _ string) (net.Conn, error) {
 			d := net.Dialer{}
-			return d.DialContext(ctx, "unix", ProxyPath)
+			return d.DialContext(ctx, "unix", proxyPath)
 		}
 		dialTLS := func(ctx context.Context, network, addr string) (net.Conn, error) {
 			conn, err := dial(ctx, network, addr)
@@ -53,17 +53,17 @@ func applyProxy(transport *http.Transport, ProxyURL *url.URL, ProxyPath string) 
 		// clear out any system proxy settings
 		transport.Proxy = nil
 		proxyApplied = true
-	} else if ProxyURL != nil {
-		if ProxyURL.Scheme == "socks5" ||
-			ProxyURL.Scheme == "socks5h" {
+	} else if proxyURL != nil {
+		if proxyURL.Scheme == "socks5" ||
+			proxyURL.Scheme == "socks5h" {
 			// SOCKS proxies work out of the box - no need to manually dial
-			transport.Proxy = http.ProxyURL(ProxyURL)
+			transport.Proxy = http.ProxyURL(proxyURL)
 			proxyApplied = true
-		} else if ProxyURL.Scheme == "http" || ProxyURL.Scheme == "https" {
+		} else if proxyURL.Scheme == "http" || proxyURL.Scheme == "https" {
 			dial := func(ctx context.Context, network, addr string) (net.Conn, error) {
 				// Dial the proxy
 				d := net.Dialer{}
-				conn, err := d.DialContext(ctx, "tcp", ProxyURL.Host)
+				conn, err := d.DialContext(ctx, "tcp", proxyURL.Host)
 				if err != nil {
 					return nil, err
 				}
@@ -90,9 +90,9 @@ func applyProxy(transport *http.Transport, ProxyURL *url.URL, ProxyPath string) 
 				connectReq += fmt.Sprintf("Host: %s\r\n", addr)
 
 				// use authentication if proxy credentials are present
-				if ProxyURL.User != nil {
-					password, _ := ProxyURL.User.Password()
-					auth := base64.StdEncoding.EncodeToString([]byte(ProxyURL.User.Username() + ":" + password))
+				if proxyURL.User != nil {
+					password, _ := proxyURL.User.Password()
+					auth := base64.StdEncoding.EncodeToString([]byte(proxyURL.User.Username() + ":" + password))
 					connectReq += fmt.Sprintf("Proxy-Authorization: Basic %s\r\n", auth)
 				}
 
@@ -113,7 +113,7 @@ func applyProxy(transport *http.Transport, ProxyURL *url.URL, ProxyPath string) 
 				}
 				if resp.StatusCode != http.StatusOK {
 					conn.Close()
-					return nil, fmt.Errorf("failed to connect to proxy %v: %v", ProxyURL, resp.Status)
+					return nil, fmt.Errorf("failed to connect to proxy %v: %v", proxyURL, resp.Status)
 				}
 				resp.Body.Close()
 				return conn, nil

--- a/internal/api/proxy.go
+++ b/internal/api/proxy.go
@@ -22,10 +22,10 @@ func applyProxy(transport *http.Transport, proxyURL *url.URL, proxyPath string) 
 		if err != nil {
 			return nil, err
 		}
-		// Be sure to clone TLS-specific config settings from the transport,
-		// like InsecureSkipVerify.
 		tlsConn := tls.Client(conn, &tls.Config{
-			ServerName:         host,
+			ServerName: host,
+			// Pull InsecureSkipVerify from the target host transport
+			// so that insecure-skip-verify flag settings are honored for the proxy server
 			InsecureSkipVerify: transport.TLSClientConfig.InsecureSkipVerify,
 		})
 		if err := tlsConn.HandshakeContext(ctx); err != nil {

--- a/internal/api/proxy.go
+++ b/internal/api/proxy.go
@@ -1,0 +1,139 @@
+package api
+
+import (
+	"bufio"
+	"context"
+	"crypto/tls"
+	"encoding/base64"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+
+	"golang.org/x/net/proxy"
+)
+
+func applyProxy(transport *http.Transport, proxyEndpointURL *url.URL, proxyEndpointPath string) (applied bool) {
+	if proxyEndpointURL == nil && proxyEndpointPath == "" {
+		return false
+	}
+
+	handshakeTLS := func(conn net.Conn, addr string) (net.Conn, error) {
+		// Extract the hostname (without the port) for TLS SNI
+		host, _, err := net.SplitHostPort(addr)
+		if err != nil {
+			return nil, err
+		}
+		// Be sure to clone TLS-specific config settings from the transport,
+		// like InsecureSkipVerify.
+		tlsConn := tls.Client(conn, &tls.Config{
+			ServerName:         host,
+			InsecureSkipVerify: transport.TLSClientConfig.InsecureSkipVerify,
+		})
+		if err := tlsConn.Handshake(); err != nil {
+			return nil, err
+		}
+		return tlsConn, nil
+	}
+
+	var dial func(ctx context.Context, network, addr string) (net.Conn, error)
+	var dialTLS func(ctx context.Context, network, addr string) (net.Conn, error)
+
+	if proxyEndpointPath != "" {
+		dial = func(_ context.Context, _, _ string) (net.Conn, error) {
+			return net.Dial("unix", proxyEndpointPath)
+		}
+		dialTLS = func(ctx context.Context, network, addr string) (net.Conn, error) {
+			conn, err := dial(ctx, network, addr)
+			if err != nil {
+				return nil, err
+			}
+			return handshakeTLS(conn, addr)
+		}
+	} else if proxyEndpointURL != nil {
+		if proxyEndpointURL.Scheme == "socks5" ||
+			proxyEndpointURL.Scheme == "socks5h" {
+			dial = func(_ context.Context, network, addr string) (net.Conn, error) {
+				// figure out the proxy every dial because we have error handling here.
+				// In NewClient, we don't have error handling; all we can do there is panic.
+
+				// FromURL really only handles SOCKS5 (unless other schemes have ben registered),
+				// but since it also handles credentials,
+				// we'll use it instead of manually handling any credentials embedded in the URL,
+				// and calling SOCKS5 ourself.
+				dialer, err := proxy.FromURL(proxyEndpointURL, proxy.Direct)
+				if err != nil {
+					return nil, err
+				}
+				return dialer.Dial(network, addr)
+			}
+			dialTLS = func(ctx context.Context, network, addr string) (net.Conn, error) {
+				// Dial the underlying connection through the proxy
+				conn, err := dial(ctx, network, addr)
+				if err != nil {
+					return nil, err
+				}
+				return handshakeTLS(conn, addr)
+			}
+		} else if proxyEndpointURL.Scheme == "http" || proxyEndpointURL.Scheme == "https" {
+			dial = func(ctx context.Context, network, addr string) (net.Conn, error) {
+				// separate the host from the port for the Host header
+				host, _, err := net.SplitHostPort(addr)
+				if err != nil {
+					return nil, err
+				}
+
+				// Dial the proxy
+				conn, err := net.Dial("tcp", proxyEndpointURL.Host)
+				if err != nil {
+					return nil, err
+				}
+
+				connectReq := fmt.Sprintf("CONNECT %s HTTP/1.1\r\nHost: %s\r\n", addr, host)
+
+				// use authentication if proxy credentials are present
+				if proxyEndpointURL.User != nil {
+					password, _ := proxyEndpointURL.User.Password()
+					auth := base64.StdEncoding.EncodeToString([]byte(proxyEndpointURL.User.Username() + ":" + password))
+					connectReq += "Proxy-Authorization: Basic " + auth + "\r\n"
+				}
+
+				connectReq += "\r\n"
+
+				// Send the CONNECT request to the proxy to establish the tunnel
+				if _, err := conn.Write([]byte(connectReq)); err != nil {
+					conn.Close()
+					return nil, err
+				}
+
+				// Read and check the response from the proxy
+				resp, err := http.ReadResponse(bufio.NewReader(conn), nil)
+				if err != nil {
+					conn.Close()
+					return nil, err
+				}
+				if resp.StatusCode != http.StatusOK {
+					conn.Close()
+					return nil, fmt.Errorf("failed to connect to proxy %v: %v", proxyEndpointURL, resp.Status)
+				}
+				resp.Body.Close()
+				return conn, nil
+			}
+			dialTLS = func(ctx context.Context, network, addr string) (net.Conn, error) {
+				// Dial the underlying connection through the proxy
+				conn, err := dial(ctx, network, addr)
+				if err != nil {
+					return nil, err
+				}
+				return handshakeTLS(conn, addr)
+			}
+		}
+	}
+
+	if dial != nil && dialTLS != nil {
+		transport.DialContext = dial
+		transport.DialTLSContext = dialTLS
+	}
+
+	return dial != nil && dialTLS != nil
+}

--- a/internal/api/test_unix_socket_server.go
+++ b/internal/api/test_unix_socket_server.go
@@ -1,0 +1,109 @@
+package api
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"sync"
+)
+
+type Server struct {
+	Listener net.Listener
+	StopChan chan struct{}
+	Wg       sync.WaitGroup
+}
+
+func CreateTempFile(dir, prefix, suffix string) (string, error) {
+	// Get the default temporary directory for the OS
+	if dir == "" {
+		dir = os.TempDir()
+	}
+
+	// Create a temporary file with the specified prefix and suffix
+	tempFile, err := os.CreateTemp(dir, prefix+"*"+suffix)
+	if err != nil {
+		return "", fmt.Errorf("failed to create temp file: %w", err)
+	}
+
+	// Close the file to release the file descriptor
+	tempFile.Close()
+
+	// Return the name of the created file
+	return tempFile.Name(), nil
+}
+
+func createUnixSocket(socketPath string) (net.Listener, error) {
+	// Clean up the socket file if it already exists
+	_ = os.Remove(socketPath)
+
+	// Create a Unix domain socket
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Unix domain socket: %w", err)
+	}
+
+	return listener, nil
+}
+
+// StartServer starts the server in a goroutine and returns a stop function
+func StartUnixSocketServer(socketPath string) (*Server, error) {
+	listener, err := createUnixSocket(socketPath)
+	if err != nil {
+		return nil, err
+	}
+
+	server := &Server{
+		Listener: listener,
+		StopChan: make(chan struct{}),
+	}
+
+	server.Wg.Add(1)
+	go func() {
+		defer server.Wg.Done()
+		for {
+			conn, err := server.Listener.Accept()
+			if err != nil {
+				select {
+				case <-server.StopChan:
+					return
+				default:
+					fmt.Println("Error accepting connection:", err)
+					continue
+				}
+			}
+
+			// Handle each connection in a separate goroutine
+			server.Wg.Add(1)
+			go func(conn net.Conn) {
+				defer server.Wg.Done()
+				defer conn.Close()
+
+				// Handle incoming data from the connection
+				buf := make([]byte, 1024)
+				n, err := conn.Read(buf)
+				if err != nil {
+					fmt.Println("Error reading from connection:", err)
+					return
+				}
+
+				fmt.Printf("Received: %s\n", string(buf[:n]))
+
+				// Example: Write a response back
+				_, err = conn.Write([]byte("Hello from server\n"))
+				if err != nil {
+					fmt.Println("Error writing to connection:", err)
+					return
+				}
+			}(conn)
+		}
+	}()
+
+	return server, nil
+}
+
+// StopServer stops the server and waits for all goroutines to finish
+func (s *Server) Stop() {
+	close(s.StopChan)
+	s.Listener.Close()
+	s.Wg.Wait()
+}


### PR DESCRIPTION
This PR adds support for explicit HTTP(S), SOCKS5 and UNIX Domain Socket proxies that can be set using the `SRC_PROXY` environment variable:
```
SRC_ENDPOINT=https://sourcegraph.sourcegraph.com \
SRC_ACCESS_TOKEN=deadbeef \
SRC_PROXY=https://localhost:8080 \
src login --insecure-skip-verify=true

✔️  Authenticated as peter.guy on https://sourcegraph.sourcegraph.com
```

### Test plan

CI tests all pass.

Added more config tests.

#### Manual tests

*Option 1:*

Use `dev/test-proxies.sh`. 
Follow the instructions in comments at the beginning, then run the script.

*Option 2:*

0. Install `socat` and `mitmproxy`
```
brew install socat mitmproxy
```
3. In two separate terminals, run:
```
socat -d -d unix-listen:${HOME}/src-proxy.sock,fork tcp:localhost:8080
```
and
```
mitmproxy -v
```
4. Check out this branch and build `src-cli`:
```
go build -o ~/go/bin/src ./cmd/src
```
5. Run `src`, setting the endpoint, PAT, and UDS path in the environment variables:
```
SRC_ENDPOINT=https://sourcegraph.sourcegraph.com \
SRC_ACCESS_TOKEN=deadbeef \
SRC_PROXY=~/src-proxy.sock \
~/go/bin/src login --insecure-skip-verify=true
```
- You need to use the `--insecure-skip-verify=true` flag because `mitmproxy` uses a self-signed certificate. (You can get rid of that by [importing the `mitmproxy` CA cert into your local cert store](https://docs.mitmproxy.org/stable/concepts-certificates/))
- You should get a successful "Authenticated as ..." message. If the PAT is wrong, you'll see "Problem: Invalid access token."
- Look in the terminal where `socat` is running. You'll see output showing connections being made.
- Look in the terminal running `mitmproxy`. You'll see output showing connections being made.

Repeat those tests using the `mitmproxy` HTTP proxy directly:
```
SRC_ENDPOINT=https://sourcegraph.sourcegraph.com \
SRC_ACCESS_TOKEN=deadbeef \
SRC_PROXY=https://localhost:8080 \
~/go/bin/src login --insecure-skip-verify=true
```

To test SOCKS5 proxies, you can use a Docker-based SOCKS5 proxy.
Run this command in a terminal window:
```
docker run --rm -p 1080:1080 serjs/go-socks5-proxy
```
Then in another terminal window, run `src` pointing at that proxy:
```
SRC_ENDPOINT=https://sourcegraph.sourcegraph.com \
SRC_ACCESS_TOKEN=deadbeef \
SRC_PROXY=socks5://localhost:1080 \
~/go/bin/src login
```
You should see the same success messages as before, and in the terminal running the `docker` command, you should see connections being made.

We support proxy authentication with HTTP(S) and SOCKS5 proxies.

To test that, run `mitmproxy` and `serjs/go-socks-proxy` with authentication specified:
```
mitmproxy -v --proxyauth user:pass
```
```
docker run --rm -p 1080:1080 -e PROXY_USER=user -e PROXY_PASSWORD=pass serjs/go-socks5-proxy
```
Then add those credentials to the `SRC_PROXY` URL: either `https://user:pass@localhost:8080` or `socks5://user:pass@localhost:1080`

Also confirm that non-proxied connections can be made by omitting the `SRC_PROXY` environment variable setting.
