### PR TITLE
feat/gateway: Add `src gateway benchmark` command

### DIFF
--- a/cmd/src/colors.go
+++ b/cmd/src/colors.go
@@ -22,7 +22,14 @@ func bg256Color(code int) string {
 
 // See https://i.stack.imgur.com/KTSQa.png or https://jonasjacek.github.io/colors/
 var ansiColors = map[string]string{
-	"nc":      "\033[0m",
+	// Simple colors.
+	"blue":   "\033[34m",
+	"green":  "\033[32m",
+	"yellow": "\033[33m",
+	"red":    "\033[31m",
+	"nc":     "\033[0m", // reset
+
+	// Custom colors.
 	"logo":    fg256Color(57),
 	"warning": fg256Color(124),
 	"success": fg256Color(2),

--- a/cmd/src/gateway.go
+++ b/cmd/src/gateway.go
@@ -8,7 +8,7 @@ import (
 var gatewayCommands commander
 
 func init() {
-	usage := `'src gateway' manages Cody Gateway operations on a Sourcegraph instance.
+	usage := `'src gateway' interacts with Cody Gateway (directly or through a Sourcegraph instance).
 
 Usage:
 
@@ -30,9 +30,9 @@ Use "src gateway [command] -h" for more information about a command.
 
 	// Register the command.
 	commands = append(commands, &command{
-		flagSet: flagSet,
-		aliases: []string{},  // No aliases for gateway command
-		handler: handler,
+		flagSet:   flagSet,
+		aliases:   []string{}, // No aliases for gateway command
+		handler:   handler,
 		usageFunc: func() { fmt.Println(usage) },
 	})
 }

--- a/cmd/src/gateway.go
+++ b/cmd/src/gateway.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+)
+
+var gatewayCommands commander
+
+func init() {
+	usage := `'src gateway' manages Cody Gateway operations on a Sourcegraph instance.
+
+Usage:
+
+	src gateway command [command options]
+
+The commands are:
+
+	benchmark           runs benchmarks against Cody Gateway
+
+Use "src gateway [command] -h" for more information about a command.
+
+`
+
+	flagSet := flag.NewFlagSet("gateway", flag.ExitOnError)
+	handler := func(args []string) error {
+		gatewayCommands.run(flagSet, "src gateway", usage, args)
+		return nil
+	}
+
+	// Register the command.
+	commands = append(commands, &command{
+		flagSet: flagSet,
+		aliases: []string{},  // No aliases for gateway command
+		handler: handler,
+		usageFunc: func() { fmt.Println(usage) },
+	})
+}

--- a/cmd/src/gateway_benchmark.go
+++ b/cmd/src/gateway_benchmark.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"crypto/tls"
 	"flag"
 	"fmt"
 	"io"
@@ -43,11 +42,7 @@ Examples:
 		}
 
 		// Create HTTP client with TLS skip verify
-		client := &http.Client{
-			Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-			},
-		}
+		client := &http.Client{Transport: &http.Transport{}}
 
 		endpoints := map[string]string{
 			"HTTP":                fmt.Sprintf("%s/gateway", cfg.Endpoint),

--- a/cmd/src/gateway_benchmark.go
+++ b/cmd/src/gateway_benchmark.go
@@ -1,0 +1,255 @@
+package main
+
+import (
+	"crypto/tls"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/sourcegraph/src-cli/internal/cmderrors"
+)
+
+const (
+	numRequests = 100
+	blue        = "\033[34m"
+	green       = "\033[32m"
+	yellow      = "\033[33m"
+	red         = "\033[31m"
+	reset       = "\033[0m"
+)
+
+func init() {
+	usage := `
+'src gateway benchmark' runs performance benchmarks against Cody Gateway endpoints.
+
+Usage:
+
+    src gateway benchmark [flags]
+
+Examples:
+
+    $ src gateway benchmark
+    $ src gateway benchmark --requests 50
+`
+
+	flagSet := flag.NewFlagSet("benchmark", flag.ExitOnError)
+
+	var (
+		requestCount = flagSet.Int("requests", numRequests, "Number of requests to make per endpoint")
+	)
+
+	handler := func(args []string) error {
+		if err := flagSet.Parse(args); err != nil {
+			return err
+		}
+
+		if len(flagSet.Args()) != 0 {
+			return cmderrors.Usage("additional arguments not allowed")
+		}
+
+		// Create HTTP client with TLS skip verify
+		client := &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			},
+		}
+
+		endpoints := map[string]string{
+			"HTTP":                fmt.Sprintf("%s/cody-gateway-call-http", cfg.Endpoint),
+			"HTTP then WebSocket": fmt.Sprintf("%s/cody-gateway-call-http-then-websocket", cfg.Endpoint),
+		}
+
+		fmt.Printf("Starting benchmark with %d requests per endpoint...\n", *requestCount)
+
+		var results []endpointResult
+
+		for name, url := range endpoints {
+			durations := make([]time.Duration, 0, *requestCount)
+			fmt.Printf("\nTesting %s...", name)
+
+			for i := 0; i < *requestCount; i++ {
+				duration := benchmarkEndpoint(client, url)
+				if duration > 0 {
+					durations = append(durations, duration)
+				}
+				fmt.Printf("\rTesting %s: %d/%d", name, i+1, *requestCount)
+			}
+			fmt.Println()
+
+			avg, p5, p95, median, total := calculateStats(durations)
+
+			results = append(results, endpointResult{
+				name:       name,
+				avg:        avg,
+				median:     median,
+				p5:         p5,
+				p95:        p95,
+				total:      total,
+				successful: len(durations),
+			})
+		}
+
+		printResults(results)
+		return nil
+	}
+
+	gatewayCommands = append(gatewayCommands, &command{
+		flagSet: flagSet,
+		aliases: []string{},
+		handler: handler,
+		usageFunc: func() {
+			fmt.Fprintf(flag.CommandLine.Output(), "Usage of 'src gateway %s':\n", flagSet.Name())
+			flagSet.PrintDefaults()
+			fmt.Println(usage)
+		},
+	})
+}
+
+type endpointResult struct {
+	name       string
+	avg        time.Duration
+	median     time.Duration
+	p5         time.Duration
+	p95        time.Duration
+	total      time.Duration
+	successful int
+}
+
+func benchmarkEndpoint(client *http.Client, url string) time.Duration {
+	start := time.Now()
+	resp, err := client.Get(url)
+	if err != nil {
+		fmt.Printf("Error calling %s: %v\n", url, err)
+		return 0
+	}
+	defer func(Body io.ReadCloser) {
+		err := Body.Close()
+		if err != nil {
+			fmt.Printf("Error closing response body: %v\n", err)
+		}
+	}(resp.Body)
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		fmt.Printf("Error reading response body: %v\n", err)
+		return 0
+	}
+	fmt.Printf("Response from %s: %s\n", url, body)
+
+	return time.Since(start)
+}
+
+func calculateStats(durations []time.Duration) (time.Duration, time.Duration, time.Duration, time.Duration, time.Duration) {
+	if len(durations) == 0 {
+		return 0, 0, 0, 0, 0
+	}
+
+	sort.Slice(durations, func(i, j int) bool {
+		return durations[i] < durations[j]
+	})
+
+	var sum time.Duration
+	for _, d := range durations {
+		sum += d
+	}
+	avg := sum / time.Duration(len(durations))
+
+	p5idx := int(float64(len(durations)) * 0.05)
+	p95idx := int(float64(len(durations)) * 0.95)
+	medianIdx := len(durations) / 2
+
+	return avg, durations[p5idx], durations[p95idx], durations[medianIdx], sum
+}
+
+func formatDuration(d time.Duration, best bool, worst bool) string {
+	value := fmt.Sprintf("%.2fms", float64(d.Microseconds())/1000)
+	if best {
+		return green + value + reset
+	}
+	if worst {
+		return red + value + reset
+	}
+	return yellow + value + reset
+}
+
+func formatSuccessRate(successful, total int, best bool, worst bool) string {
+	value := fmt.Sprintf("%d/%d", successful, total)
+	if best {
+		return green + value + reset
+	}
+	if worst {
+		return red + value + reset
+	}
+	return yellow + value + reset
+}
+
+func printResults(results []endpointResult) {
+	// Print header
+	headerFmt := blue + "%-20s | %-10s | %-10s | %-10s | %-10s | %-10s | %-10s" + reset + "\n"
+	fmt.Printf("\n"+headerFmt,
+		"Endpoint    ", "Average", "Median", "P5", "P95", "Total", "Success")
+	fmt.Println(blue + strings.Repeat("-", 96) + reset)
+
+	// Find best/worst values for each metric
+	var bestAvg, worstAvg time.Duration
+	var bestMedian, worstMedian time.Duration
+	var bestP5, worstP5 time.Duration
+	var bestP95, worstP95 time.Duration
+	var bestTotal, worstTotal time.Duration
+	var bestSuccess, worstSuccess int
+
+	for i, r := range results {
+		if i == 0 || r.avg < bestAvg {
+			bestAvg = r.avg
+		}
+		if i == 0 || r.avg > worstAvg {
+			worstAvg = r.avg
+		}
+		if i == 0 || r.median < bestMedian {
+			bestMedian = r.median
+		}
+		if i == 0 || r.median > worstMedian {
+			worstMedian = r.median
+		}
+		if i == 0 || r.p5 < bestP5 {
+			bestP5 = r.p5
+		}
+		if i == 0 || r.p5 > worstP5 {
+			worstP5 = r.p5
+		}
+		if i == 0 || r.p95 < bestP95 {
+			bestP95 = r.p95
+		}
+		if i == 0 || r.p95 > worstP95 {
+			worstP95 = r.p95
+		}
+		if i == 0 || r.total < bestTotal {
+			bestTotal = r.total
+		}
+		if i == 0 || r.total > worstTotal {
+			worstTotal = r.total
+		}
+		if i == 0 || r.successful > bestSuccess {
+			bestSuccess = r.successful
+		}
+		if i == 0 || r.successful < worstSuccess {
+			worstSuccess = r.successful
+		}
+	}
+
+	// Print each row
+	for _, r := range results {
+		fmt.Printf("%-20s | %-19s | %-19s | %-19s | %-19s | %-19s | %s\n",
+			r.name,
+			formatDuration(r.avg, r.avg == bestAvg, r.avg == worstAvg),
+			formatDuration(r.median, r.median == bestMedian, r.median == worstMedian),
+			formatDuration(r.p5, r.p5 == bestP5, r.p5 == worstP5),
+			formatDuration(r.p95, r.p95 == bestP95, r.p95 == worstP95),
+			formatDuration(r.total, r.total == bestTotal, r.total == worstTotal),
+			formatSuccessRate(r.successful, numRequests, r.successful == bestSuccess, r.successful == worstSuccess))
+	}
+}

