### PR TITLE
feature/security: Implement image signature verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ All notable changes to `src-cli` are documented in this file.
 
 ## Unreleased
 
+## 6.0.0
+
+- Container signature verification support: Container signatures can now be verified for Sourcegraph releases after 5.11.4013 using `src signature verify -v <release>` [#1143](https://github.com/sourcegraph/src-cli/pull/1143)
+
 ## 5.11.1
 
 - Update x/net to fix CVE-2024-45338

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to `src-cli` are documented in this file.
 
 ## Unreleased
 
-## 6.0.0
+## 6.0.1
 
 - Container signature verification support: Container signatures can now be verified for Sourcegraph releases after 5.11.4013 using `src signature verify -v <release>` [#1143](https://github.com/sourcegraph/src-cli/pull/1143)
 

--- a/cmd/src/sbom.go
+++ b/cmd/src/sbom.go
@@ -8,7 +8,7 @@ import (
 var sbomCommands commander
 
 func init() {
-	usage := `'src sbom' fetches and verified SBOM (Software Bill of Materials) data for Sourcegraph containers.
+	usage := `'src sbom' fetches and verifies SBOM (Software Bill of Materials) data for Sourcegraph containers.
 
 Usage:
 

--- a/cmd/src/sbom_fetch.go
+++ b/cmd/src/sbom_fetch.go
@@ -1,37 +1,23 @@
 package main
 
 import (
-	"bufio"
 	"bytes"
 	"encoding/base64"
 	"encoding/json"
 	"flag"
 	"fmt"
-	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"unicode"
 
-	"github.com/grafana/regexp"
-	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/lib/output"
 
 	"github.com/sourcegraph/src-cli/internal/cmderrors"
 )
 
-type sbomConfig struct {
-	publicKey                     string
-	outputDir                     string
-	version                       string
-	internalRelease               bool
-	insecureIgnoreTransparencyLog bool
-}
-
-const publicKey = "https://storage.googleapis.com/sourcegraph-release-sboms/keys/cosign_keyring-cosign-1.pub"
-const imageListBaseURL = "https://storage.googleapis.com/sourcegraph-release-sboms"
-const imageListFilename = "release-image-list.txt"
+const sbomPublicKey = "https://storage.googleapis.com/sourcegraph-release-sboms/keys/cosign_keyring-cosign-1.pub"
 
 func init() {
 	usage := `
@@ -55,8 +41,8 @@ Examples:
 	insecureIgnoreTransparencyLogFlag := flagSet.Bool("insecure-ignore-tlog", false, "Disable transparency log verification. Defaults to false.")
 
 	handler := func(args []string) error {
-		c := sbomConfig{
-			publicKey: publicKey,
+		c := cosignConfig{
+			publicKey: sbomPublicKey,
 		}
 
 		if err := flagSet.Parse(args); err != nil {
@@ -155,7 +141,7 @@ Examples:
 	})
 }
 
-func (c sbomConfig) getSBOMForImageVersion(image string, version string) (string, error) {
+func (c cosignConfig) getSBOMForImageVersion(image string, version string) (string, error) {
 	hash, err := getImageDigest(image, version)
 	if err != nil {
 		return "", err
@@ -169,51 +155,7 @@ func (c sbomConfig) getSBOMForImageVersion(image string, version string) (string
 	return sbom, nil
 }
 
-func verifyCosign() error {
-	_, err := exec.LookPath("cosign")
-	if err != nil {
-		return errors.New("SBOM verification requires 'cosign' to be installed and available in $PATH. See https://docs.sigstore.dev/cosign/system_config/installation/")
-	}
-	return nil
-}
-
-func (c sbomConfig) getImageList() ([]string, error) {
-	imageReleaseListURL := c.getImageReleaseListURL()
-
-	resp, err := http.Get(imageReleaseListURL)
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch image list: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		// Compare version number against a regex that matches versions up to and including 5.8.0
-		versionRegex := regexp.MustCompile(`^v?[0-5]\.([0-7]\.[0-9]+|8\.0)$`)
-		if versionRegex.MatchString(c.version) {
-			return nil, fmt.Errorf("unsupported version %s: SBOMs are only available for Sourcegraph releases after 5.8.0", c.version)
-		}
-		return nil, fmt.Errorf("failed to fetch list of images - check that %s is a valid Sourcegraph release: HTTP status %d", c.version, resp.StatusCode)
-	}
-
-	scanner := bufio.NewScanner(resp.Body)
-	var images []string
-	for scanner.Scan() {
-		image := strings.TrimSpace(scanner.Text())
-		if image != "" {
-			// Strip off a version suffix if present
-			parts := strings.SplitN(image, ":", 2)
-			images = append(images, parts[0])
-		}
-	}
-
-	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("error reading image list: %w", err)
-	}
-
-	return images, nil
-}
-
-func (c sbomConfig) getSBOMForImageHash(image string, hash string) (string, error) {
+func (c cosignConfig) getSBOMForImageHash(image string, hash string) (string, error) {
 	tempDir, err := os.MkdirTemp("", "sbom-")
 	if err != nil {
 		return "", fmt.Errorf("failed to create temporary directory: %w", err)
@@ -224,7 +166,7 @@ func (c sbomConfig) getSBOMForImageHash(image string, hash string) (string, erro
 
 	cosignArgs := []string{
 		"verify-attestation",
-		"--key", publicKey,
+		"--key", c.publicKey,
 		"--type", "cyclonedx",
 		fmt.Sprintf("%s@%s", image, hash),
 		"--output-file", outputFile,
@@ -297,7 +239,7 @@ func extractSBOM(attestationBytes []byte) (string, error) {
 	return string(predicate), nil
 }
 
-func (c sbomConfig) storeSBOM(sbom string, image string) error {
+func (c cosignConfig) storeSBOM(sbom string, image string) error {
 	// Make the image name safe for use as a filename
 	safeImageName := strings.Map(func(r rune) rune {
 		if unicode.IsLetter(r) || unicode.IsDigit(r) || r == '-' || r == '_' {
@@ -320,13 +262,4 @@ func (c sbomConfig) storeSBOM(sbom string, image string) error {
 	}
 
 	return nil
-}
-
-// getImageReleaseListURL returns the URL for the list of images in a release, based on the version and whether it's an internal release.
-func (c *sbomConfig) getImageReleaseListURL() string {
-	if c.internalRelease {
-		return fmt.Sprintf("%s/release-internal/%s/%s", imageListBaseURL, c.version, imageListFilename)
-	} else {
-		return fmt.Sprintf("%s/release/%s/%s", imageListBaseURL, c.version, imageListFilename)
-	}
 }

--- a/cmd/src/sbom_utils.go
+++ b/cmd/src/sbom_utils.go
@@ -10,10 +10,10 @@ import (
 	"net/http"
 	"os/exec"
 	"path"
+	"regexp"
 	"strings"
 	"time"
 
-	"github.com/grafana/regexp"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 

--- a/cmd/src/sbom_utils.go
+++ b/cmd/src/sbom_utils.go
@@ -1,6 +1,9 @@
 package main
 
+// Utility functions used by the SBOM and Signature commands.
+
 import (
+	"bufio"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -9,7 +12,21 @@ import (
 	"path"
 	"strings"
 	"time"
+
+	"github.com/grafana/regexp"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
+
+const imageListBaseURL = "https://storage.googleapis.com/sourcegraph-release-sboms"
+const imageListFilename = "release-image-list.txt"
+
+type cosignConfig struct {
+	publicKey                     string
+	outputDir                     string
+	version                       string
+	internalRelease               bool
+	insecureIgnoreTransparencyLog bool
+}
 
 // TokenResponse represents the JSON response from dockerHub's token service
 type dockerHubTokenResponse struct {
@@ -199,4 +216,61 @@ func getOutputDir(parentDir, version string) string {
 // sanitizeVersion removes any leading "v" from the version string
 func sanitizeVersion(version string) string {
 	return strings.TrimPrefix(version, "v")
+}
+
+func verifyCosign() error {
+	_, err := exec.LookPath("cosign")
+	if err != nil {
+		return errors.New("SBOM verification requires 'cosign' to be installed and available in $PATH. See https://docs.sigstore.dev/cosign/system_config/installation/")
+	}
+	return nil
+}
+
+func (c cosignConfig) getImageList() ([]string, error) {
+	imageReleaseListURL := c.getImageReleaseListURL()
+
+	resp, err := http.Get(imageReleaseListURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch image list: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		// Compare version number against a regex that matches versions up to and including 5.8.0
+		versionRegex := regexp.MustCompile(`^v?[0-5]\.([0-7]\.[0-9]+|8\.0)$`)
+		if versionRegex.MatchString(c.version) {
+			return nil, fmt.Errorf("unsupported version %s: SBOMs are only available for Sourcegraph releases after 5.8.0", c.version)
+		}
+		return nil, fmt.Errorf("failed to fetch list of images - check that %s is a valid Sourcegraph release: HTTP status %d", c.version, resp.StatusCode)
+	}
+
+	scanner := bufio.NewScanner(resp.Body)
+	var images []string
+	for scanner.Scan() {
+		image := strings.TrimSpace(scanner.Text())
+		if image != "" {
+			// Strip off a version suffix if present
+			parts := strings.SplitN(image, ":", 2)
+			images = append(images, parts[0])
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("error reading image list: %w", err)
+	}
+
+	// editedImages := images[0:2]
+	editedImages := []string{}
+	editedImages = append(editedImages, "sourcegraph/nginx")
+
+	return editedImages, nil
+}
+
+// getImageReleaseListURL returns the URL for the list of images in a release, based on the version and whether it's an internal release.
+func (c *cosignConfig) getImageReleaseListURL() string {
+	if c.internalRelease {
+		return fmt.Sprintf("%s/release-internal/%s/%s", imageListBaseURL, c.version, imageListFilename)
+	} else {
+		return fmt.Sprintf("%s/release/%s/%s", imageListBaseURL, c.version, imageListFilename)
+	}
 }

--- a/cmd/src/sbom_utils.go
+++ b/cmd/src/sbom_utils.go
@@ -259,11 +259,7 @@ func (c cosignConfig) getImageList() ([]string, error) {
 		return nil, fmt.Errorf("error reading image list: %w", err)
 	}
 
-	// editedImages := images[0:2]
-	editedImages := []string{}
-	editedImages = append(editedImages, "sourcegraph/nginx")
-
-	return editedImages, nil
+	return images, nil
 }
 
 // getImageReleaseListURL returns the URL for the list of images in a release, based on the version and whether it's an internal release.

--- a/cmd/src/signature.go
+++ b/cmd/src/signature.go
@@ -16,7 +16,7 @@ Usage:
 
 The commands are:
 
-	verify                 verify signatures for a released version of Sourcegraph
+	verify                 verify signatures for a Sourcegraph release
 `
 	flagSet := flag.NewFlagSet("signature", flag.ExitOnError)
 	handler := func(args []string) error {

--- a/cmd/src/signature.go
+++ b/cmd/src/signature.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+)
+
+var signatureCommands commander
+
+func init() {
+	usage := `'src signature' verifies published signatures for Sourcegraph containers.
+
+Usage:
+
+	src signature command [command options]
+
+The commands are:
+
+	verify                 verify signatures for a released version of Sourcegraph
+`
+	flagSet := flag.NewFlagSet("signature", flag.ExitOnError)
+	handler := func(args []string) error {
+		signatureCommands.run(flagSet, "src signature", usage, args)
+		return nil
+	}
+
+	// Register the command.
+	commands = append(commands, &command{
+		flagSet: flagSet,
+		aliases: []string{"signature", "sig"},
+		handler: handler,
+		usageFunc: func() {
+			fmt.Println(usage)
+		},
+	})
+}

--- a/cmd/src/signature_fetch.go
+++ b/cmd/src/signature_fetch.go
@@ -25,9 +25,9 @@ Usage:
 
 Examples:
 
-    $ src signature verify -v 5.8.0                                 # Verify all signatures for the 5.8.0 release
+    $ src signature verify -v 5.11.4013                 # Verify all signatures for the 5.11.4013 release
 
-    $ src signature verify -v 5.8.123 -d /tmp/signatures  # Verify all signatures for the 5.8.123 release and write verified image digests in /tmp/signatures
+    $ src signature verify -v 6.0.0 -d /tmp/signatures  # Verify all signatures for the 6.0.0 release and write verified image digests under /tmp/signatures
 `
 
 	flagSet := flag.NewFlagSet("verify", flag.ExitOnError)

--- a/cmd/src/signature_fetch.go
+++ b/cmd/src/signature_fetch.go
@@ -76,7 +76,7 @@ Examples:
 		out.Writef("Verifying signatures for all %d images in the Sourcegraph %s release...\n", len(images), c.version)
 
 		if c.insecureIgnoreTransparencyLog {
-			out.WriteLine(output.Line("⚠️", output.StyleWarning, "WARNING: Transparency log verification is disabled, increasing the risk that SBOMs may have been tampered with."))
+			out.WriteLine(output.Line("⚠️", output.StyleWarning, "WARNING: Transparency log verification is disabled, increasing the risk that images may have been tampered with."))
 			out.WriteLine(output.Line("️", output.StyleWarning, "         This setting should only be used for testing or under explicit instruction from Sourcegraph.\n"))
 		}
 

--- a/cmd/src/signature_fetch.go
+++ b/cmd/src/signature_fetch.go
@@ -1,0 +1,202 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/sourcegraph/sourcegraph/lib/output"
+
+	"github.com/sourcegraph/src-cli/internal/cmderrors"
+)
+
+const signaturePublicKey = "https://storage.googleapis.com/sourcegraph-release-sboms/keys/cosign_keyring-cosign_image_signing_key-1.pub"
+
+func init() {
+	usage := `
+'src signature verify' verifies signatures for the given release version of Sourcegraph.
+
+Usage:
+
+    src signature verify -v <version>
+
+Examples:
+
+    $ src signature verify -v 5.8.0                                 # Verify all signatures for the 5.8.0 release
+
+    $ src signature verify -v 5.8.123 -d /tmp/signatures  # Verify all signatures for the 5.8.123 release and write verified image digests in /tmp/signatures
+`
+
+	flagSet := flag.NewFlagSet("verify", flag.ExitOnError)
+	versionFlag := flagSet.String("v", "", "The version of Sourcegraph to verify signatures for.")
+	outputDirFlag := flagSet.String("d", "", "The directory to store verified image digests in.")
+	insecureIgnoreTransparencyLogFlag := flagSet.Bool("insecure-ignore-tlog", false, "Disable transparency log verification. Defaults to false.")
+
+	handler := func(args []string) error {
+		c := cosignConfig{
+			publicKey:       signaturePublicKey,
+			internalRelease: false,
+		}
+
+		if err := flagSet.Parse(args); err != nil {
+			return err
+		}
+
+		if len(flagSet.Args()) != 0 {
+			return cmderrors.Usage("additional arguments not allowed")
+		}
+
+		if versionFlag == nil || *versionFlag == "" {
+			return cmderrors.Usage("version is required")
+		}
+		c.version = sanitizeVersion(*versionFlag)
+
+		if outputDirFlag != nil && *outputDirFlag != "" {
+			c.outputDir = getOutputDir(*outputDirFlag, c.version)
+		}
+
+		if insecureIgnoreTransparencyLogFlag != nil && *insecureIgnoreTransparencyLogFlag {
+			c.insecureIgnoreTransparencyLog = true
+		}
+
+		out := output.NewOutput(flagSet.Output(), output.OutputOpts{Verbose: *verbose})
+
+		if err := verifyCosign(); err != nil {
+			return cmderrors.ExitCode(1, err)
+		}
+
+		images, err := c.getImageList()
+		if err != nil {
+			return err
+		}
+
+		out.Writef("Verifying signatures for all %d images in the Sourcegraph %s release...\n", len(images), c.version)
+
+		if c.insecureIgnoreTransparencyLog {
+			out.WriteLine(output.Line("⚠️", output.StyleWarning, "WARNING: Transparency log verification is disabled, increasing the risk that SBOMs may have been tampered with."))
+			out.WriteLine(output.Line("️", output.StyleWarning, "         This setting should only be used for testing or under explicit instruction from Sourcegraph.\n"))
+		}
+
+		var successCount, failureCount int
+		var verifiedDigests []string
+		for _, image := range images {
+			stopSpinner := make(chan bool)
+			go spinner(image, stopSpinner)
+
+			verifiedDigest, err := c.verifySignatureForImageVersion(image, c.version)
+			verifiedDigests = append(verifiedDigests, image+"@"+verifiedDigest)
+
+			stopSpinner <- true
+
+			if err != nil {
+				out.WriteLine(output.Line(output.EmojiFailure, output.StyleWarning,
+					fmt.Sprintf("\r%s: error verifying signature:\n    %v", image, err)))
+				failureCount += 1
+			} else {
+				out.WriteLine(output.Line("\r\u2705", output.StyleSuccess, image+"@"+verifiedDigest))
+				successCount += 1
+			}
+		}
+
+		out.Write("")
+		if successCount > 0 && failureCount > 0 {
+			out.WriteLine(output.Line("🟠", output.StyleOrange, fmt.Sprintf("Verified signatures and digests for %d images, but failed to verify signatures for %d images", successCount, failureCount)))
+		} else if successCount > 0 && failureCount == 0 {
+			out.WriteLine(output.Line("🟢", output.StyleSuccess, fmt.Sprintf("Verified signatures and digests for %d images", successCount)))
+		} else {
+			out.WriteLine(output.Line("🔴", output.StyleWarning, "Failed to verify signatures for any images"))
+
+		}
+
+		if c.outputDir != "" {
+			if err = c.writeVerifiedDigests(verifiedDigests); err != nil {
+				out.WriteLine(output.Line("🔴", output.StyleWarning, err.Error()))
+				return cmderrors.ExitCode1
+			}
+			out.Writef("\nVerified digests have been written to `%s`.\n", c.getOutputFilepath())
+		}
+		out.WriteLine(output.Linef("", output.StyleBold, "Your Sourcegraph deployment may not use all of these images. Please check your deployment to confirm which images are used.\n"))
+
+		if failureCount > 0 || successCount == 0 {
+			return cmderrors.ExitCode1
+		}
+
+		return nil
+	}
+
+	signatureCommands = append(signatureCommands, &command{
+		flagSet: flagSet,
+		handler: handler,
+		usageFunc: func() {
+			fmt.Fprintf(flag.CommandLine.Output(), "Usage of 'src signature %s':\n", flagSet.Name())
+			flagSet.PrintDefaults()
+			fmt.Println(usage)
+		},
+	})
+}
+
+func (c cosignConfig) verifySignatureForImageVersion(image string, version string) (string, error) {
+	digest, err := getImageDigest(image, version)
+	if err != nil {
+		return "", err
+	}
+
+	err = c.verifySignatureForImageHash(image, digest)
+	if err != nil {
+		return "", err
+	}
+
+	// Only return the digest if the signature is verified
+	return digest, nil
+}
+
+func (c cosignConfig) verifySignatureForImageHash(image string, hash string) error {
+	tempDir, err := os.MkdirTemp("", "signature-")
+	if err != nil {
+		return fmt.Errorf("failed to create temporary directory: %w", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	cosignArgs := []string{
+		"verify",
+		"--key", c.publicKey,
+		fmt.Sprintf("%s@%s", image, hash),
+	}
+
+	if c.insecureIgnoreTransparencyLog {
+		cosignArgs = append(cosignArgs, "--insecure-ignore-tlog")
+	}
+
+	cmd := exec.Command("cosign", cosignArgs...)
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("Signature verification failed: %w\nOutput: %s", err, output)
+	}
+
+	return nil
+}
+
+func (c cosignConfig) writeVerifiedDigests(verifiedDigests []string) error {
+	// Create the output file
+	outputFile := c.getOutputFilepath()
+	err := os.MkdirAll(c.outputDir, 0755)
+	if err != nil {
+		return fmt.Errorf("failed to create output directory: %w", err)
+	}
+
+	// Write the verified digests to the file, one per line
+	err = os.WriteFile(outputFile, []byte(strings.Join(verifiedDigests, "\n")+"\n"), 0644)
+	if err != nil {
+		return fmt.Errorf("failed to write verified digests to file: %w", err)
+	}
+
+	return nil
+}
+
+func (c cosignConfig) getOutputFilepath() string {
+	return filepath.Join(c.outputDir, "verified-digests.txt")
+}


### PR DESCRIPTION
Implement verification of container signatures for release images. This allows customers to easily verify the signatures we started publishing in [SEC-2445](https://linear.app/sourcegraph/issue/SEC-2445/sign-public-releases).

The implementation shares several helper functions with the `src sbom fetch` command, as both fetch information about releases, talk to our container registries, and use `cosign` behind the scenes.

The verification process is:
- Fetch list of images in $release from GCS bucket
- Fetch our public key from GCS bucket
- Verify signature of each image at the release tag using `cosign verify` with our public key
- Output image digests once they're verified

Digests can then be used or checked against our deployment configs by customers. Customers could also use the sigstore admission controller on their cluster to automate this, but allowing signature verification via `src-cli` is convenient and a small code change.

Signature verification of a subset of images:

![CleanShot 2025-01-28 at 20 40 47](https://github.com/user-attachments/assets/8e47969f-bd49-4bcd-b74e-d3142c270ae8)


### Test plan

- Tested signature verification locally
- Verified SBOM fetching still works after changes to helper funcs