### PR TITLE
chore(cli): automerge setting for renovate bot

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,7 @@
 {
-  "$schema": "http://json.schemastore.org/renovate",
+  "$schema": "http://json.schemastore.org/renovate",,
+  "automerge": true,
+  "automergeType": "pr",
   "extends": [
     "github>sourcegraph/renovate-config"
   ],


### PR DESCRIPTION
This PR adds values to the `renovate` bot's config to let it automerge PRs when CI passes. It will automatically wait for CI checks to pass; this config only bypasses the need for human review.

### Test plan
CI Passes
