### PR TITLE
Chore: Rename 'primary' to 'pgsql' in the src-cli commands for database uploads

### DIFF
--- a/cmd/src/snapshot_databases.go
+++ b/cmd/src/snapshot_databases.go
@@ -19,13 +19,13 @@ func init() {
 Note that these commands are intended for use as reference - you may need to adjust the commands for your deployment.
 
 USAGE
-	src [-v] snapshot databases [--targets=<docker|k8s|"targets.yaml">] [--run] <pg_dump|docker|kubectl> 
+	src [-v] snapshot databases [--targets=<docker|k8s|"targets.yaml">] [--run] <pg_dump|docker|kubectl>
 
 TARGETS FILES
 	Predefined targets are available based on default Sourcegraph configurations ('docker', 'k8s').
 	Custom targets configuration can be provided in YAML format with '--targets=target.yaml', e.g.
 
-		primary:
+		pgsql:
 			target: ...   # the DSN of the database deployment, e.g. in docker, the name of the database container
 			dbname: ...   # name of database
 			username: ... # username for database access
@@ -109,7 +109,7 @@ TARGETS FILES
 // predefinedDatabaseDumpTargets is based on default Sourcegraph configurations.
 var predefinedDatabaseDumpTargets = map[string]pgdump.Targets{
 	"local": {
-		Primary: pgdump.Target{
+		Pgsql: pgdump.Target{
 			DBName:   "sg",
 			Username: "sg",
 			Password: "sg",
@@ -126,7 +126,7 @@ var predefinedDatabaseDumpTargets = map[string]pgdump.Targets{
 		},
 	},
 	"docker": { // based on deploy-sourcegraph-managed
-		Primary: pgdump.Target{
+		Pgsql: pgdump.Target{
 			Target:   "pgsql",
 			DBName:   "sg",
 			Username: "sg",
@@ -146,7 +146,7 @@ var predefinedDatabaseDumpTargets = map[string]pgdump.Targets{
 		},
 	},
 	"k8s": { // based on deploy-sourcegraph-helm
-		Primary: pgdump.Target{
+		Pgsql: pgdump.Target{
 			Target:   "statefulset/pgsql",
 			DBName:   "sg",
 			Username: "sg",

--- a/cmd/src/snapshot_restore.go
+++ b/cmd/src/snapshot_restore.go
@@ -25,7 +25,7 @@ TARGETS FILES
 	Predefined targets are available based on default Sourcegraph configurations ('docker', 'k8s').
 	Custom targets configuration can be provided in YAML format with '--targets=target.yaml', e.g.
 
-		primary:
+		pgsql:
 			target: ...   # the DSN of the database deployment, e.g. in docker, the name of the database container
 			dbname: ...   # name of database
 			username: ... # username for database access

--- a/internal/pgdump/pgdump.go
+++ b/internal/pgdump/pgdump.go
@@ -9,7 +9,7 @@ import (
 
 // Targets represents configuration for each of Sourcegraph's databases.
 type Targets struct {
-	Primary      Target `yaml:"primary"`
+	Pgsql        Target `yaml:"pgsql"`
 	CodeIntel    Target `yaml:"codeintel"`
 	CodeInsights Target `yaml:"codeinsights"`
 }
@@ -59,8 +59,8 @@ type Output struct {
 // path. It can be provided a zero-value Targets to just generate the output paths.
 func Outputs(dir string, targets Targets) []Output {
 	return []Output{{
-		Output: filepath.Join(dir, "primary.sql"),
-		Target: targets.Primary,
+		Output: filepath.Join(dir, "pgsql.sql"),
+		Target: targets.Pgsql,
 	}, {
 		Output: filepath.Join(dir, "codeintel.sql"),
 		Target: targets.CodeIntel,


### PR DESCRIPTION
The `pgsql` / `frontend` database already has too much confusion over its name when TS teams work with self-hosted customer admins. As far as I'm aware, the `src snapshot databases` commands for taking and uploading database snapshots as part of the migration from self-hosted to our Cloud is the only place our customers see the same database get a bonus third name `primary`, adding unnecessary confusion to a process which is already a little overwhelming for our customers, specifically the types of customers we're encouraging to migrate from self-hosted to Cloud.

I propose renaming `primary` -> `pgsql` in these src-cli commands, because that's the name of the pod / container which our self-hosted customer admins and TS teams already work with on a day-to-day basis, and it matches the database's name in the SG Cloud infra, and the rest of the commands throughout the migration process:

Customer commands:
```shell
# pgsql / frontend database is the only one that doesn't match from container name to snapshot name
docker exec -i pgsql sh -c 'PGPASSWORD=sg pg_dump ... --username=sg --dbname=sg' > src-snapshot/primary.sql

# codeintel and codeinsights get a snapshot name which match the container names
docker exec -i codeintel-db sh -c 'PGPASSWORD=sg pg_dump ... --username=sg --dbname=sg' > src-snapshot/codeintel.sql
docker exec -i codeinsights-db sh -c 'PGPASSWORD=password pg_dump ... --username=postgres --dbname=postgres' > src-snapshot/codeinsights.sql
```

IE commands: 
```sql
DROP DATABASE IF EXISTS "pgsql";
CREATE DATABASE "pgsql";
```

```shell
gcloud sql import sql $CLOUD_SQL_INSTANCE  \
  gs://$BUCKET/primary.sql  \ # Confusing primary.sql
  --database=pgsql            # Database is named pgsql inside our Cloud instances
```

This database is referred to as `frontend` in database schema code, however, our self-hosted customer admins are never exposed to the database name `frontend`; it is the pgsql container that they work with / are taking the snapshot out of. The database name inside the container is also `sg`, but renaming the src-cli commands to `sg` wouldn't be any clearer.

### Test plan

Naming change

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
