### PR TITLE
gateway: benchmark: fix 'all websocket requests fail' case

### DIFF
--- a/cmd/src/gateway_benchmark.go
+++ b/cmd/src/gateway_benchmark.go
@@ -62,21 +62,15 @@ Examples:
 		}
 
 		var (
-			gatewayWebsocket, sourcegraphWebsocket *websocket.Conn
-			err                                    error
-			httpClient                             = &http.Client{}
-			endpoints                              = map[string]any{} // Values: URL `string`s or `*websocket.Conn`s
+			httpClient = &http.Client{}
+			endpoints  = map[string]any{} // Values: URL `string`s or `*webSocketClient`s
 		)
 		if *gatewayEndpoint != "" {
 			fmt.Println("Benchmarking Cody Gateway instance:", *gatewayEndpoint)
-			wsURL := strings.Replace(fmt.Sprint(*gatewayEndpoint, "/v2/websocket"), "http", "ws", 1)
-			fmt.Println("Connecting to Cody Gateway via WebSocket..", wsURL)
-			gatewayWebsocket, _, err = websocket.DefaultDialer.Dial(wsURL, nil)
-			if err != nil {
-				return fmt.Errorf("WebSocket dial(%s): %v", wsURL, err)
+			endpoints["ws(s): gateway"] = &webSocketClient{
+				conn: nil,
+				URL:  strings.Replace(fmt.Sprint(*gatewayEndpoint, "/v2/websocket"), "http", "ws", 1),
 			}
-			fmt.Println("Connected!")
-			endpoints["ws(s): gateway"] = gatewayWebsocket
 			endpoints["http(s): gateway"] = fmt.Sprint(*gatewayEndpoint, "/v2/http")
 		} else {
 			fmt.Println("warning: not benchmarking Cody Gateway (-gateway endpoint not provided)")
@@ -86,14 +80,10 @@ Examples:
 				return cmderrors.Usage("must specify --sgp <Sourcegraph personal access token>")
 			}
 			fmt.Println("Benchmarking Sourcegraph instance:", *sgEndpoint)
-			wsURL := strings.Replace(fmt.Sprint(*sgEndpoint, "/.api/gateway/websocket"), "http", "ws", 1)
-			fmt.Println("Connecting to Sourcegraph instance via WebSocket..", wsURL)
-			sourcegraphWebsocket, _, err = websocket.DefaultDialer.Dial(wsURL, nil)
-			if err != nil {
-				return fmt.Errorf("WebSocket dial(%s): %v", wsURL, err)
+			endpoints["ws(s): sourcegraph"] = &webSocketClient{
+				conn: nil,
+				URL:  strings.Replace(fmt.Sprint(*sgEndpoint, "/.api/gateway/websocket"), "http", "ws", 1),
 			}
-			fmt.Println("Connected!")
-			endpoints["ws(s): sourcegraph"] = sourcegraphWebsocket
 			endpoints["http(s): sourcegraph"] = fmt.Sprint(*sgEndpoint, "/.api/gateway/http")
 			endpoints["http(s): http-then-ws"] = fmt.Sprint(*sgEndpoint, "/.api/gateway/http-then-websocket")
 		} else {
@@ -108,7 +98,7 @@ Examples:
 			fmt.Printf("\nTesting %s...", name)
 
 			for i := 0; i < *requestCount; i++ {
-				if ws, ok := clientOrURL.(*websocket.Conn); ok {
+				if ws, ok := clientOrURL.(*webSocketClient); ok {
 					duration := benchmarkEndpointWebSocket(ws)
 					if duration > 0 {
 						durations = append(durations, duration)
@@ -164,6 +154,26 @@ Examples:
 	})
 }
 
+type webSocketClient struct {
+	conn *websocket.Conn
+	URL  string
+}
+
+func (c *webSocketClient) reconnect() error {
+	if c.conn != nil {
+		c.conn.Close() // don't leak connections
+	}
+	fmt.Println("Connecting to WebSocket..", c.URL)
+	var err error
+	c.conn, _, err = websocket.DefaultDialer.Dial(c.URL, nil)
+	if err != nil {
+		c.conn = nil // retry again later
+		return fmt.Errorf("WebSocket dial(%s): %v", c.URL, err)
+	}
+	fmt.Println("Connected!")
+	return nil
+}
+
 type endpointResult struct {
 	name       string
 	avg        time.Duration
@@ -213,20 +223,39 @@ func benchmarkEndpointHTTP(client *http.Client, url, accessToken string) time.Du
 	return time.Since(start)
 }
 
-func benchmarkEndpointWebSocket(conn *websocket.Conn) time.Duration {
+func benchmarkEndpointWebSocket(client *webSocketClient) time.Duration {
+	// Perform initial websocket connection, if needed.
+	if client.conn == nil {
+		if err := client.reconnect(); err != nil {
+			fmt.Printf("Error reconnecting: %v\n", err)
+			return 0
+		}
+	}
+
+	// Perform the benchmarked request using the websocket.
 	start := time.Now()
-	err := conn.WriteMessage(websocket.TextMessage, []byte("ping"))
+	err := client.conn.WriteMessage(websocket.TextMessage, []byte("ping"))
 	if err != nil {
 		fmt.Printf("WebSocket write error: %v\n", err)
+		if err := client.reconnect(); err != nil {
+			fmt.Printf("Error reconnecting: %v\n", err)
+		}
 		return 0
 	}
-	_, message, err := conn.ReadMessage()
+	_, message, err := client.conn.ReadMessage()
+
 	if err != nil {
 		fmt.Printf("WebSocket read error: %v\n", err)
+		if err := client.reconnect(); err != nil {
+			fmt.Printf("Error reconnecting: %v\n", err)
+		}
 		return 0
 	}
 	if string(message) != "pong" {
 		fmt.Printf("Expected 'pong' response, got: %q\n", string(message))
+		if err := client.reconnect(); err != nil {
+			fmt.Printf("Error reconnecting: %v\n", err)
+		}
 		return 0
 	}
 	return time.Since(start)


### PR DESCRIPTION
The first commit here replaces the authentication with a simpler / more correct implementation (no transport) and improves usage doc commands slightly.

The second commit fixes a major issue: we would connect the websocket at the very start, which meant that if the tests which run _before_ we use the websocket take >60s.. by the time we use the websocket, the server would already consider the connection dead due to inactivity. This fixes the issue by only connecting the first time we want to use the connection, and also adding reconnect logic.

### Test plan

Manually tested