--- a/cmd/src/gateway_benchmark.go
+++ b/cmd/src/gateway_benchmark.go
@@ -14,8 +14,8 @@ import (
 )
 
 const (
-	numRequests = 100
-	blue        = "\033[34m"
+	defaultRequestCount = 100
+	blue                = "\033[34m"
 	green       = "\033[32m"
 	yellow      = "\033[33m"
 	red         = "\033[31m"
@@ -39,7 +39,7 @@ Examples:
 	flagSet := flag.NewFlagSet("benchmark", flag.ExitOnError)
 
 	var (
-		requestCount = flagSet.Int("requests", numRequests, "Number of requests to make per endpoint")
+		requestCount = flagSet.Int("requests", defaultRequestCount, "Number of requests to make per endpoint")
 	)
 
 	handler := func(args []string) error {
@@ -93,7 +93,7 @@ Examples:
 			})
 		}
 
-		printResults(results)
+		printResults(results, requestCount)
 		return nil
 	}
 
@@ -102,7 +102,10 @@ Examples:
 		aliases: []string{},
 		handler: handler,
 		usageFunc: func() {
-			fmt.Fprintf(flag.CommandLine.Output(), "Usage of 'src gateway %s':\n", flagSet.Name())
+			_, err := fmt.Fprintf(flag.CommandLine.Output(), "Usage of 'src gateway %s':\n", flagSet.Name())
+			if err != nil {
+				return
+			}
 			flagSet.PrintDefaults()
 			fmt.Println(usage)
 		},
