### PR TITLE
gateway: benchmark has same alignment for header and rows

### DIFF
--- a/cmd/src/gateway_benchmark.go
+++ b/cmd/src/gateway_benchmark.go
@@ -384,7 +384,7 @@ func printResults(results []endpointResult, requestCount *int) {
 
 	// Print each row
 	for _, r := range results {
-		fmt.Printf("%-20s | %-19s | %-19s | %-19s | %-19s | %-19s | %-19s | %-19s | %s\n",
+		fmt.Printf("%-25s | %-19s | %-19s | %-19s | %-19s | %-19s | %-19s | %-19s | %s\n",
 			r.name,
 			formatDuration(r.avg, r.avg == bestAvg, r.avg == worstAvg),
 			formatDuration(r.median, r.median == bestMedian, r.median == worstMedian),


### PR DESCRIPTION
Minor formatting issue which caused the table to not be aligned.

Test Plan: Ran the shared incantation with "--requests 1" and the table looked good.
