### PR TITLE
Update alpine version for release image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,14 +4,14 @@
 #
 # Nothing fancy here: we copy in the source code and build on the Alpine Go
 # image. Refer to .dockerignore to get a sense of what we're not going to copy.
-FROM golang:1.24.1-alpine@sha256:43c094ad24b6ac0546c62193baeb3e6e49ce14d3250845d166c77c25f64b0386 as builder
+FROM golang:1.25.0-alpine3.22@sha256:f18a072054848d87a8077455f0ac8a25886f2397f88bfdd222d6fafbb5bba440 AS builder
 
 COPY . /src
 WORKDIR /src
 RUN go build ./cmd/src
 
 # This stage should be kept in sync with Dockerfile.release.
-FROM sourcegraph/alpine:3.12@sha256:ce099fbcd3cf70b338fc4cb2a4e1fa9ae847de21afdb0a849a393b87d94fb174
+FROM alpine:3.22@sha256:4bcff63911fcb4448bd4fdacec207030997caf25e9bea4045fa6c8c44de311d1
 
 # needed for `src code-intel upload` and `src actions exec`
 RUN apk add --no-cache git

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 #
 # Nothing fancy here: we copy in the source code and build on the Alpine Go
 # image. Refer to .dockerignore to get a sense of what we're not going to copy.
-FROM golang:1.25.0-alpine3.22@sha256:f18a072054848d87a8077455f0ac8a25886f2397f88bfdd222d6fafbb5bba440 AS builder
+FROM golang:1.24.1-alpine@sha256:43c094ad24b6ac0546c62193baeb3e6e49ce14d3250845d166c77c25f64b0386 AS builder
 
 COPY . /src
 WORKDIR /src

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -2,7 +2,7 @@
 # suitable for testing, since it depends on a src binary being at the project
 # root _and_ that src binary being runnable on Alpine. To test this, refer to
 # the main Dockerfile, which should have an identical second stage.
-FROM sourcegraph/alpine:3.12@sha256:ce099fbcd3cf70b338fc4cb2a4e1fa9ae847de21afdb0a849a393b87d94fb174
+FROM alpine:3.22@sha256:4bcff63911fcb4448bd4fdacec207030997caf25e9bea4045fa6c8c44de311d1
 
 # needed for `src code-intel upload` and `src actions exec`
 RUN apk add --no-cache git

--- a/docker/batch-change-volume-workspace/Dockerfile
+++ b/docker/batch-change-volume-workspace/Dockerfile
@@ -2,6 +2,6 @@
 # image that we use to run curl, git, and unzip against a Docker volume when
 # using the volume workspace.
 
-FROM alpine:3.19.1@sha256:c5b1261d6d3e43071626931fc004f70149baeba2c8ec672bd4f27761f8e1ad6b
+FROM alpine:3.22@sha256:4bcff63911fcb4448bd4fdacec207030997caf25e9bea4045fa6c8c44de311d1
 
 RUN apk add --update git unzip


### PR DESCRIPTION
Update the version of alpine in our release image to 3.22.

### Test plan

Built and run locally + CI