@@ -187,7 +190,7 @@ func formatSuccessRate(successful, total int, best bool, worst bool) string {
 	return yellow + value + reset
 }
 
-func printResults(results []endpointResult) {
+func printResults(results []endpointResult, requestCount *int) {
 	// Print header
 	headerFmt := blue + "%-20s | %-10s | %-10s | %-10s | %-10s | %-10s | %-10s" + reset + "\n"
 	fmt.Printf("\n"+headerFmt,
@@ -250,6 +253,6 @@ func printResults(results []endpointResult) {
 			formatDuration(r.p5, r.p5 == bestP5, r.p5 == worstP5),
 			formatDuration(r.p95, r.p95 == bestP95, r.p95 == worstP95),
 			formatDuration(r.total, r.total == bestTotal, r.total == worstTotal),
-			formatSuccessRate(r.successful, numRequests, r.successful == bestSuccess, r.successful == worstSuccess))
+			formatSuccessRate(r.successful, *requestCount, r.successful == bestSuccess, r.successful == worstSuccess))
 	}
 }

--- a/cmd/src/gateway_benchmark.go
+++ b/cmd/src/gateway_benchmark.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"encoding/csv"
 	"flag"
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"sort"
 	"strings"
 	"time"
@@ -34,12 +36,14 @@ Examples:
 
     $ src gateway benchmark
     $ src gateway benchmark --requests 50
