### PR TITLE
Add --use-special-header to gateway benchmark (PRIME-651)

### DIFF
--- a/cmd/src/gateway_benchmark.go
+++ b/cmd/src/gateway_benchmark.go
@@ -26,6 +26,11 @@ type Stats struct {
 	Total  time.Duration
 }
 
+type requestResult struct {
+	duration time.Duration
+	traceID  string // X-Trace header value
+}
+
 func init() {
 	usage := `
 'src gateway benchmark' runs performance benchmarks against Cody Gateway and Sourcegraph test endpoints.
@@ -46,12 +51,13 @@ Examples:
 	flagSet := flag.NewFlagSet("benchmark", flag.ExitOnError)
 
 	var (
-		requestCount    = flagSet.Int("requests", 1000, "Number of requests to make per endpoint")
-		csvOutput       = flagSet.String("csv", "", "Export results to CSV file (provide filename)")
-		gatewayEndpoint = flagSet.String("gateway", "https://cody-gateway.sourcegraph.com", "Cody Gateway endpoint")
-		sgEndpoint      = flagSet.String("sourcegraph", "https://sourcegraph.com", "Sourcegraph endpoint")
-		sgpToken        = flagSet.String("sgp", "", "Sourcegraph personal access token for the called instance")
-		useSpecialHeader = flagSet.Bool("use-special-header", false, "Use special header to test the gateway")
+		requestCount          = flagSet.Int("requests", 1000, "Number of requests to make per endpoint")
+		csvOutput             = flagSet.String("csv", "", "Export results to CSV file (provide filename)")
+		requestLevelCsvOutput = flagSet.String("request-csv", "", "Export request results to CSV file (provide filename)")
+		gatewayEndpoint       = flagSet.String("gateway", "https://cody-gateway.sourcegraph.com", "Cody Gateway endpoint")
+		sgEndpoint            = flagSet.String("sourcegraph", "https://sourcegraph.com", "Sourcegraph endpoint")
+		sgpToken              = flagSet.String("sgp", "", "Sourcegraph personal access token for the called instance")
+		useSpecialHeader      = flagSet.Bool("use-special-header", false, "Use special header to test the gateway")
 	)
 
 	handler := func(args []string) error {
@@ -73,9 +79,13 @@ Examples:
 		)
 		if *gatewayEndpoint != "" {
 			fmt.Println("Benchmarking Cody Gateway instance:", *gatewayEndpoint)
+			headers := http.Header{
+				"X-Sourcegraph-Should-Trace": []string{"true"},
+			}
 			endpoints["ws(s): gateway"] = &webSocketClient{
-				conn: nil,
-				URL:  strings.Replace(fmt.Sprint(*gatewayEndpoint, "/v2/websocket"), "http", "ws", 1),
+				conn:       nil,
+				URL:        strings.Replace(fmt.Sprint(*gatewayEndpoint, "/v2/websocket"), "http", "ws", 1),
+				reqHeaders: headers,
 			}
 			endpoints["http(s): gateway"] = fmt.Sprint(*gatewayEndpoint, "/v2/http")
 		} else {
@@ -88,15 +98,16 @@ Examples:
 			fmt.Println("Benchmarking Sourcegraph instance:", *sgEndpoint)
 			headers := http.Header{
 				"Authorization": []string{"token " + *sgpToken},
+				"X-Sourcegraph-Should-Trace": []string{"true"},
 			}
 			if *useSpecialHeader {
 				headers.Set("cody-core-gc-test", "M2R{+6VI?1,M3n&<vpw1&AK>")
 			}
 
 			endpoints["ws(s): sourcegraph"] = &webSocketClient{
-				conn:    nil,
-				URL:     strings.Replace(fmt.Sprint(*sgEndpoint, "/.api/gateway/websocket"), "http", "ws", 1),
-				headers: headers,
+				conn:       nil,
+				URL:        strings.Replace(fmt.Sprint(*sgEndpoint, "/.api/gateway/websocket"), "http", "ws", 1),
+				reqHeaders: headers,
 			}
 			endpoints["http(s): sourcegraph"] = fmt.Sprint(*sgEndpoint, "/.api/gateway/http")
 			endpoints["http(s): http-then-ws"] = fmt.Sprint(*sgEndpoint, "/.api/gateway/http-then-websocket")
@@ -106,21 +117,25 @@ Examples:
 
 		fmt.Printf("Starting benchmark with %d requests per endpoint...\n", *requestCount)
 
-		var results []endpointResult
+		var eResults []endpointResult
+		rResults := map[string][]requestResult {}
 		for name, clientOrURL := range endpoints {
 			durations := make([]time.Duration, 0, *requestCount)
+			rResults[name] = make([]requestResult, 0, *requestCount)
 			fmt.Printf("\nTesting %s...", name)
 
 			for i := 0; i < *requestCount; i++ {
 				if ws, ok := clientOrURL.(*webSocketClient); ok {
-					duration := benchmarkEndpointWebSocket(ws)
-					if duration > 0 {
-						durations = append(durations, duration)
+					result := benchmarkEndpointWebSocket(ws)
+					if result.duration > 0 {
+						durations = append(durations, result.duration)
+						rResults[name] = append(rResults[name], result)
 					}
 				} else if url, ok := clientOrURL.(string); ok {
-					duration := benchmarkEndpointHTTP(httpClient, url, *sgpToken, *useSpecialHeader)
-					if duration > 0 {
-						durations = append(durations, duration)
+					result := benchmarkEndpointHTTP(httpClient, url, *sgpToken, *useSpecialHeader)
+					if result.duration > 0 {
+						durations = append(durations, result.duration)
+						rResults[name] = append(rResults[name], result)
 					}
 				}
 			}
@@ -128,7 +143,7 @@ Examples:
 
 			stats := calculateStats(durations)
 
-			results = append(results, endpointResult{
+			eResults = append(eResults, endpointResult{
 				name:       name,
 				avg:        stats.Avg,
 				median:     stats.Median,
@@ -141,13 +156,19 @@ Examples:
 			})
 		}
 
-		printResults(results, requestCount)
+		printResults(eResults, requestCount)
 
 		if *csvOutput != "" {
-			if err := writeResultsToCSV(*csvOutput, results, requestCount); err != nil {
+			if err := writeResultsToCSV(*csvOutput, eResults, requestCount); err != nil {
 				return fmt.Errorf("failed to export CSV: %v", err)
 			}
 			fmt.Printf("\nResults exported to %s\n", *csvOutput)
+		}
+		if *requestLevelCsvOutput != "" {
+			if err := writeRequestResultsToCSV(*requestLevelCsvOutput, rResults); err != nil {
+				return fmt.Errorf("failed to export request-level CSV: %v", err)
+			}
+			fmt.Printf("\nRequest-level results exported to %s\n", *requestLevelCsvOutput)
 		}
 
 		return nil
@@ -170,8 +191,9 @@ Examples:
 
 type webSocketClient struct {
 	conn    *websocket.Conn
-	URL     string
-	headers http.Header
+	URL         string
+	reqHeaders  http.Header
+	respHeaders http.Header
 }
 
 func (c *webSocketClient) reconnect() error {
@@ -180,11 +202,13 @@ func (c *webSocketClient) reconnect() error {
 	}
 	fmt.Println("Connecting to WebSocket..", c.URL)
 	var err error
-	c.conn, _, err = websocket.DefaultDialer.Dial(c.URL, c.headers)
+	var resp *http.Response
+	c.conn, resp, err = websocket.DefaultDialer.Dial(c.URL, c.reqHeaders)
 	if err != nil {
 		c.conn = nil // retry again later
 		return fmt.Errorf("WebSocket dial(%s): %v", c.URL, err)
 	}
+	c.respHeaders = resp.Header
 	fmt.Println("Connected!")
 	return nil
 }
@@ -201,22 +225,23 @@ type endpointResult struct {
 	successful int
 }
 
-func benchmarkEndpointHTTP(client *http.Client, url, accessToken string, useSpecialHeader bool) time.Duration {
+func benchmarkEndpointHTTP(client *http.Client, url, accessToken string, useSpecialHeader bool) requestResult {
 	start := time.Now()
 	req, err := http.NewRequest("POST", url, strings.NewReader("ping"))
 	if err != nil {
 		fmt.Printf("Error creating request: %v\n", err)
-		return 0
+		return requestResult{}
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "token "+accessToken)
+	req.Header.Set("X-Sourcegraph-Should-Trace", "true")
 	if useSpecialHeader {
 		req.Header.Set("cody-core-gc-test", "M2R{+6VI?1,M3n&<vpw1&AK>")
 	}
 	resp, err := client.Do(req)
 	if err != nil {
 		fmt.Printf("Error calling %s: %v\n", url, err)
-		return 0
+		return requestResult{}
 	}
 	defer func() {
 		err := resp.Body.Close()
@@ -226,27 +251,30 @@ func benchmarkEndpointHTTP(client *http.Client, url, accessToken string, useSpec
 	}()
 	if resp.StatusCode != http.StatusOK {
 		fmt.Printf("non-200 response: %v\n", resp.Status)
-		return 0
+		return requestResult{}
 	}
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		fmt.Printf("Error reading response body: %v\n", err)
-		return 0
+		return requestResult{}
 	}
 	if string(body) != "pong" {
 		fmt.Printf("Expected 'pong' response, got: %q\n", string(body))
-		return 0
+		return requestResult{}
 	}
 
-	return time.Since(start)
+	return requestResult{
+		duration: time.Since(start),
+		traceID:  resp.Header.Get("X-Trace"),
+	}
 }
 
-func benchmarkEndpointWebSocket(client *webSocketClient) time.Duration {
+func benchmarkEndpointWebSocket(client *webSocketClient) requestResult {
 	// Perform initial websocket connection, if needed.
 	if client.conn == nil {
 		if err := client.reconnect(); err != nil {
 			fmt.Printf("Error reconnecting: %v\n", err)
-			return 0
+			return requestResult{}
 		}
 	}
 
@@ -258,7 +286,7 @@ func benchmarkEndpointWebSocket(client *webSocketClient) time.Duration {
 		if err := client.reconnect(); err != nil {
 			fmt.Printf("Error reconnecting: %v\n", err)
 		}
-		return 0
+		return requestResult{}
 	}
 	_, message, err := client.conn.ReadMessage()
 
@@ -267,16 +295,19 @@ func benchmarkEndpointWebSocket(client *webSocketClient) time.Duration {
 		if err := client.reconnect(); err != nil {
 			fmt.Printf("Error reconnecting: %v\n", err)
 		}
-		return 0
+		return requestResult{}
 	}
 	if string(message) != "pong" {
 		fmt.Printf("Expected 'pong' response, got: %q\n", string(message))
 		if err := client.reconnect(); err != nil {
 			fmt.Printf("Error reconnecting: %v\n", err)
 		}
-		return 0
+		return requestResult{}
 	}
-	return time.Since(start)
+	return requestResult{
+		duration: time.Since(start),
+		traceID:  client.respHeaders.Get("Content-Type"),
+	}
 }
 
 func calculateStats(durations []time.Duration) Stats {
@@ -447,6 +478,43 @@ func writeResultsToCSV(filename string, results []endpointResult, requestCount *
 		}
 		if err := writer.Write(row); err != nil {
 			return fmt.Errorf("failed to write CSV row: %v", err)
+		}
+	}
+
+	return nil
+}
+
+func writeRequestResultsToCSV(filename string, results map[string][]requestResult) error {
+	file, err := os.Create(filename)
+	if err != nil {
+		return fmt.Errorf("failed to create CSV file: %v", err)
+	}
+	defer func() {
+		err := file.Close()
+		if err != nil {
+			return
+		}
+	}()
+
+	writer := csv.NewWriter(file)
+	defer writer.Flush()
+
+	// Write header
+	header := []string{"Endpoint", "Duration (ms)", "Trace ID"}
+	if err := writer.Write(header); err != nil {
+		return fmt.Errorf("failed to write CSV header: %v", err)
+	}
+
+	for endpoint, requestResults := range results {
+		for _, result := range requestResults {
+			row := []string{
+				endpoint,
+				fmt.Sprintf("%.2f", float64(result.duration.Microseconds())/1000),
+				result.traceID,
+			}
+			if err := writer.Write(row); err != nil {
+				return fmt.Errorf("failed to write CSV row: %v", err)
+			}
 		}
 	}
 

--- a/cmd/src/gateway_benchmark_stream.go
+++ b/cmd/src/gateway_benchmark_stream.go
@@ -1,12 +1,10 @@
 package main
 
 import (
-	"encoding/csv"
 	"flag"
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"strings"
 	"time"
 
@@ -17,11 +15,6 @@ type httpEndpoint struct {
 	url        string
 	authHeader string
 	body       string
-}
-
-type requestResult struct {
-	duration time.Duration
-	traceID  string // X-Trace header value
 }
 
 func init() {
@@ -287,41 +280,4 @@ func toEndpointResult(name string, stats Stats, requestCount int) endpointResult
 		successful: requestCount,
 		total:      stats.Total,
 	}
-}
-
-func writeRequestResultsToCSV(filename string, results map[string][]requestResult) error {
-	file, err := os.Create(filename)
-	if err != nil {
-		return fmt.Errorf("failed to create CSV file: %v", err)
-	}
-	defer func() {
-		err := file.Close()
-		if err != nil {
-			return
-		}
-	}()
-
-	writer := csv.NewWriter(file)
-	defer writer.Flush()
-
-	// Write header
-	header := []string{"Endpoint", "Duration (ms)", "Trace ID"}
-	if err := writer.Write(header); err != nil {
-		return fmt.Errorf("failed to write CSV header: %v", err)
-	}
-
-	for endpoint, requestResults := range results {
-		for _, result := range requestResults {
-			row := []string{
-				endpoint,
-				fmt.Sprintf("%.2f", float64(result.duration.Microseconds())/1000),
-				result.traceID,
-			}
-			if err := writer.Write(row); err != nil {
-				return fmt.Errorf("failed to write CSV row: %v", err)
-			}
-		}
-	}
-
-	return nil
 }


### PR DESCRIPTION
Helps with https://linear.app/sourcegraph/issue/PRIME-651/look-into-cloudflare-settings-for-gateway-vs-dotcom-streaming.

- Uses the benchmarking endpoints that were introduced in https://github.com/sourcegraph/src-cli/pull/1124 and its cousin PRs to sg/sg
- Adds a flag that sets the special header `cody-core-gc-test` that Security enabled for us which disables WAF (Web Application Firewall) headers for the request that contains it.

The goal is to run this on a few dev machines to learn more about how Cloudflare might affect latency.

Created this PR to store and share the code we used for this particular benchmarking.

### Test plan

I don't intend to merge this.