### PR TITLE
Changelog entries for 6.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ All notable changes to `src-cli` are documented in this file.
 
 ## Unreleased
 
+## 6.1.0
 - Support uploading GZIP compressed SCIP indexes [1146](https://github.com/sourcegraph/src-cli/pull/1146)
+- Remove deprecated `lsif` subcommand, and remove LSIF->SCIP conversion support [1147](https://github.com/sourcegraph/src-cli/pull/1147)
 
 ## 6.0.1
 


### PR DESCRIPTION
Following the release procedure: https://github.com/sourcegraph/src-cli/blob/main/DEVELOPMENT.md#releasing

### Test plan
N/A