+    $ src gateway benchmark --requests 50 --csv results.csv
 `
 
 	flagSet := flag.NewFlagSet("benchmark", flag.ExitOnError)
 
 	var (
 		requestCount = flagSet.Int("requests", 1000, "Number of requests to make per endpoint")
+		csvOutput    = flagSet.String("csv", "", "Export results to CSV file (provide filename)")
 	)
 
 	handler := func(args []string) error {
@@ -82,6 +86,8 @@ Examples:
 				avg:        stats.Avg,
 				median:     stats.Median,
 				p5:         stats.P5,
+				p75:        stats.P75,
+				p80:        stats.P80,
 				p95:        stats.P95,
 				total:      stats.Total,
 				successful: len(durations),
@@ -89,6 +95,14 @@ Examples:
 		}
 
 		printResults(results, requestCount)
+
+		if *csvOutput != "" {
+			if err := writeResultsToCSV(*csvOutput, results, requestCount); err != nil {
+				return fmt.Errorf("failed to export CSV: %v", err)
+			}
+			fmt.Printf("\nResults exported to %s\n", *csvOutput)
+		}
+
 		return nil
 	}
 
@@ -112,6 +126,8 @@ type endpointResult struct {
 	avg        time.Duration
 	median     time.Duration
 	p5         time.Duration
+	p75        time.Duration
+	p80        time.Duration
 	p95        time.Duration
 	total      time.Duration
 	successful int
@@ -191,15 +207,17 @@ func formatSuccessRate(successful, total int, best bool, worst bool) string {
 
 func printResults(results []endpointResult, requestCount *int) {
 	// Print header
-	headerFmt := ansiColors["blue"] + "%-20s | %-10s | %-10s | %-10s | %-10s | %-10s | %-10s" + ansiColors["nc"] + "\n"
+	headerFmt := ansiColors["blue"] + "%-20s | %-10s | %-10s | %-10s | %-10s | %-10s | %-10s | %-10s | %-10s" + ansiColors["nc"] + "\n"
 	fmt.Printf("\n"+headerFmt,
-		"Endpoint    ", "Average", "Median", "P5", "P95", "Total", "Success")
-	fmt.Println(ansiColors["blue"] + strings.Repeat("-", 96) + ansiColors["nc"])
+		"Endpoint    ", "Average", "Median", "P5", "P75", "P80", "P95", "Total", "Success")
+	fmt.Println(ansiColors["blue"] + strings.Repeat("-", 121) + ansiColors["nc"])
 
 	// Find best/worst values for each metric
 	var bestAvg, worstAvg time.Duration
 	var bestMedian, worstMedian time.Duration
 	var bestP5, worstP5 time.Duration
+	var bestP75, worstP75 time.Duration
+	var bestP80, worstP80 time.Duration
 	var bestP95, worstP95 time.Duration
 	var bestTotal, worstTotal time.Duration
 	var bestSuccess, worstSuccess int
@@ -223,6 +241,18 @@ func printResults(results []endpointResult, requestCount *int) {
 		if i == 0 || r.p5 > worstP5 {
 			worstP5 = r.p5
 		}
+		if i == 0 || r.p75 < bestP75 {
+			bestP75 = r.p75
+		}
+		if i == 0 || r.p75 > worstP75 {
+			worstP75 = r.p75
+		}
+		if i == 0 || r.p80 < bestP80 {
+			bestP80 = r.p80
+		}
+		if i == 0 || r.p80 > worstP80 {
+			worstP80 = r.p80
+		}
 		if i == 0 || r.p95 < bestP95 {
 			bestP95 = r.p95
 		}
@@ -245,13 +275,57 @@ func printResults(results []endpointResult, requestCount *int) {
 
 	// Print each row
 	for _, r := range results {
-		fmt.Printf("%-20s | %-19s | %-19s | %-19s | %-19s | %-19s | %s\n",
+		fmt.Printf("%-20s | %-19s | %-19s | %-19s | %-19s | %-19s | %-19s | %-19s | %s\n",
 			r.name,
 			formatDuration(r.avg, r.avg == bestAvg, r.avg == worstAvg),
 			formatDuration(r.median, r.median == bestMedian, r.median == worstMedian),
 			formatDuration(r.p5, r.p5 == bestP5, r.p5 == worstP5),
+			formatDuration(r.p75, r.p75 == bestP75, r.p75 == worstP75),
+			formatDuration(r.p80, r.p80 == bestP80, r.p80 == worstP80),
 			formatDuration(r.p95, r.p95 == bestP95, r.p95 == worstP95),
 			formatDuration(r.total, r.total == bestTotal, r.total == worstTotal),
 			formatSuccessRate(r.successful, *requestCount, r.successful == bestSuccess, r.successful == worstSuccess))
 	}
+}
+
+func writeResultsToCSV(filename string, results []endpointResult, requestCount *int) error {
+	file, err := os.Create(filename)
+	if err != nil {
+		return fmt.Errorf("failed to create CSV file: %v", err)
+	}
+	defer func() {
+		err := file.Close()
+		if err != nil {
+			return
+		}
+	}()
+
+	writer := csv.NewWriter(file)
+	defer writer.Flush()
+
+	// Write header
+	header := []string{"Endpoint", "Average (ms)", "Median (ms)", "P5 (ms)", "P75 (ms)", "P80 (ms)", "P95 (ms)", "Total (ms)", "Success Rate"}
+	if err := writer.Write(header); err != nil {
+		return fmt.Errorf("failed to write CSV header: %v", err)
+	}
+
+	// Write data rows
+	for _, r := range results {
+		row := []string{
+			r.name,
+			fmt.Sprintf("%.2f", float64(r.avg.Microseconds())/1000),
+			fmt.Sprintf("%.2f", float64(r.median.Microseconds())/1000),
+			fmt.Sprintf("%.2f", float64(r.p5.Microseconds())/1000),
+			fmt.Sprintf("%.2f", float64(r.p75.Microseconds())/1000),
+			fmt.Sprintf("%.2f", float64(r.p80.Microseconds())/1000),
+			fmt.Sprintf("%.2f", float64(r.p95.Microseconds())/1000),
+			fmt.Sprintf("%.2f", float64(r.total.Microseconds())/1000),
+			fmt.Sprintf("%d/%d", r.successful, *requestCount),
+		}
+		if err := writer.Write(row); err != nil {
+			return fmt.Errorf("failed to write CSV row: %v", err)
+		}
+	}
+
+	return nil
 }

--- a/cmd/src/main.go
+++ b/cmd/src/main.go
@@ -53,7 +53,7 @@ The commands are:
 	config          manages global, org, and user settings
 	extensions,ext  manages extensions (experimental)
 	extsvc          manages external services
-	gateway         manages Cody Gateway
+	gateway         interacts with Cody Gateway
 	login           authenticate to a Sourcegraph instance with your user credentials
 	lsif            manages LSIF data (deprecated: use 'code-intel')
 	orgs,org        manages organizations

--- a/cmd/src/main.go
+++ b/cmd/src/main.go
@@ -53,6 +53,7 @@ The commands are:
 	config          manages global, org, and user settings
 	extensions,ext  manages extensions (experimental)
 	extsvc          manages external services
+	gateway         manages Cody Gateway
 	login           authenticate to a Sourcegraph instance with your user credentials
 	lsif            manages LSIF data (deprecated: use 'code-intel')
 	orgs,org        manages organizations


### PR DESCRIPTION
Adds the `src gateway benchmark` command to the tool.

https://github.com/sourcegraph/sourcegraph/pull/1526 adds some new endpoints that this benchmarking script uses.

The benchmarking tool compares ~three~ two routes using the endpoints added in above PR:
1. Sourcegraph HTTP → Cody Gateway HTTP
2. Sourcegraph HTTP → Cody Gateway WebSocket
3. (There should be a third one: Sourcegraph WebSocket → Cody Gateway WebSocket, but I haven't been able to make that endpoint work so it's currently not added to this script.)

### Testing the benchmarking tool locally

(Description WIP)

- `brew install ngrok/ngrok/ngrok` if you don't have ngrok
- Run `ngrok http http://localhost:9992`
- Copy the `*.ngrok-free.app` URL from the "Forwarding" section of ngrok's output to your `dev-private/enterprise/dev/site-config.json` as the "modelConfiguration" / "sourcegraph" / "endpoint" value.
- **Important note:** Actually, when using ngrok, the protocol when calling Cody Gateway in the new endpoint handler has to be `wss://`, not `ws://`! (Just a one-char change but it's manual for now.) But when running locally, it needs to be `ws://`. Something to be mindful of when running this and in the future.
- Run Sourcegraph: `run sg dotcom`
- Run: `src gateway benchmark`

The output should look like this:

![CleanShot 2024-11-07 at 15 01 49@2x](https://github.com/user-attachments/assets/84428fe3-1926-4fd4-a3de-47c9b53c7dfb)

### Next steps

Missing work to be done:
- Add a direct call to Cody Gateway. Endpoints are at:
  - `{codyGatewayUrl}/v2/http` and
  - `{codyGatewayUrl}/v2/websocket`.
- Docs?

### Test plan

Tested manually:

1. ✅ `go run ./cmd/src` lists the new `gateway` command correctly.
2. ✅ `go run ./cmd/src gateway` lists the `benchmark` subcommand correctly.
3. ✅ `go run ./cmd/src gateway benchmark` runs the benchmarks against the endpoint set in the `SRC_ENDPOINT` env var correctly.
4. ✅ `go run ./cmd/src gateway benchmark --requests 2` sets the number of requests correctly.
5. ✅ `SRC_ENDPOINT=http://localhost:3080 go run ./cmd/src gateway benchmark --requests 2` sets the endpoint to my localhost and works correctly.