### PR TITLE
fix(release): Add note in release procedure doc

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -83,7 +83,7 @@ We adhere to the [general Sourcegraph principles for testing](https://docs.sourc
         [...]
         ```
         After updating the checksums, rerun the command to verify that the values are correct.
-    4. Run `sg generate bazel` (this may not result in any changes)
+    4. Run `sg generate bazel` and `sg bazel configure` (this may not result in any changes)
     4. Commit the changes, and open a PR.
  6. Once the version bump PR is merged and the commit is live on dotcom, check that the [curl commands in the README](README.md#installation) also fetch the new latest version.
 


### PR DESCRIPTION
This adds a note about running `sg bzael configure` this is sometimes necessary when some of the digests are changed during the release

### Test plan
Tested in release
