### PR TITLE
Update ubuntu in Github Actions to latest LTS (24.04)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Test Plan: CI

[_Created by Sourcegraph batch change `keegan/update-old-ubuntu-on-github-actions`._](https://sourcegraph.sourcegraph.com/users/keegan/batch-changes/update-old-ubuntu-on-github-actions)