### PR TITLE
Add image name filters to src sbom fetch command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ All notable changes to `src-cli` are documented in this file.
 
 ## Unreleased
 
+### Added
+
+- SBOM support: Added `--image` and `--exclude-image` flags to `src sbom fetch` for filtering which docker images SBOMs are fetched for. Both flags support glob patterns (e.g., `frontend`, `*api*`) and comma-separated lists. The `sourcegraph/` image name prefix is optional.
+
 ## 6.4.0
 
 ## 6.3.0


### PR DESCRIPTION
When running `src sbom fetch`, all container images of the given release version would always get their SBOMs fetched; this leads to HTTP 429 rate limit blocks from Dockerhub if more than 2 versions are fetched. Allowing filtering of image names means that more versions can have SBOMs fetched for fewer images.

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->

Amp wrote the code and tested it itself
<img width="709" alt="Screenshot 2025-06-03 at 18 01 48" src="https://github.com/user-attachments/assets/80e44308-6edd-43c3-8824-e2980d4aa7f8" />
<img width="620" alt="Screenshot 2025-06-03 at 18 01 57" src="https://github.com/user-attachments/assets/e8e8437b-8408-400c-948a-2f14bc6c3dac" />

I was also able to run it successfully in my Bash script:
```bash
declare -a versions=("6.4.1203" "6.4.0" "6.3.4167" ... "5.8.0")
for version in "${versions[@]}"
do
    go run ./cmd/src sbom fetch -v "$version" --image 'postgres*' --exclude-image '*exporter*,*codeinsights*'
done
```

- Amp thread [here](https://ampcode.com/threads/T-4c37a0d3-470e-46aa-9e0b-100601e0e9ac)
- Slack thread [here](https://sourcegraph.slack.com/archives/C1JH2BEHZ/p1748988018899649)
- Linear issue from Slack thread [SEC-3108 Find easier way to fetch SBOMs for specific postgres versions](https://linear.app/sourcegraph/issue/SEC-3108/find-easier-way-to-fetch-sboms-for-specific-postgres-versions)