### PR TITLE
Bike-shedding on search jobs

### DIFF
--- a/cmd/src/format.go
+++ b/cmd/src/format.go
@@ -80,6 +80,20 @@ func parseTemplate(text string) (*template.Template, error) {
 			}
 			return humanize.Time(t), nil
 		},
+		"searchJobIDNumber": func(id string) string {
+			sjid, err := ParseSearchJobID(id)
+			if err != nil {
+				return id
+			}
+			return fmt.Sprintf("%d", sjid.Number())
+		},
+		"searchJobIDCanonical": func(id string) string {
+			sjid, err := ParseSearchJobID(id)
+			if err != nil {
+				return id
+			}
+			return sjid.Canonical()
+		},
 
 		// Register search-specific template functions
 		"searchSequentialLineNumber":        searchTemplateFuncs["searchSequentialLineNumber"],

--- a/cmd/src/search_jobs_create.go
+++ b/cmd/src/search_jobs_create.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+
 	"github.com/sourcegraph/src-cli/internal/api"
 	"github.com/sourcegraph/src-cli/internal/cmderrors"
 )
@@ -43,9 +44,9 @@ Examples:
 	}
 
 	var (
-		queryFlag = flagSet.String("query", "", "Search query")
-		formatFlag = flagSet.String("f", "{{.ID}}: {{.Creator.Username}} {{.State}} ({{.Query}})", `Format for the output, using the syntax of Go package text/template. (e.g. "{{.ID}}: {{.Creator.Username}} ({{.Query}})" or "{{.|json}}")`)
-		apiFlags  = api.NewFlags(flagSet)
+		queryFlag  = flagSet.String("query", "", "Search query")
+		formatFlag = flagSet.String("f", "{{searchJobIDNumber .ID}}: {{.Creator.Username}} {{.State}} ({{.Query}})", `Format for the output, using the syntax of Go package text/template. (e.g. "{{.ID}}: {{.Creator.Username}} ({{.Query}})" or "{{.|json}}")`)
+		apiFlags   = api.NewFlags(flagSet)
 	)
 
 	handler := func(args []string) error {

--- a/cmd/src/search_jobs_get.go
+++ b/cmd/src/search_jobs_get.go
@@ -1,11 +1,11 @@
 package main
 
 import (
-    "context"
-    "flag"
-    "fmt"
-    "github.com/sourcegraph/src-cli/internal/api"
-	"github.com/sourcegraph/src-cli/internal/cmderrors"
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/sourcegraph/src-cli/internal/api"
 )
 
 const GetSearchJobQuery = `query SearchJob($id: ID!) {
@@ -20,73 +20,76 @@ const GetSearchJobQuery = `query SearchJob($id: ID!) {
 // init registers the "get" subcommand for search-jobs which retrieves a search job by ID.
 // It supports formatting the output using Go templates and requires authentication via API flags.
 func init() {
-    usage := `
+	usage := `
 Examples:
 
   Get a search job by ID:
 
-    $ src search-jobs get U2VhcmNoSm9iOjY5
+    $ src search-jobs get -id 999
 `
 
-    flagSet := flag.NewFlagSet("get", flag.ExitOnError)
-    usageFunc := func() {
-        fmt.Fprintf(flag.CommandLine.Output(), "Usage of 'src search-jobs %s':\n", flagSet.Name())
-        flagSet.PrintDefaults()
-        fmt.Println(usage)
-    }
+	flagSet := flag.NewFlagSet("get", flag.ExitOnError)
+	usageFunc := func() {
+		fmt.Fprintf(flag.CommandLine.Output(), "Usage of 'src search-jobs %s':\n", flagSet.Name())
+		flagSet.PrintDefaults()
+		fmt.Println(usage)
+	}
 
-    var (
-		idFlag = flagSet.String("id", "", "ID of the search job")
-        formatFlag = flagSet.String("f", "{{.ID}}: {{.Creator.Username}} {{.State}} ({{.Query}})", `Format for the output, using the syntax of Go package text/template. (e.g. "{{.ID}}: {{.Creator.Username}} ({{.Query}})" or "{{.|json}}")`)
-        apiFlags   = api.NewFlags(flagSet)
-    )
+	var (
+		idFlag     = flagSet.String("id", "", "ID of the search job")
+		formatFlag = flagSet.String("f", "{{searchJobIDNumber .ID}}: {{.Creator.Username}} {{.State}} ({{.Query}})", `Format for the output, using the syntax of Go package text/template. (e.g. "{{.ID}}: {{.Creator.Username}} ({{.Query}})" or "{{.|json}}")`)
+		apiFlags   = api.NewFlags(flagSet)
+	)
 
-    handler := func(args []string) error {
-        if err := flagSet.Parse(args); err != nil {
-            return err
-        }
+	handler := func(args []string) error {
+		if err := flagSet.Parse(args); err != nil {
+			return err
+		}
 
-        client := api.NewClient(api.ClientOpts{
-            Endpoint:    cfg.Endpoint,
-            AccessToken: cfg.AccessToken,
-            Out:         flagSet.Output(),
-            Flags:       apiFlags,
-        })
+		client := api.NewClient(api.ClientOpts{
+			Endpoint:    cfg.Endpoint,
+			AccessToken: cfg.AccessToken,
+			Out:         flagSet.Output(),
+			Flags:       apiFlags,
+		})
 
-        tmpl, err := parseTemplate(*formatFlag)
-        if err != nil {
-            return err
-        }
+		tmpl, err := parseTemplate(*formatFlag)
+		if err != nil {
+			return err
+		}
 
-        if *idFlag == "" {
-            return cmderrors.Usage("must provide a search job ID")
-        }
+		job, err := getSearchJob(client, *idFlag)
+		if err != nil {
+			return err
+		}
 
-        job, err := getSearchJob(client, *idFlag)
-        if err != nil {
-            return err
-        }
-        return execTemplate(tmpl, job)
-    }
-    searchJobsCommands = append(searchJobsCommands, &command{
-        flagSet:   flagSet,
-        handler:   handler,
-        usageFunc: usageFunc,
-    })
+		return execTemplate(tmpl, job)
+	}
+	searchJobsCommands = append(searchJobsCommands, &command{
+		flagSet:   flagSet,
+		handler:   handler,
+		usageFunc: usageFunc,
+	})
 }
 
 func getSearchJob(client api.Client, id string) (*SearchJob, error) {
-    query := GetSearchJobQuery + SearchJobFragment
 
-    var result struct {
-        Node *SearchJob
-    }
+	jobID, err := ParseSearchJobID(id)
+	if err != nil {
+		return nil, err
+	}
 
-    if ok, err := client.NewRequest(query, map[string]interface{}{
-        "id": api.NullString(id),
-    }).Do(context.Background(), &result); err != nil || !ok {
-        return nil, err
-    }
+	query := GetSearchJobQuery + SearchJobFragment
 
-    return result.Node, nil
+	var result struct {
+		Node *SearchJob
+	}
+
+	if ok, err := client.NewRequest(query, map[string]interface{}{
+		"id": api.NullString(jobID.Canonical()),
+	}).Do(context.Background(), &result); err != nil || !ok {
+		return nil, err
+	}
+
+	return result.Node, nil
 }

--- a/cmd/src/search_jobs_logs.go
+++ b/cmd/src/search_jobs_logs.go
@@ -6,10 +6,9 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"github.com/sourcegraph/src-cli/internal/api"
-	"github.com/sourcegraph/src-cli/internal/cmderrors"
-)
 
+	"github.com/sourcegraph/src-cli/internal/api"
+)
 
 // init registers the 'logs' subcommand for search jobs, which allows users to view
 // logs for a specific search job by its ID. The command requires a search job ID
@@ -19,7 +18,7 @@ func init() {
 Examples:
 
 	View the logs of a search job:
-	  $ src search-jobs logs U2VhcmNoSm9iOjY5
+	  $ src search-jobs logs -id 999
 
 	Save the logs to a file:
 	  $ src search-jobs logs U2VhcmNoSm9iOjY5 -out logs.csv
@@ -33,8 +32,8 @@ Examples:
 	}
 
 	var (
-		idFlag = flagSet.String("id", "", "ID of the search job to view logs for")
-		outFlag = flagSet.String("out", "", "File path to save the logs (optional)")
+		idFlag   = flagSet.String("id", "", "ID of the search job to view logs for")
+		outFlag  = flagSet.String("out", "", "File path to save the logs (optional)")
 		apiFlags = api.NewFlags(flagSet)
 	)
 
@@ -43,20 +42,12 @@ Examples:
 			return err
 		}
 
-		if *idFlag == "" {
-			return cmderrors.Usage("must provide a search job ID")
-		}
-
 		client := api.NewClient(api.ClientOpts{
 			Endpoint:    cfg.Endpoint,
 			AccessToken: cfg.AccessToken,
 			Out:         flagSet.Output(),
 			Flags:       apiFlags,
 		})
-
-		if *idFlag == "" {
-			return cmderrors.Usage("must provide a search job ID")
-		}
 
 		job, err := getSearchJob(client, *idFlag)
 		if err != nil {

--- a/cmd/src/search_jobs_results.go
+++ b/cmd/src/search_jobs_results.go
@@ -6,8 +6,8 @@ import (
 	"io"
 	"net/http"
 	"os"
+
 	"github.com/sourcegraph/src-cli/internal/api"
-	"github.com/sourcegraph/src-cli/internal/cmderrors"
 )
 
 func init() {
@@ -15,10 +15,10 @@ func init() {
 Examples:
 
 	Get the results of a search job:
-	  $ src search-jobs results -id U2VhcmNoSm9iOjY5
+	  $ src search-jobs results -id 999
 
 	Save search results to a file:
-	  $ src search-jobs results -id U2VhcmNoSm9iOjY5 -out results.jsonl
+	  $ src search-jobs results -id 999 -out results.jsonl
 `
 
 	flagSet := flag.NewFlagSet("results", flag.ExitOnError)
@@ -29,18 +29,14 @@ Examples:
 	}
 
 	var (
-		idFlag = flagSet.String("id", "", "ID of the search job to get results for")
-		outFlag = flagSet.String("out", "", "File path to save the results (optional)")
+		idFlag   = flagSet.String("id", "", "ID of the search job to get results for")
+		outFlag  = flagSet.String("out", "", "File path to save the results (optional)")
 		apiFlags = api.NewFlags(flagSet)
 	)
 
 	handler := func(args []string) error {
 		if err := flagSet.Parse(args); err != nil {
 			return err
-		}
-
-		if *idFlag == "" {
-			return cmderrors.Usage("must provide a search job ID")
 		}
 
 		client := api.NewClient(api.ClientOpts{


### PR DESCRIPTION
What started as a simple linter placating ended up with adding support for numeric search job ids instead of needing to use the base64-encoded values.

Not sure how helpful that is.

### Test plan

TBD