### PR TITLE
fix: update documentation URLs to use sourcegraph.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 - **Search & get results in your terminal**
 - **Search & get JSON** for programmatic consumption
 - Make **GraphQL API requests** with auth easily & get JSON back fast
-- Execute **[batch changes](https://docs.sourcegraph.com/batch_changes)**
+- Execute **[batch changes](https://sourcegraph.com/docs/batch_changes)**
 - **Manage & administrate** repositories, users, and more
 - **Easily convert src-CLI commands to equivalent curl commands**, just add --get-curl!
 
@@ -161,7 +161,7 @@ Is your Sourcegraph instance behind a custom auth proxy? See [auth proxy configu
  - `src login` - authenticate to a Sourcegraph instance with your user credentials
  - `src search` - perform searches and get results in your terminal or as JSON
  - `src api` - run Sourcegraph GraphQL API requests
- - `src batch` - execute and manage [batch changes](https://docs.sourcegraph.com/batch_changes)
+ - `src batch` - execute and manage [batch changes](https://sourcegraph.com/docs/batch_changes)
  - `src repos` - manage repositories
  - `src users` - manage users
  - `src orgs` - manages organization
@@ -173,7 +173,7 @@ Is your Sourcegraph instance behind a custom auth proxy? See [auth proxy configu
  - `src version` - check version and guaranteed-compatible version for your Sourcegraph instance
 
 Run `src -h` and `src <subcommand> -h` for more detailed usage information.
-You can also read the [usage docs for the latest version of `src-cli`](https://docs.sourcegraph.com/cli/references) online.
+You can also read the [usage docs for the latest version of `src-cli`](https://sourcegraph.com/docs/cli/references) online.
 
 #### Optional: Renaming `src`
 

--- a/cmd/src/code_intel_upload.go
+++ b/cmd/src/code_intel_upload.go
@@ -291,7 +291,7 @@ func attachHintsForAuthorizationError(accessToken string, originalError error) e
 	return errorWithHint{err: originalError, hint: strings.Join(mergeStringSlices(
 		[]string{"This Sourcegraph instance has enforced auth for SCIP uploads."},
 		actionableHints,
-		[]string{"For more details, see https://docs.sourcegraph.com/cli/references/code-intel/upload."},
+		[]string{"For more details, see https://sourcegraph.com/docs/cli/references/code-intel/upload."},
 	), "\n")}
 }
 

--- a/cmd/src/search.go
+++ b/cmd/src/search.go
@@ -48,7 +48,7 @@ Other tips:
 
   Force color output on (not on by default when piped to other programs) by setting COLOR=t
 
-  Query syntax: https://docs.sourcegraph.com/code_search/reference/queries
+  Query syntax: https://sourcegraph.com/docs/code_search/reference/queries
 
   Be careful with search strings including negation: a search with an initial
   negated term may be parsed as a flag rather than as a search string. You can

--- a/cmd/src/validate.go
+++ b/cmd/src/validate.go
@@ -12,7 +12,7 @@ func init() {
 
 EXPERIMENTAL: 'validate' is an experimental command in the 'src' tool.
 
-Please visit https://docs.sourcegraph.com/admin/validation for documentation of the validate command.
+Please visit https://sourcegraph.com/docs/admin/validation for documentation of the validate command.
 
 Usage:
 

--- a/internal/api/flags.go
+++ b/internal/api/flags.go
@@ -42,7 +42,7 @@ func NewFlags(flagSet *flag.FlagSet) *Flags {
 	return &Flags{
 		dump:               flagSet.Bool("dump-requests", false, "Log GraphQL requests and responses to stdout"),
 		getCurl:            flagSet.Bool("get-curl", false, "Print the curl command for executing this query and exit (WARNING: includes printing your access token!)"),
-		trace:              flagSet.Bool("trace", false, "Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing"),
+		trace:              flagSet.Bool("trace", false, "Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing"),
 		insecureSkipVerify: flagSet.Bool("insecure-skip-verify", false, "Skip validation of TLS certificates against trusted chains"),
 		userAgentTelemetry: flagSet.Bool("user-agent-telemetry", defaultUserAgentTelemetry(), "Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph"),
 	}

--- a/internal/batches/ui/tui.go
+++ b/internal/batches/ui/tui.go
@@ -394,7 +394,7 @@ func printExecutionError(out *output.Output, err error) {
 	out.Write("")
 
 	block := out.Block(output.Line(output.EmojiLightbulb, output.StyleSuggestion, "The troubleshooting documentation can help to narrow down the cause of the errors:"))
-	block.WriteLine(output.Line("", output.StyleSuggestion, "https://docs.sourcegraph.com/batch_changes/references/troubleshooting"))
+	block.WriteLine(output.Line("", output.StyleSuggestion, "https://sourcegraph.com/docs/batch_changes/references/troubleshooting"))
 	block.Close()
 }
 


### PR DESCRIPTION
This commit updates several documentation URLs throughout the codebase to point to the `sourcegraph.com` domain instead of `docs.sourcegraph.com`. This ensures that users are directed to the most up-to-date and accurate documentation.

docs.sourcegraph.com links that were broken after updating were left as-is

### Test plan

#### Manual testing
Validated methods with changed URLs are still functional as expected. No application logic was changed, only the URL string.
