### PR TITLE
gateway: benchmark: use POST, improve logging slightly

### DIFF
--- a/cmd/src/gateway_benchmark.go
+++ b/cmd/src/gateway_benchmark.go
@@ -26,6 +26,23 @@ type Stats struct {
 	Total  time.Duration
 }
 
+// httpEndpointConfig represents the configuration for an HTTP endpoint.
+type httpEndpointConfig struct {
+	client *http.Client
+	url    string
+}
+
+// sgAuthTransport is an http.RoundTripper that adds an Authorization header to requests.
+// It is used to add the Sourcegraph access token to requests to Sourcegraph endpoints.
+type sgAuthTransport struct {
+	token string
+	base  http.RoundTripper
+}
+func (t *sgAuthTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.Header.Add("Authorization", "token "+t.token)
+	return t.base.RoundTrip(req)
+}
+
 func init() {
 	usage := `
 'src gateway benchmark' runs performance benchmarks against Cody Gateway endpoints.
@@ -38,7 +55,7 @@ Examples:
 
     $ src gateway benchmark
     $ src gateway benchmark --requests 50
-    $ src gateway benchmark --gateway http://localhost:9992 --sourcegraph http://localhost:3082
+    $ src gateway benchmark --gateway http://localhost:9992 --sourcegraph http://localhost:3082 --sgp sgp_***** --requests 50
     $ src gateway benchmark --requests 50 --csv results.csv
 `
 
@@ -49,6 +66,7 @@ Examples:
 		csvOutput       = flagSet.String("csv", "", "Export results to CSV file (provide filename)")
 		gatewayEndpoint = flagSet.String("gateway", "https://cody-gateway.sourcegraph.com", "Cody Gateway endpoint")
 		sgEndpoint      = flagSet.String("sourcegraph", "https://sourcegraph.com", "Sourcegraph endpoint")
+		sgpToken        = flagSet.String("sgp", "sgp_*****", "Sourcegraph personal access token for the called instance")
 	)
 
 	handler := func(args []string) error {
@@ -63,9 +81,12 @@ Examples:
 		var (
 			gatewayWebsocket, sourcegraphWebsocket *websocket.Conn
 			err                                    error
-			httpClient                             = &http.Client{}
+			gatewayClient                          = &http.Client{}
+			sourcegraphClient                      = &http.Client{}
 			endpoints                              = map[string]any{} // Values: URL `string`s or `*websocket.Conn`s
 		)
+
+		// Connect to endpoints
 		if *gatewayEndpoint != "" {
 			fmt.Println("Benchmarking Cody Gateway instance:", *gatewayEndpoint)
 			wsURL := strings.Replace(fmt.Sprint(*gatewayEndpoint, "/v2/websocket"), "http", "ws", 1)
@@ -76,22 +97,41 @@ Examples:
 			}
 			fmt.Println("Connected!")
 			endpoints["ws(s): gateway"] = gatewayWebsocket
-			endpoints["http(s): gateway"] = fmt.Sprint(*gatewayEndpoint, "/v2/http")
+			endpoints["http(s): gateway"] = &httpEndpointConfig{
+				client: gatewayClient,
+				url:    fmt.Sprint(*gatewayEndpoint, "/v2/http"),
+			}
 		} else {
 			fmt.Println("warning: not benchmarking Cody Gateway (-gateway endpoint not provided)")
 		}
 		if *sgEndpoint != "" {
+			// Add auth header to sourcegraphClient transport
+			if *sgpToken != "" {
+				sourcegraphClient.Transport = &sgAuthTransport{
+					token: *sgpToken,
+					base:  http.DefaultTransport,
+				}
+			}
 			fmt.Println("Benchmarking Sourcegraph instance:", *sgEndpoint)
 			wsURL := strings.Replace(fmt.Sprint(*sgEndpoint, "/.api/gateway/websocket"), "http", "ws", 1)
+			header := http.Header{}
+			header.Add("Authorization", "token "+*sgpToken)
 			fmt.Println("Connecting to Sourcegraph instance via WebSocket..", wsURL)
-			sourcegraphWebsocket, _, err = websocket.DefaultDialer.Dial(wsURL, nil)
+			sourcegraphWebsocket, _, err = websocket.DefaultDialer.Dial(wsURL, header)
 			if err != nil {
 				return fmt.Errorf("WebSocket dial(%s): %v", wsURL, err)
 			}
 			fmt.Println("Connected!")
+
 			endpoints["ws(s): sourcegraph"] = sourcegraphWebsocket
-			endpoints["http(s): sourcegraph"] = fmt.Sprint(*sgEndpoint, "/.api/gateway/http")
-			endpoints["http(s): http-then-ws"] = fmt.Sprint(*sgEndpoint, "/.api/gateway/http-then-websocket")
+			endpoints["http(s): sourcegraph"] = &httpEndpointConfig{
+				client: sourcegraphClient,
+				url:    fmt.Sprint(*sgEndpoint, "/.api/gateway/http"),
+			}
+			endpoints["http(s): http-then-ws"] = &httpEndpointConfig{
+				client: sourcegraphClient,
+				url:    fmt.Sprint(*sgEndpoint, "/.api/gateway/http-then-websocket"),
+			}
 		} else {
 			fmt.Println("warning: not benchmarking Sourcegraph instance (-sourcegraph endpoint not provided)")
 		}
