### PR TITLE
bug: check split header length correctly

### DIFF
--- a/cmd/src/headers.go
+++ b/cmd/src/headers.go
@@ -38,7 +38,7 @@ func parseAdditionalHeadersFromEnviron(environ []string) map[string]string {
 
 			for _, h := range splitHeaders {
 				p := strings.SplitN(h, ":", 2)
-				if len(parts) != 2 || p[1] == "" {
+				if len(p) != 2 || p[1] == "" {
 					continue
 				}
 


### PR DESCRIPTION
We checked `len(parts)` where we should check `len(p)`.

### Test plan
CI

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
