### PR TITLE
Add a check that only succeeds if all matrix tests pass

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -38,7 +38,7 @@ jobs:
     needs: go-test
     if: always()
     steps:
-      - name: Check Go CI matrix job results
+      - name: Check Go CI results
         run: |
           if [[ "${{ needs.go-test.result }}" != "success" ]]; then
             echo "One or more Go CI tests failed"

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -30,3 +30,18 @@ jobs:
       - run: |
           go test -race -v ./...
           go test -v ./...
+
+  # This job provides a stable name for branch protection rules
+  # It will only pass if all Go CI matrix tests above pass
+  go-test-complete:
+    runs-on: ubuntu-latest
+    needs: go-test
+    if: always()
+    steps:
+      - name: Check Go CI matrix job results
+        run: |
+          if [[ "${{ needs.go-test.result }}" != "success" ]]; then
+            echo "One or more Go CI tests failed"
+            exit 1
+          fi
+          echo "All Go CI tests passed"


### PR DESCRIPTION
This is required so that we can make the CI checks mandatory in branch protection - otherwise the names of the jobs will keep changing when we update Go.

The next step will be to make the new job mandatory in branch protection.

[SEC-3159: Investigate missing required checks on src-cli](https://linear.app/sourcegraph/issue/SEC-3159/investigate-missing-required-checks-on-src-cli)

### Test plan

Manual testing, which I'll have to do after merging.