### PR TITLE
switch back to using setup-go

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -16,10 +16,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Set up mise
-        uses: jdx/mise-action@v2
+      - name: Get Go version from mise
+        id: mise
+        run: echo "go-version=$(grep 'golang' mise.toml | cut -d'"' -f2)" >> $GITHUB_OUTPUT
+        shell: bash
+      - name: Set up Go
+        uses: actions/setup-go@v6
         with:
-          cache: true
+          go-version: ${{ steps.mise.outputs.go-version }}
       - name: (Windows) Enable pulling Go modules from private sourcegraph/sourcegraph
         if: runner.os == 'Windows'
         run: git config --global url."https://$env:PRIVATE_TOKEN@github.com/sourcegraph/".insteadOf "https://github.com/sourcegraph/"

--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -13,10 +13,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Set up mise
-        uses: jdx/mise-action@v2
+      - name: Get Go version from mise
+        id: mise
+        run: echo "go-version=$(grep 'golang' mise.toml | cut -d'"' -f2)" >> $GITHUB_OUTPUT
+      - name: Set up Go
+        uses: actions/setup-go@v6
         with:
-          cache: true
+          go-version: ${{ steps.mise.outputs.go-version }}
       - name: Enable pulling Go modules from private sourcegraph/sourcegraph
         run: git config --global url."https://${PRIVATE_TOKEN}@github.com/sourcegraph/".insteadOf "https://github.com/sourcegraph/"
       - run: ./dev/go-lint.sh

--- a/.github/workflows/goreleaser-check.yml
+++ b/.github/workflows/goreleaser-check.yml
@@ -16,10 +16,13 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Set up mise
-        uses: jdx/mise-action@v2
+      - name: Get Go version from mise
+        id: mise
+        run: echo "go-version=$(grep 'golang' mise.toml | cut -d'"' -f2)" >> $GITHUB_OUTPUT
+      - name: Set up Go
+        uses: actions/setup-go@v6
         with:
-          cache: true
+          go-version: ${{ steps.mise.outputs.go-version }}
       - name: Enable pulling Go modules from private sourcegraph/sourcegraph
         run: git config --global url."https://${PRIVATE_TOKEN}@github.com/sourcegraph/".insteadOf "https://github.com/sourcegraph/"
       - name: Check GoReleaser config

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -178,10 +178,13 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Set up mise
-        uses: jdx/mise-action@v2
+      - name: Get Go version from mise
+        id: mise
+        run: echo "go-version=$(grep 'golang' mise.toml | cut -d'"' -f2)" >> $GITHUB_OUTPUT
+      - name: Set up Go
+        uses: actions/setup-go@v6
         with:
-          cache: true
+          go-version: ${{ steps.mise.outputs.go-version }}
       - name: Enable pulling Go modules from private sourcegraph/sourcegraph
         run: git config --global url."https://${PRIVATE_TOKEN}@github.com/sourcegraph/".insteadOf "https://github.com/sourcegraph/"
       - run: go test ./...

--- a/.github/workflows/scip.yml
+++ b/.github/workflows/scip.yml
@@ -11,10 +11,13 @@ jobs:
     container: sourcegraph/scip-go
     steps:
       - uses: actions/checkout@v4
-      - name: Set up mise
-        uses: jdx/mise-action@v2
+      - name: Get Go version from mise
+        id: mise
+        run: echo "go-version=$(grep 'golang' mise.toml | cut -d'"' -f2)" >> $GITHUB_OUTPUT
+      - name: Set up Go
+        uses: actions/setup-go@v6
         with:
-          cache: true
+          go-version: ${{ steps.mise.outputs.go-version }}
 
       - name: Set directory to safe for git
         run: git config --global --add safe.directory $GITHUB_WORKSPACE


### PR DESCRIPTION
`setup-go` caches the go module deps which mise steps didn't do which lead to much longer build times as go redownloaded the dependencies the whole time.

Some proof:
<img width="559" height="97" alt="Screenshot 2025-11-25 at 12 53 53" src="https://github.com/user-attachments/assets/f1ac2bbd-f110-4c16-83e2-f0e5d85a6356" />
<img width="646" height="85" alt="Screenshot 2025-11-25 at 12 53 46" src="https://github.com/user-attachments/assets/5e668b35-fca9-41a2-b23b-7176304f7e70" />


### Test plan

CI on this branch
