### PR TITLE
chore(ci): always use go version in .tool-versions

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@faf52423ec0d44c58f68e83b614bfcd99dded66f
         with:
           go-version-file: '.tool-versions'
       - name: (Windows) Enable pulling Go modules from private sourcegraph/sourcegraph

--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@faf52423ec0d44c58f68e83b614bfcd99dded66f
         with:
           go-version-file: '.tool-versions'
       - name: Enable pulling Go modules from private sourcegraph/sourcegraph

--- a/.github/workflows/goreleaser-check.yml
+++ b/.github/workflows/goreleaser-check.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@faf52423ec0d44c58f68e83b614bfcd99dded66f
         with:
           go-version-file: '.tool-versions'
       - name: Enable pulling Go modules from private sourcegraph/sourcegraph

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -179,7 +179,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@faf52423ec0d44c58f68e83b614bfcd99dded66f
         with:
           go-version-file: '.tool-versions'
       - name: Enable pulling Go modules from private sourcegraph/sourcegraph

--- a/.github/workflows/pr-auditor.yml
+++ b/.github/workflows/pr-auditor.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           repository: 'sourcegraph/devx-service'
           token: ${{ secrets.PR_AUDITOR_TOKEN }}
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@faf52423ec0d44c58f68e83b614bfcd99dded66f
         with: { go-version-file: '.tool-versions' }
 
       - run: 'go run ./cmd/pr-auditor'

--- a/.github/workflows/scip.yml
+++ b/.github/workflows/scip.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@faf52423ec0d44c58f68e83b614bfcd99dded66f
         with:
           go-version-file: '.tool-versions'
 


### PR DESCRIPTION
setup-go@v6 supports reading in .tool-versions which means we will now always run the same version we run in local dev. This is also a better version to use than go.mod since that is a minimum version.

Test Plan: CI