### PR TITLE
chore(ci): use setup-go v6.1.0

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@faf52423ec0d44c58f68e83b614bfcd99dded66f
+        uses: actions/setup-go@v6.1.0
         with:
           go-version-file: '.tool-versions'
       - name: (Windows) Enable pulling Go modules from private sourcegraph/sourcegraph

--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@faf52423ec0d44c58f68e83b614bfcd99dded66f
+        uses: actions/setup-go@v6.1.0
         with:
           go-version-file: '.tool-versions'
       - name: Enable pulling Go modules from private sourcegraph/sourcegraph

--- a/.github/workflows/goreleaser-check.yml
+++ b/.github/workflows/goreleaser-check.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up Go
-        uses: actions/setup-go@faf52423ec0d44c58f68e83b614bfcd99dded66f
+        uses: actions/setup-go@v6.1.0
         with:
           go-version-file: '.tool-versions'
       - name: Enable pulling Go modules from private sourcegraph/sourcegraph

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -179,7 +179,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up Go
-        uses: actions/setup-go@faf52423ec0d44c58f68e83b614bfcd99dded66f
+        uses: actions/setup-go@v6.1.0
         with:
           go-version-file: '.tool-versions'
       - name: Enable pulling Go modules from private sourcegraph/sourcegraph

--- a/.github/workflows/scip.yml
+++ b/.github/workflows/scip.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@faf52423ec0d44c58f68e83b614bfcd99dded66f
+        uses: actions/setup-go@v6.1.0
         with:
           go-version-file: '.tool-versions'
 


### PR DESCRIPTION
They have just tagged a version which includes the changes we need. So we can switch away from the dev hash we pinned to a tagged release.

Test Plan: CI