### PR TITLE
Fix body closing format for CI

### DIFF
--- a/cmd/src/gateway_benchmark.go
+++ b/cmd/src/gateway_benchmark.go
@@ -166,12 +166,12 @@ func benchmarkEndpointHTTP(client *http.Client, url string) time.Duration {
 		fmt.Printf("Error calling %s: %v\n", url, err)
 		return 0
 	}
-	defer func(body io.ReadCloser) {
-		err := body.Close()
+	defer func() {
+		err := resp.Body.Close()
 		if err != nil {
 			fmt.Printf("Error closing response body: %v\n", err)
 		}
-	}(resp.Body)
+	}()
 
 	_, err = io.ReadAll(resp.Body)
 	if err != nil {


### PR DESCRIPTION
Fix body closing func format to match the expectations in our CI.

### Test plan

CI