### PR TITLE
support --help anywhere on command line

### DIFF
--- a/cmd/src/cmd.go
+++ b/cmd/src/cmd.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"slices"
 
 	"github.com/sourcegraph/src-cli/internal/cmderrors"
 )
@@ -84,16 +83,6 @@ func (c commander) run(flagSet *flag.FlagSet, cmdName, usageText string, args []
 		cfg, err = readConfig()
 		if err != nil {
 			log.Fatal("reading config: ", err)
-		}
-
-		// Print help to stdout if requested
-		if slices.IndexFunc(args, func(s string) bool {
-			return s == "--help"
-		}) >= 0 {
-			cmd.flagSet.SetOutput(os.Stdout)
-			flag.CommandLine.SetOutput(os.Stdout)
-			cmd.flagSet.Usage()
-			os.Exit(0)
 		}
 
 		// Parse subcommand flags.

--- a/cmd/src/main.go
+++ b/cmd/src/main.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -89,7 +90,21 @@ func main() {
 	log.SetFlags(0)
 	log.SetPrefix("")
 
-	commands.run(flag.CommandLine, "src", usageText, os.Args[1:])
+	commands.run(flag.CommandLine, "src", usageText, normalizeDashHelp(os.Args[1:]))
+}
+
+// normalizeDashHelp converts --help to -help since Go's flag parser only supports single dash.
+func normalizeDashHelp(args []string) []string {
+	args = slices.Clone(args)
+	for i, arg := range args {
+		if arg == "--" {
+			break
+		}
+		if arg == "--help" {
+			args[i] = "-help"
+		}
+	}
+	return args
 }
 
 var cfg *config


### PR DESCRIPTION
Previously we special cased --help only for the first level of subcommands. However, this broke for example if you did "src snapshot upload --help". So instead we normalize our command line arguments so that if a user does "--help" we see "-help". We can then rely on go's stdlib flag parser to do the right thing w.r.t. sub commands/etc.

Test Plan: ran with --help in a few different places and observed good behaviour.

Alternative to https://github.com/sourcegraph/src-cli/pull/1190