### PR TITLE
Use 50, 200, 500 max token counts (PRIME-654)

### DIFF
--- a/cmd/src/gateway_benchmark_stream.go
+++ b/cmd/src/gateway_benchmark_stream.go
@@ -66,18 +66,20 @@ Examples:
 		fmt.Printf("Starting benchmark with %d requests per endpoint...\n", *requestCount)
 		if *gatewayEndpoint != "" {
 			fmt.Println("Benchmarking Cody Gateway instance:", *gatewayEndpoint)
-			endpoint := buildGatewayHttpEndpoint(*gatewayEndpoint, *sgdToken, 200)
-			cgResults := benchmarkCodeCompletions("gateway", httpClient, endpoint, *requestCount)
-			results = append(results, cgResults)
+			cgResults50 := benchmarkCodeCompletions("gateway-50", httpClient, buildGatewayHttpEndpoint(*gatewayEndpoint, *sgdToken, 50), *requestCount)
+			cgResults200 := benchmarkCodeCompletions("gateway-200", httpClient, buildGatewayHttpEndpoint(*gatewayEndpoint, *sgdToken, 200), *requestCount)
+			cgResults500 := benchmarkCodeCompletions("gateway-500", httpClient, buildGatewayHttpEndpoint(*gatewayEndpoint, *sgdToken, 500), *requestCount)
+			results = append(results, cgResults50, cgResults200, cgResults500)
 			fmt.Println()
 		} else {
 			fmt.Println("warning: not benchmarking Cody Gateway (-gateway endpoint not provided)")
 		}
 		if *sgEndpoint != "" {
 			fmt.Println("Benchmarking Sourcegraph instance:", *sgEndpoint)
-			endpoint := buildSourcegraphHttpEndpoint(*sgEndpoint, *sgpToken, 200)
-			sgResults := benchmarkCodeCompletions("sourcegraph", httpClient, endpoint, *requestCount)
-			results = append(results, sgResults)
+			sgResults50 := benchmarkCodeCompletions("sourcegraph-50", httpClient, buildSourcegraphHttpEndpoint(*sgEndpoint, *sgpToken, 50), *requestCount)
+			sgResults200 := benchmarkCodeCompletions("sourcegraph-200", httpClient, buildSourcegraphHttpEndpoint(*sgEndpoint, *sgpToken, 200), *requestCount)
+			sgResults500 := benchmarkCodeCompletions("sourcegraph-500", httpClient, buildSourcegraphHttpEndpoint(*sgEndpoint, *sgpToken, 500), *requestCount)
+			results = append(results, sgResults50, sgResults200, sgResults500)
 			fmt.Println()
 		} else {
 			fmt.Println("warning: not benchmarking Sourcegraph instance (-sourcegraph endpoint not provided)")


### PR DESCRIPTION
This PR aims to investigate https://linear.app/sourcegraph/issue/PRIME-654/investigate-why-the-fastpathnon-fastpath-diff-decreases-with-longer, and answer the question of whether the back end seems to contribute to our observations there (increased latency diff between SG→CG and direct CG with _shorter_ completions).

It uses the somewhat arbitrary token counts 50, 200, and 500 to simulate single-line, multiline, and long code completions. In all cases, it uses the messages

```
{"role": "user", "content": "def bubble_sort(arr):"},
{"role": "assistant", "content": "Here is a bubble sort:"}
```

talking to Claude 3 Haiku (for cost efficiency) at temperature 0.0 and streaming ON.

To fully understand the changes in this PR, see also https://github.com/sourcegraph/src-cli/pull/1138 which this PR builds on.

### Test plan

(I don't intend to merge this.)

Caveat: I was not extremely rigorous in looking into the exact differences between the requests assembled by SG and by the `src-cli` script. I trusted that we successfully converted the same arguments passed to SG to the format CG needs them. Whitespace in the body and some HTTP headers are probably different, though. This can be tested and improved if needed.