### PR TITLE
Update SBOM file format and extract different payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ All notable changes to `src-cli` are documented in this file.
 
 ## Unreleased
 
+## 5.9.1
+
+- Update SBOM output file extension from `.json` to `.cdx.json` [#1123](https://github.com/sourcegraph/src-cli/pull/1123)
+- Improve SBOM compatibility with scanning tools [#1123](https://github.com/sourcegraph/src-cli/pull/1123)
+
 ## 5.9.0
 
 ## 5.8.2

--- a/cmd/src/sbom_fetch.go
+++ b/cmd/src/sbom_fetch.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
-	"path"
 	"path/filepath"
 	"strings"
 	"unicode"
@@ -71,12 +70,12 @@ Examples:
 		if versionFlag == nil || *versionFlag == "" {
 			return cmderrors.Usage("version is required")
 		}
-		c.version = *versionFlag
+		c.version = sanitizeVersion(*versionFlag)
 
 		if outputDirFlag == nil || *outputDirFlag == "" {
 			return cmderrors.Usage("output directory is required")
 		}
-		c.outputDir = getOutputDir(*outputDirFlag, *versionFlag)
+		c.outputDir = getOutputDir(*outputDirFlag, c.version)
 
 		if internalReleaseFlag == nil || !*internalReleaseFlag {
 			c.internalRelease = false
@@ -321,10 +320,6 @@ func (c sbomConfig) storeSBOM(sbom string, image string) error {
 	}
 
 	return nil
-}
-
-func getOutputDir(parentDir, version string) string {
-	return path.Join(parentDir, "sourcegraph-"+version)
 }
 
 // getImageReleaseListURL returns the URL for the list of images in a release, based on the version and whether it's an internal release.

--- a/cmd/src/sbom_utils.go
+++ b/cmd/src/sbom_utils.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"os/exec"
+	"path"
 	"strings"
 	"time"
 )
@@ -189,4 +190,13 @@ func spinner(name string, stop chan bool) {
 			time.Sleep(100 * time.Millisecond)
 		}
 	}
+}
+
+func getOutputDir(parentDir, version string) string {
+	return path.Join(parentDir, "sourcegraph-"+version)
+}
+
+// sanitizeVersion removes any leading "v" from the version string
+func sanitizeVersion(version string) string {
+	return strings.TrimPrefix(version, "v")
 }


### PR DESCRIPTION
- Update SBOM output file format to `.cdx.json`
- Remove an additional layout of JSON wrapping, as this isn't handled by some SBOM parsers

### Test plan

- Tested locally

```
> go run ./cmd/src sbom fetch -v 5.9.45
Fetching SBOMs and validating signatures for all 39 images in the Sourcegraph 5.9.45 release...

✅ sourcegraph/appliance
✅ sourcegraph/batcheshelper
✅ sourcegraph/bundled-executor
✅ sourcegraph/cody-gateway
[...]

> grype sourcegraph-sboms/sourcegraph-5.9.45/sourcegraph_gitserver.cdx.json
 ✔ Vulnerability DB                [no update available]  
 ✔ Scanned for vulnerabilities     [8 vulnerability matches]  
   ├── by severity: 0 critical, 1 high, 2 medium, 1 low, 0 negligible (4 unknown)
   └── by status:   8 fixed, 0 not-fixed, 0 ignored 
NAME                          INSTALLED  FIXED-IN   TYPE       VULNERABILITY        SEVERITY 
github.com/golang-jwt/jwt/v4  v4.5.0     4.5.1      go-module  GHSA-29wx-vh33-7x7r  Low       
google.golang.org/grpc        v1.54.1    1.56.3     go-module  GHSA-qppj-fm5r-hxr3  Medium    
google.golang.org/protobuf    v1.28.1    1.33.0     go-module  GHSA-8r3f-844c-mc37  Medium    
[...]
```
