### PR TITLE
Access token err msg

### DIFF
--- a/cmd/src/login.go
+++ b/cmd/src/login.go
@@ -71,12 +71,12 @@ func loginCmd(ctx context.Context, cfg *config, client api.Client, endpointArg s
 		fmt.Fprintf(out, "❌ Problem: %s\n", problem)
 	}
 
-	createAccessTokenMessage := fmt.Sprintf("\n"+`🛠  To fix: Create an access token at %s/user/settings/tokens, then set the following environment variables:
+	createAccessTokenMessage := fmt.Sprintf("\n"+`🛠  To fix: Create an access token by going to %s/user/settings/tokens, then set the following environment variables in your terminal:
 
-   SRC_ENDPOINT=%s
-   SRC_ACCESS_TOKEN=(the access token you just created)
+   export SRC_ENDPOINT=%s
+   export SRC_ACCESS_TOKEN=(your access token)
 
-   To verify that it's working, run this command again.
+   To verify that it's working, run the login command again.
 `, endpointArg, endpointArg)
 
 	if cfg.ConfigFilePath != "" {

--- a/cmd/src/login_test.go
+++ b/cmd/src/login_test.go
@@ -27,7 +27,7 @@ func TestLogin(t *testing.T) {
 		if err != cmderrors.ExitCode1 {
 			t.Fatal(err)
 		}
-		wantOut := "❌ Problem: No access token is configured.\n\n🛠  To fix: Create an access token at https://sourcegraph.example.com/user/settings/tokens, then set the following environment variables:\n\n   SRC_ENDPOINT=https://sourcegraph.example.com\n   SRC_ACCESS_TOKEN=(the access token you just created)\n\n   To verify that it's working, run this command again."
+		wantOut := "❌ Problem: No access token is configured.\n\n🛠  To fix: Create an access token by going to https://sourcegraph.example.com/user/settings/tokens, then set the following environment variables in your terminal:\n\n   export SRC_ENDPOINT=https://sourcegraph.example.com\n   export SRC_ACCESS_TOKEN=(your access token)\n\n   To verify that it's working, run the login command again."
 		if out != wantOut {
 			t.Errorf("got output %q, want %q", out, wantOut)
 		}
@@ -38,7 +38,7 @@ func TestLogin(t *testing.T) {
 		if err != cmderrors.ExitCode1 {
 			t.Fatal(err)
 		}
-		wantOut := "❌ Problem: No access token is configured.\n\n🛠  To fix: Create an access token at https://sourcegraph.example.com/user/settings/tokens, then set the following environment variables:\n\n   SRC_ENDPOINT=https://sourcegraph.example.com\n   SRC_ACCESS_TOKEN=(the access token you just created)\n\n   To verify that it's working, run this command again."
+		wantOut := "❌ Problem: No access token is configured.\n\n🛠  To fix: Create an access token by going to https://sourcegraph.example.com/user/settings/tokens, then set the following environment variables in your terminal:\n\n   export SRC_ENDPOINT=https://sourcegraph.example.com\n   export SRC_ACCESS_TOKEN=(your access token)\n\n   To verify that it's working, run the login command again."
 		if out != wantOut {
 			t.Errorf("got output %q, want %q", out, wantOut)
 		}
@@ -49,7 +49,7 @@ func TestLogin(t *testing.T) {
 		if err != cmderrors.ExitCode1 {
 			t.Fatal(err)
 		}
-		wantOut := "⚠️  Warning: Configuring src with a JSON file is deprecated. Please migrate to using the env vars SRC_ENDPOINT, SRC_ACCESS_TOKEN, and SRC_PROXY instead, and then remove f. See https://github.com/sourcegraph/src-cli#readme for more information.\n\n❌ Problem: No access token is configured.\n\n🛠  To fix: Create an access token at https://example.com/user/settings/tokens, then set the following environment variables:\n\n   SRC_ENDPOINT=https://example.com\n   SRC_ACCESS_TOKEN=(the access token you just created)\n\n   To verify that it's working, run this command again."
+		wantOut := "⚠️  Warning: Configuring src with a JSON file is deprecated. Please migrate to using the env vars SRC_ENDPOINT, SRC_ACCESS_TOKEN, and SRC_PROXY instead, and then remove f. See https://github.com/sourcegraph/src-cli#readme for more information.\n\n❌ Problem: No access token is configured.\n\n🛠  To fix: Create an access token by going to https://example.com/user/settings/tokens, then set the following environment variables in your terminal:\n\n   export SRC_ENDPOINT=https://example.com\n   export SRC_ACCESS_TOKEN=(your access token)\n\n   To verify that it's working, run the login command again."
 		if out != wantOut {
 			t.Errorf("got output %q, want %q", out, wantOut)
 		}
@@ -67,7 +67,7 @@ func TestLogin(t *testing.T) {
 		if err != cmderrors.ExitCode1 {
 			t.Fatal(err)
 		}
-		wantOut := "❌ Problem: Invalid access token.\n\n🛠  To fix: Create an access token at $ENDPOINT/user/settings/tokens, then set the following environment variables:\n\n   SRC_ENDPOINT=$ENDPOINT\n   SRC_ACCESS_TOKEN=(the access token you just created)\n\n   To verify that it's working, run this command again.\n\n   (If you need to supply custom HTTP request headers, see information about SRC_HEADER_* and SRC_HEADERS env vars at https://github.com/sourcegraph/src-cli/blob/main/AUTH_PROXY.md.)"
+		wantOut := "❌ Problem: Invalid access token.\n\n🛠  To fix: Create an access token by going to $ENDPOINT/user/settings/tokens, then set the following environment variables in your terminal:\n\n   export SRC_ENDPOINT=$ENDPOINT\n   export SRC_ACCESS_TOKEN=(your access token)\n\n   To verify that it's working, run the login command again.\n\n   (If you need to supply custom HTTP request headers, see information about SRC_HEADER_* and SRC_HEADERS env vars at https://github.com/sourcegraph/src-cli/blob/main/AUTH_PROXY.md.)"
 		wantOut = strings.ReplaceAll(wantOut, "$ENDPOINT", endpoint)
 		if out != wantOut {
 			t.Errorf("got output %q, want %q", out, wantOut)

--- a/go.mod
+++ b/go.mod
@@ -196,3 +196,4 @@ require (
 
 // See: https://github.com/ghodss/yaml/pull/65
 replace github.com/ghodss/yaml => github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152
+replace github.com/sourcegraph/sourcegraph/lib => github.com/sourcegraph/sourcegraph-public-snapshot/lib v0.0.0-20240709083501-1af563b61442

--- a/go.sum
+++ b/go.sum
@@ -388,8 +388,8 @@ github.com/sourcegraph/log v0.0.0-20231018134238-fbadff7458bb h1:tHKdC+bXxxGJ0cy
 github.com/sourcegraph/log v0.0.0-20231018134238-fbadff7458bb/go.mod h1:IDp09QkoqS8Z3CyN2RW6vXjgABkNpDbyjLIHNQwQ8P8=
 github.com/sourcegraph/scip v0.3.1-0.20230627154934-45df7f6d33fc h1:o+eq0cjVV3B5ngIBF04Lv3GwttKOuYFF5NTcfXWXzfA=
 github.com/sourcegraph/scip v0.3.1-0.20230627154934-45df7f6d33fc/go.mod h1:7ZKAtLIUmiMvOIgG5LMcBxdtBXVa0v2GWC4Hm1ASYQ0=
-github.com/sourcegraph/sourcegraph/lib v0.0.0-20240709083501-1af563b61442 h1:n3HZCz5fJRtxCzjcUHZwrfJb96xU0+s2L4/+Da2kD3A=
-github.com/sourcegraph/sourcegraph/lib v0.0.0-20240709083501-1af563b61442/go.mod h1:RBdAauod1tGL33L1Izr2YymwN8uWQV++fL6orhD4aqc=
+github.com/sourcegraph/sourcegraph-public-snapshot/lib v0.0.0-20240709083501-1af563b61442 h1:M/jSgKSzeYbfrE/C6H8b8zu07c59taz4fIQcOGh1vqY=
+github.com/sourcegraph/sourcegraph-public-snapshot/lib v0.0.0-20240709083501-1af563b61442/go.mod h1:RBdAauod1tGL33L1Izr2YymwN8uWQV++fL6orhD4aqc=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
 github.com/spf13/cobra v1.7.0 h1:hyqWnYt1ZQShIddO5kBpj3vu05/++x6tJ6dg8EC572I=


### PR DESCRIPTION
This PR fixes two issues- 
1. #716

Improved the error message in `login.go` to emphasize that the access token is created by going to the webpage and the env vars are updated in the terminal. 

3. #1114

As https://github.com/sourcegraph/sourcegraph was changed to https://github.com/sourcegraph/sourcegraph-public-snapshot
The dependency `github.com/sourcegraph/sourcegraph/lib` was not found. To fix this, a replace directive was added in the go.mod to update the path of that dependency to the new one. 

### Test plan
1. Tested by running `go run ./cmd/src login` to get the following as the expected result- 
```
❌ Problem: No access token is configured.

🛠  To fix: Create an access token by going to https://sourcegraph.com/user/settings/tokens, then set the following environment variables in your terminal:

   export SRC_ENDPOINT=https://sourcegraph.com
   export SRC_ACCESS_TOKEN=(your access token)

   To verify that it's working, run this command again.

exit status 1
```
2. Unit tests 
```
Running tool: /usr/local/go/bin/go test -timeout 30s -run ^TestLogin$ github.com/sourcegraph/src-cli/cmd/src

=== RUN   TestLogin
=== RUN   TestLogin/different_endpoint_in_config_vs._arg
--- PASS: TestLogin/different_endpoint_in_config_vs._arg (0.00s)
=== RUN   TestLogin/no_access_token
--- PASS: TestLogin/no_access_token (0.00s)
=== RUN   TestLogin/warning_when_using_config_file
--- PASS: TestLogin/warning_when_using_config_file (0.00s)
=== RUN   TestLogin/invalid_access_token
--- PASS: TestLogin/invalid_access_token (0.01s)
=== RUN   TestLogin/valid
--- PASS: TestLogin/valid (0.00s)
--- PASS: TestLogin (0.01s)
PASS
ok      github.com/sourcegraph/src-cli/cmd/src  0.066s
```