@@ -99,18 +139,18 @@ Examples:
 		fmt.Printf("Starting benchmark with %d requests per endpoint...\n", *requestCount)
 
 		var results []endpointResult
-		for name, clientOrURL := range endpoints {
+		for name, clientOrEndpointConfig := range endpoints {
 			durations := make([]time.Duration, 0, *requestCount)
 			fmt.Printf("\nTesting %s...", name)
 
 			for i := 0; i < *requestCount; i++ {
-				if ws, ok := clientOrURL.(*websocket.Conn); ok {
+				if ws, ok := clientOrEndpointConfig.(*websocket.Conn); ok {
 					duration := benchmarkEndpointWebSocket(ws)
 					if duration > 0 {
 						durations = append(durations, duration)
 					}
-				} else if url, ok := clientOrURL.(string); ok {
-					duration := benchmarkEndpointHTTP(httpClient, url)
+				} else if epConf, ok := clientOrEndpointConfig.(httpEndpointConfig); ok {
+					duration := benchmarkEndpointHTTP(epConf)
 					if duration > 0 {
 						durations = append(durations, duration)
 					}
@@ -172,11 +212,11 @@ type endpointResult struct {
 	successful int
 }
 
-func benchmarkEndpointHTTP(client *http.Client, url string) time.Duration {
+func benchmarkEndpointHTTP(epConfig httpEndpointConfig) time.Duration {
 	start := time.Now()
-	resp, err := client.Post(url, "application/json", strings.NewReader("ping"))
+	resp, err := epConfig.client.Post(epConfig.url, "application/json", strings.NewReader("ping"))
 	if err != nil {
-		fmt.Printf("Error calling %s: %v\n", url, err)
+		fmt.Printf("Error calling %s: %v\n", epConfig.url, err)
 		return 0
 	}
 	defer func() {


### PR DESCRIPTION
Minor changes which pair with https://github.com/sourcegraph/sourcegraph/pull/2119and help debug e.g. WebSocket connection issues

### Test plan

Manually tested via running:

```
go install ./cmd/src && ~/.gobin/src gateway benchmark --gateway http://localhost:9992 --sourcegraph http://localhost:3082 --requests 10000
```

With this site config in a dev instance:

```
  "modelConfiguration": {
    "sourcegraph": {
      "endpoint": "http://localhost:9992"
      // "endpoint": "https://cody-gateway.sgdev.org"
    }
  },

```

Running this PR: https://github.com/sourcegraph/sourcegraph/pull/2119

Which produces these results:

```
Endpoint                  | Average    | Median     | P5         | P75        | P80        | P95        | Total      | Success   
-------------------------------------------------------------------------------------------------------------------------
http(s): gateway     | 0.07ms     | 0.07ms     | 0.05ms     | 0.09ms     | 0.09ms     | 0.11ms     | 741.92ms   | 10000/10000
ws(s): sourcegraph   | 0.06ms     | 0.05ms     | 0.04ms     | 0.08ms     | 0.09ms     | 0.11ms     | 649.26ms   | 10000/10000
http(s): sourcegraph | 2.00ms     | 1.81ms     | 1.45ms     | 2.21ms     | 2.33ms     | 2.83ms     | 20046.89ms | 10000/10000
http(s): http-then-ws | 1.52ms     | 1.42ms     | 1.22ms     | 1.58ms     | 1.64ms     | 2.12ms     | 15236.48ms | 10000/10000
ws(s): gateway       | 0.03ms     | 0.02ms     | 0.02ms     | 0.02ms     | 0.03ms     | 0.05ms     | 253.06ms   | 10000/10000
```