### PR TITLE
feat(oauth): use oauth device flow to authenticate with predefined src-cli OAuth client 

### DIFF
--- a/cmd/src/login_test.go
+++ b/cmd/src/login_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/sourcegraph/src-cli/internal/cmderrors"
+	"github.com/sourcegraph/src-cli/internal/oauth"
 )
 
 func TestLogin(t *testing.T) {
@@ -18,7 +19,13 @@ func TestLogin(t *testing.T) {
 		t.Helper()
 
 		var out bytes.Buffer
-		err = loginCmd(context.Background(), loginParams{cfg: cfg, client: cfg.apiClient(nil, io.Discard), endpoint: endpointArg, out: &out})
+		err = loginCmd(context.Background(), loginParams{
+			cfg:              cfg,
+			client:           cfg.apiClient(nil, io.Discard),
+			endpoint:         endpointArg,
+			out:              &out,
+			deviceFlowClient: oauth.NewClient(oauth.DefaultClientID),
+		})
 		return strings.TrimSpace(out.String()), err
 	}
 
@@ -27,7 +34,7 @@ func TestLogin(t *testing.T) {
 		if err != cmderrors.ExitCode1 {
 			t.Fatal(err)
 		}
-		wantOut := "❌ Problem: No access token is configured.\n\n🛠  To fix: Create an access token by going to https://sourcegraph.example.com/user/settings/tokens, then set the following environment variables in your terminal:\n\n   export SRC_ENDPOINT=https://sourcegraph.example.com\n   export SRC_ACCESS_TOKEN=(your access token)\n\n   To verify that it's working, run the login command again."
+		wantOut := "❌ Problem: No access token is configured.\n\n🛠  To fix: Create an access token by going to https://sourcegraph.example.com/user/settings/tokens, then set the following environment variables in your terminal:\n\n   export SRC_ENDPOINT=https://sourcegraph.example.com\n   export SRC_ACCESS_TOKEN=(your access token)\n\n   To verify that it's working, run the login command again.\n\n   Alternatively, you can try logging in using OAuth by running: src login --oauth https://sourcegraph.example.com"
 		if out != wantOut {
 			t.Errorf("got output %q, want %q", out, wantOut)
 		}
@@ -38,7 +45,7 @@ func TestLogin(t *testing.T) {
 		if err != cmderrors.ExitCode1 {
 			t.Fatal(err)
 		}
-		wantOut := "❌ Problem: No access token is configured.\n\n🛠  To fix: Create an access token by going to https://sourcegraph.example.com/user/settings/tokens, then set the following environment variables in your terminal:\n\n   export SRC_ENDPOINT=https://sourcegraph.example.com\n   export SRC_ACCESS_TOKEN=(your access token)\n\n   To verify that it's working, run the login command again."
+		wantOut := "❌ Problem: No access token is configured.\n\n🛠  To fix: Create an access token by going to https://sourcegraph.example.com/user/settings/tokens, then set the following environment variables in your terminal:\n\n   export SRC_ENDPOINT=https://sourcegraph.example.com\n   export SRC_ACCESS_TOKEN=(your access token)\n\n   To verify that it's working, run the login command again.\n\n   Alternatively, you can try logging in using OAuth by running: src login --oauth https://sourcegraph.example.com"
 		if out != wantOut {
 			t.Errorf("got output %q, want %q", out, wantOut)
 		}
@@ -49,7 +56,7 @@ func TestLogin(t *testing.T) {
 		if err != cmderrors.ExitCode1 {
 			t.Fatal(err)
 		}
-		wantOut := "⚠️  Warning: Configuring src with a JSON file is deprecated. Please migrate to using the env vars SRC_ENDPOINT, SRC_ACCESS_TOKEN, and SRC_PROXY instead, and then remove f. See https://github.com/sourcegraph/src-cli#readme for more information.\n\n❌ Problem: No access token is configured.\n\n🛠  To fix: Create an access token by going to https://example.com/user/settings/tokens, then set the following environment variables in your terminal:\n\n   export SRC_ENDPOINT=https://example.com\n   export SRC_ACCESS_TOKEN=(your access token)\n\n   To verify that it's working, run the login command again."
+		wantOut := "⚠️  Warning: Configuring src with a JSON file is deprecated. Please migrate to using the env vars SRC_ENDPOINT, SRC_ACCESS_TOKEN, and SRC_PROXY instead, and then remove f. See https://github.com/sourcegraph/src-cli#readme for more information.\n\n❌ Problem: No access token is configured.\n\n🛠  To fix: Create an access token by going to https://example.com/user/settings/tokens, then set the following environment variables in your terminal:\n\n   export SRC_ENDPOINT=https://example.com\n   export SRC_ACCESS_TOKEN=(your access token)\n\n   To verify that it's working, run the login command again.\n\n   Alternatively, you can try logging in using OAuth by running: src login --oauth https://example.com"
 		if out != wantOut {
 			t.Errorf("got output %q, want %q", out, wantOut)
 		}
@@ -67,7 +74,7 @@ func TestLogin(t *testing.T) {
 		if err != cmderrors.ExitCode1 {
 			t.Fatal(err)
 		}
-		wantOut := "❌ Problem: Invalid access token.\n\n🛠  To fix: Create an access token by going to $ENDPOINT/user/settings/tokens, then set the following environment variables in your terminal:\n\n   export SRC_ENDPOINT=$ENDPOINT\n   export SRC_ACCESS_TOKEN=(your access token)\n\n   To verify that it's working, run the login command again.\n\n   (If you need to supply custom HTTP request headers, see information about SRC_HEADER_* and SRC_HEADERS env vars at https://github.com/sourcegraph/src-cli/blob/main/AUTH_PROXY.md)"
+		wantOut := "❌ Problem: Invalid access token.\n\n🛠  To fix: Create an access token by going to $ENDPOINT/user/settings/tokens, then set the following environment variables in your terminal:\n\n   export SRC_ENDPOINT=$ENDPOINT\n   export SRC_ACCESS_TOKEN=(your access token)\n\n   To verify that it's working, run the login command again.\n\n   Alternatively, you can try logging in using OAuth by running: src login --oauth $ENDPOINT\n\n   (If you need to supply custom HTTP request headers, see information about SRC_HEADER_* and SRC_HEADERS env vars at https://github.com/sourcegraph/src-cli/blob/main/AUTH_PROXY.md)"
 		wantOut = strings.ReplaceAll(wantOut, "$ENDPOINT", endpoint)
 		if out != wantOut {
 			t.Errorf("got output %q, want %q", out, wantOut)

--- a/cmd/src/main.go
+++ b/cmd/src/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"flag"
 	"io"
@@ -15,6 +16,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 
 	"github.com/sourcegraph/src-cli/internal/api"
+	"github.com/sourcegraph/src-cli/internal/oauth"
 )
 
 const usageText = `src is a tool that provides access to Sourcegraph instances.
@@ -122,7 +124,7 @@ type config struct {
 
 // apiClient returns an api.Client built from the configuration.
 func (c *config) apiClient(flags *api.Flags, out io.Writer) api.Client {
-	return api.NewClient(api.ClientOpts{
+	opts := api.ClientOpts{
 		Endpoint:          c.Endpoint,
 		AccessToken:       c.AccessToken,
 		AdditionalHeaders: c.AdditionalHeaders,
@@ -130,7 +132,16 @@ func (c *config) apiClient(flags *api.Flags, out io.Writer) api.Client {
 		Out:               out,
 		ProxyURL:          c.ProxyURL,
 		ProxyPath:         c.ProxyPath,
-	})
+	}
+
+	// Only use OAuth if we do not have SRC_ACCESS_TOKEN set
+	if c.AccessToken == "" {
+		if t, err := oauth.LoadToken(context.Background(), c.Endpoint); err == nil {
+			opts.OAuthToken = t
+		}
+	}
+
+	return api.NewClient(opts)
 }
 
 // readConfig reads the config file from the given path.

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/sourcegraph/sourcegraph/lib v0.0.0-20240709083501-1af563b61442
 	github.com/stretchr/testify v1.11.1
 	github.com/tliron/glsp v0.2.2
+	github.com/zalando/go-keyring v0.2.6
 	golang.org/x/sync v0.18.0
 	google.golang.org/api v0.256.0
 	google.golang.org/protobuf v1.36.10
@@ -41,6 +42,7 @@ require (
 )
 
 require (
+	al.essio.dev/pkg/shellescape v1.5.1 // indirect
 	cel.dev/expr v0.24.0 // indirect
 	cloud.google.com/go/auth v0.17.0 // indirect
 	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
@@ -64,6 +66,7 @@ require (
 	github.com/clipperhouse/uax29/v2 v2.2.0 // indirect
 	github.com/cncf/xds/go v0.0.0-20250501225837-2ac532fd4443 // indirect
 	github.com/containerd/stargz-snapshotter/estargz v0.14.3 // indirect
+	github.com/danieljoos/wincred v1.2.2 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/cli v24.0.4+incompatible // indirect
 	github.com/docker/distribution v2.8.2+incompatible // indirect
@@ -78,6 +81,7 @@ require (
 	github.com/go-chi/chi/v5 v5.2.2 // indirect
 	github.com/go-jose/go-jose/v4 v4.1.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/godbus/dbus/v5 v5.1.0 // indirect
 	github.com/gofrs/uuid/v5 v5.0.0 // indirect
 	github.com/google/gnostic-models v0.6.9 // indirect
 	github.com/google/go-containerregistry v0.19.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+al.essio.dev/pkg/shellescape v1.5.1 h1:86HrALUujYS/h+GtqoB26SBEdkWfmMI6FubjXlsXyho=
+al.essio.dev/pkg/shellescape v1.5.1/go.mod h1:6sIqp7X2P6mThCQ7twERpZTuigpr6KbZWtls1U8I890=
 cel.dev/expr v0.24.0 h1:56OvJKSH3hDGL0ml5uSxZmz3/3Pq4tJ+fb1unVLAFcY=
 cel.dev/expr v0.24.0/go.mod h1:hLPLo1W4QUmuYdA72RBX06QTs6MXw941piREPl3Yfiw=
 cloud.google.com/go v0.120.0 h1:wc6bgG9DHyKqF5/vQvX1CiZrtHnxJjBlKUyF9nP6meA=
@@ -139,6 +141,8 @@ github.com/creack/goselect v0.1.2/go.mod h1:a/NhLweNvqIYMuxcMOuWY516Cimucms3DglD
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
 github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
+github.com/danieljoos/wincred v1.2.2 h1:774zMFJrqaeYCK2W57BgAem/MLi6mtSE47MB6BOJ0i0=
+github.com/danieljoos/wincred v1.2.2/go.mod h1:w7w4Utbrz8lqeMbDAK0lkNJUv5sAOkFi7nd/ogr0Uh8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
@@ -212,6 +216,8 @@ github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1v
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
+github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=
+github.com/godbus/dbus/v5 v5.1.0/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gofrs/flock v0.8.1 h1:+gYjHKf32LDeiEEFhQaotPbLuUXjY5ZqxKgXy7n59aw=
 github.com/gofrs/flock v0.8.1/go.mod h1:F1TvTiK9OcQqauNUHlbJvyl9Qa1QvF/gOUDKA14jxHU=
 github.com/gofrs/uuid/v5 v5.0.0 h1:p544++a97kEL+svbcFbCQVM9KFu0Yo25UoISXGNNH9M=
@@ -243,6 +249,8 @@ github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db h1:097atOisP2aRj7vFgY
 github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db/go.mod h1:vavhavw2zAxS5dIdcRluK6cSGGPlZynqzFM8NdvU144=
 github.com/google/s2a-go v0.1.9 h1:LGD7gtMgezd8a/Xak7mEWL0PjoTQFvpRudN895yqKW0=
 github.com/google/s2a-go v0.1.9/go.mod h1:YA0Ei2ZQL3acow2O62kdp9UlnvMmU7kA6Eutn0dXayM=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/enterprise-certificate-proxy v0.3.7 h1:zrn2Ee/nWmHulBx5sAVrGgAa0f2/R35S4DJwfFaUPFQ=
@@ -495,6 +503,8 @@ github.com/yuin/goldmark v1.7.8 h1:iERMLn0/QJeHFhxSt3p6PeN9mGnvIKSpG9YYorDMnic=
 github.com/yuin/goldmark v1.7.8/go.mod h1:uzxRWxtg69N339t3louHJ7+O03ezfj6PlliRlaOzY1E=
 github.com/yuin/goldmark-emoji v1.0.5 h1:EMVWyCGPlXJfUXBXpuMu+ii3TIaxbVBnEX9uaDC4cIk=
 github.com/yuin/goldmark-emoji v1.0.5/go.mod h1:tTkZEbwu5wkPmgTcitqddVxY9osFZiavD+r4AzQrh1U=
+github.com/zalando/go-keyring v0.2.6 h1:r7Yc3+H+Ux0+M72zacZoItR3UDxeWfKTcabvkI8ua9s=
+github.com/zalando/go-keyring v0.2.6/go.mod h1:2TCrxYrbUNYfNS/Kgy/LSrkSQzZ5UPVH85RwfczwvcI=
 github.com/zeebo/errs v1.4.0 h1:XNdoD/RRMKP7HD0UhJnIzUy74ISdGGxURlYG8HSWSfM=
 github.com/zeebo/errs v1.4.0/go.mod h1:sgbWHsvVuTPHcqJJGQ1WhI5KbWlHYz+2+2C/LSEtCw4=
 go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=

--- a/internal/oauth/flow.go
+++ b/internal/oauth/flow.go
@@ -3,6 +3,7 @@
 package oauth
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -12,6 +13,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/sourcegraph/src-cli/internal/secrets"
 
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -30,6 +33,8 @@ const (
 	ScopeEmail         string = "email"
 	ScopeOfflineAccess string = "offline_access"
 	ScopeUserAll       string = "user:all"
+
+	oauthKey string = "src:oauth"
 )
 
 var defaultScopes = []string{ScopeEmail, ScopeOfflineAccess, ScopeOpenID, ScopeProfile, ScopeUserAll}
@@ -54,9 +59,17 @@ type DeviceAuthResponse struct {
 type TokenResponse struct {
 	AccessToken  string `json:"access_token"`
 	RefreshToken string `json:"refresh_token,omitempty"`
-	TokenType    string `json:"token_type"`
 	ExpiresIn    int    `json:"expires_in,omitempty"`
+	TokenType    string `json:"token_type"`
 	Scope        string `json:"scope,omitempty"`
+}
+
+type Token struct {
+	Endpoint     string    `json:"endpoint"`
+	ClientID     string    `json:"client_id,omitempty"`
+	AccessToken  string    `json:"access_token"`
+	RefreshToken string    `json:"refresh_token,omitempty"`
+	ExpiresAt    time.Time `json:"expires_at"`
 }
 
 type ErrorResponse struct {
@@ -65,9 +78,11 @@ type ErrorResponse struct {
 }
 
 type Client interface {
+	ClientID() string
 	Discover(ctx context.Context, endpoint string) (*OIDCConfiguration, error)
 	Start(ctx context.Context, endpoint string, scopes []string) (*DeviceAuthResponse, error)
 	Poll(ctx context.Context, endpoint, deviceCode string, interval time.Duration, expiresIn int) (*TokenResponse, error)
+	Refresh(ctx context.Context, token *Token) (*TokenResponse, error)
 }
 
 type httpClient struct {
@@ -78,20 +93,21 @@ type httpClient struct {
 }
 
 func NewClient(clientID string) Client {
+	return NewClientWithHTTPClient(clientID, &http.Client{
+		Timeout: 30 * time.Second,
+	})
+}
+
+func NewClientWithHTTPClient(clientID string, c *http.Client) Client {
 	return &httpClient{
-		clientID: clientID,
-		client: &http.Client{
-			Timeout: 30 * time.Second,
-		},
+		clientID:    cmp.Or(clientID, DefaultClientID),
+		client:      c,
 		configCache: make(map[string]*OIDCConfiguration),
 	}
 }
 
-func NewClientWithHTTPClient(c *http.Client) Client {
-	return &httpClient{
-		client:      c,
-		configCache: make(map[string]*OIDCConfiguration),
-	}
+func (c *httpClient) ClientID() string {
+	return c.clientID
 }
 
 // Discover fetches the openid-configuration which contains all the routes a client should
@@ -145,7 +161,7 @@ func (c *httpClient) Discover(ctx context.Context, endpoint string) (*OIDCConfig
 func (c *httpClient) Start(ctx context.Context, endpoint string, scopes []string) (*DeviceAuthResponse, error) {
 	endpoint = strings.TrimRight(endpoint, "/")
 
-	// Discover OIDC configuration
+	// Discover OIDC configuration - caches on first call
 	config, err := c.Discover(ctx, endpoint)
 	if err != nil {
 		return nil, errors.Wrap(err, "OIDC discovery failed")
@@ -156,7 +172,7 @@ func (c *httpClient) Start(ctx context.Context, endpoint string, scopes []string
 	}
 
 	data := url.Values{}
-	data.Set("client_id", DefaultClientID)
+	data.Set("client_id", c.clientID)
 	if len(scopes) > 0 {
 		data.Set("scope", strings.Join(scopes, " "))
 	} else {
@@ -208,7 +224,7 @@ func (c *httpClient) Start(ctx context.Context, endpoint string, scopes []string
 func (c *httpClient) Poll(ctx context.Context, endpoint, deviceCode string, interval time.Duration, expiresIn int) (*TokenResponse, error) {
 	endpoint = strings.TrimRight(endpoint, "/")
 
-	// Discover OIDC configuration (should be cached from Start)
+	// Discover OIDC configuration - caches on first call
 	config, err := c.Discover(ctx, endpoint)
 	if err != nil {
 		return nil, errors.Wrap(err, "OIDC discovery failed")
@@ -270,7 +286,7 @@ func (e *PollError) Error() string {
 
 func (c *httpClient) pollOnce(ctx context.Context, tokenEndpoint, deviceCode string) (*TokenResponse, error) {
 	data := url.Values{}
-	data.Set("client_id", DefaultClientID)
+	data.Set("client_id", c.clientID)
 	data.Set("device_code", deviceCode)
 	data.Set("grant_type", GrantTypeDeviceCode)
 
@@ -306,4 +322,108 @@ func (c *httpClient) pollOnce(ctx context.Context, tokenEndpoint, deviceCode str
 	}
 
 	return &tokenResp, nil
+}
+
+// Refresh exchanges a refresh token for a new access token.
+func (c *httpClient) Refresh(ctx context.Context, token *Token) (*TokenResponse, error) {
+	config, err := c.Discover(ctx, token.Endpoint)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to discover OIDC configuration")
+	}
+
+	if config.TokenEndpoint == "" {
+		return nil, errors.New("OIDC configuration has no token endpoint")
+	}
+
+	data := url.Values{}
+	data.Set("client_id", c.clientID)
+	data.Set("grant_type", "refresh_token")
+	data.Set("refresh_token", token.RefreshToken)
+
+	req, err := http.NewRequestWithContext(ctx, "POST", config.TokenEndpoint, strings.NewReader(data.Encode()))
+	if err != nil {
+		return nil, errors.Wrap(err, "creating refresh token request")
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, errors.Wrap(err, "refresh token request failed")
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, errors.Wrap(err, "reading refresh token response")
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		var errResp ErrorResponse
+		if err := json.Unmarshal(body, &errResp); err == nil && errResp.Error != "" {
+			return nil, errors.Newf("refresh token failed: %s: %s", errResp.Error, errResp.ErrorDescription)
+		}
+		return nil, errors.Newf("refresh token failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var tokenResp TokenResponse
+	if err := json.Unmarshal(body, &tokenResp); err != nil {
+		return nil, errors.Wrap(err, "parsing refresh token response")
+	}
+
+	return &tokenResp, err
+}
+
+func (t *TokenResponse) Token(endpoint string) *Token {
+	return &Token{
+		Endpoint:     strings.TrimRight(endpoint, "/"),
+		RefreshToken: t.RefreshToken,
+		AccessToken:  t.AccessToken,
+		ExpiresAt:    time.Now().Add(time.Second * time.Duration(t.ExpiresIn)),
+	}
+}
+
+func (t *Token) HasExpired() bool {
+	return time.Now().After(t.ExpiresAt)
+}
+
+func (t *Token) ExpiringIn(d time.Duration) bool {
+	future := time.Now().Add(d)
+	return future.After(t.ExpiresAt)
+}
+
+func StoreToken(ctx context.Context, token *Token) error {
+	if token.Endpoint == "" {
+		return errors.New("token endpoint cannot be empty when storing the token")
+	}
+
+	store, err := secrets.Open(ctx, token.Endpoint)
+	if err != nil {
+		return err
+	}
+	data, err := json.Marshal(token)
+	if err != nil {
+		return errors.Wrap(err, "failed to marshal token")
+	}
+
+	return store.Put(oauthKey, data)
+}
+
+func LoadToken(ctx context.Context, endpoint string) (*Token, error) {
+	store, err := secrets.Open(ctx, endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := store.Get(oauthKey)
+	if err != nil {
+		return nil, err
+	}
+
+	var t Token
+	if err := json.Unmarshal(data, &t); err != nil {
+		return nil, errors.Wrap(err, "failed to unmarshal token")
+	}
+
+	return &t, nil
 }

--- a/internal/oauth/flow_test.go
+++ b/internal/oauth/flow_test.go
@@ -267,9 +267,9 @@ func TestStart_NoDeviceEndpoint(t *testing.T) {
 func TestPoll_Success(t *testing.T) {
 	wantToken := TokenResponse{
 		AccessToken: "test-access-token",
-		TokenType:   "Bearer",
 		ExpiresIn:   3600,
 		Scope:       "read write",
+		TokenType:   "Bearer",
 	}
 
 	server := newTestServer(t, testServerOptions{
@@ -313,6 +313,7 @@ func TestPoll_Success(t *testing.T) {
 	if resp.TokenType != wantToken.TokenType {
 		t.Errorf("TokenType = %q, want %q", resp.TokenType, wantToken.TokenType)
 	}
+
 }
 
 func TestPoll_AuthorizationPending(t *testing.T) {
@@ -505,5 +506,68 @@ func TestPoll_ContextCancellation(t *testing.T) {
 
 	if err != context.Canceled && !strings.Contains(err.Error(), "context canceled") {
 		t.Errorf("error = %v, want context.Canceled or wrapped context canceled error", err)
+	}
+}
+
+func TestRefresh_Success(t *testing.T) {
+	server := newTestServer(t, testServerOptions{
+		handlers: map[string]http.HandlerFunc{
+			testTokenPath: func(w http.ResponseWriter, r *http.Request) {
+				if err := r.ParseForm(); err != nil {
+					http.Error(w, "bad request", http.StatusBadRequest)
+					return
+				}
+				if got := r.FormValue("grant_type"); got != "refresh_token" {
+					t.Errorf("grant_type = %q, want %q", got, "refresh_token")
+				}
+				if got := r.FormValue("refresh_token"); got != "test-refresh-token" {
+					t.Errorf("refresh_token = %q, want %q", got, "test-refresh-token")
+				}
+
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(TokenResponse{
+					AccessToken:  "new-access-token",
+					RefreshToken: "new-refresh-token",
+					ExpiresIn:    3600,
+					TokenType:    "Bearer",
+				})
+			},
+		},
+	})
+	defer server.Close()
+
+	client := NewClient(DefaultClientID)
+	token := &Token{
+		Endpoint:     server.URL,
+		AccessToken:  "new-access-token",
+		RefreshToken: "test-refresh-token",
+		ExpiresAt:    time.Now().Add(time.Second * time.Duration(3600)),
+	}
+	resp, err := client.Refresh(context.Background(), token)
+	if err != nil {
+		t.Fatalf("Refresh() error = %v", err)
+	}
+
+	if resp.AccessToken != "new-access-token" {
+		t.Errorf("AccessToken = %q, want %q", resp.AccessToken, "new-access-token")
+	}
+	if resp.RefreshToken != "new-refresh-token" {
+		t.Errorf("RefreshToken = %q, want %q", resp.RefreshToken, "new-refresh-token")
+	}
+}
+
+func TestRefresh_DiscoverFailure(t *testing.T) {
+	client := NewClient(DefaultClientID)
+	token := &Token{
+		Endpoint:     "http://127.0.0.1:1",
+		RefreshToken: "test-refresh-token",
+	}
+
+	_, err := client.Refresh(context.Background(), token)
+	if err == nil {
+		t.Fatal("Refresh() expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to discover OIDC configuration") {
+		t.Errorf("error = %q, want discovery failure context", err.Error())
 	}
 }

--- a/internal/oauth/http_transport.go
+++ b/internal/oauth/http_transport.go
@@ -1,0 +1,87 @@
+package oauth
+
+import (
+	"context"
+	"net/http"
+	"sync"
+	"time"
+)
+
+var _ http.Transport
+
+var _ http.RoundTripper = (*Transport)(nil)
+
+type Transport struct {
+	Base  http.RoundTripper
+	Token *Token
+
+	mu sync.Mutex
+}
+
+// storeRefreshedTokenFn is the function the transport should use to persist the token - mainly used during
+// tests to swap out the implementation out with a mock
+var storeRefreshedTokenFn = StoreToken
+
+// RoundTrip implements http.RoundTripper.
+func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	ctx := req.Context()
+
+	if err := t.refreshToken(ctx); err != nil {
+		return nil, err
+	}
+
+	req2 := req.Clone(req.Context())
+	req2.Header.Set("Authorization", "Bearer "+t.Token.AccessToken)
+
+	if t.Base != nil {
+		return t.Base.RoundTrip(req2)
+	}
+	return http.DefaultTransport.RoundTrip(req2)
+}
+
+// refreshToken checks if the token has expired or expiring soon and refreshes it. Once the token is
+// refreshed, the in-memory token is updated and a best effort is made to store the token.
+// If storing the token fails, no error is returned.
+func (t *Transport) refreshToken(ctx context.Context) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	prevToken := t.Token
+	token, err := maybeRefresh(ctx, t.Token)
+	if err != nil {
+		return err
+	}
+	t.Token = token
+	if token != prevToken {
+		// try to save the token if we fail let the request continue with in memory token
+		_ = storeRefreshedTokenFn(ctx, token)
+	}
+
+	return nil
+}
+
+// maybeRefresh conditionally refreshes the token. If the token has expired or is expriing in the next 30s
+// it will be refreshed and the updated token will be returned. Otherwise, no refresh occurs and the original
+// token is returned.
+func maybeRefresh(ctx context.Context, token *Token) (*Token, error) {
+	// token has NOT expired and is NOT about to expire in 30s
+	if !(token.HasExpired() || token.ExpiringIn(time.Duration(30)*time.Second)) {
+		return token, nil
+	}
+	client := NewClient(token.ClientID)
+
+	resp, err := client.Refresh(ctx, token)
+	if err != nil {
+		return nil, err
+	}
+
+	next := resp.Token(token.Endpoint)
+	next.ClientID = token.ClientID
+	return next, nil
+}
+
+// IsOAuthTransport checks wether the underlying type of the given RoundTripper is a OAuthTransport
+func IsOAuthTransport(trp http.RoundTripper) bool {
+	_, ok := trp.(*Transport)
+	return ok
+}

--- a/internal/oauth/http_transport_test.go
+++ b/internal/oauth/http_transport_test.go
@@ -1,0 +1,172 @@
+package oauth
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func newRefreshServer(t *testing.T, accessToken string) *httptest.Server {
+	t.Helper()
+	return newTestServer(t, testServerOptions{
+		handlers: map[string]http.HandlerFunc{
+			testTokenPath: func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"access_token":"` + accessToken + `","refresh_token":"new-refresh","expires_in":3600}`))
+			},
+		},
+	})
+}
+
+func TestMaybeRefresh(t *testing.T) {
+	server := newRefreshServer(t, "new-token")
+	defer server.Close()
+
+	tests := []struct {
+		name       string
+		token      *Token
+		wantAccess string
+		wantSame   bool
+	}{
+		{
+			name: "unchanged when still valid",
+			token: &Token{
+				AccessToken: "valid-token",
+				ExpiresAt:   time.Now().Add(time.Hour),
+			},
+			wantAccess: "valid-token",
+			wantSame:   true,
+		},
+		{
+			name: "refreshes expired token",
+			token: &Token{
+				Endpoint:     server.URL,
+				AccessToken:  "expired-token",
+				RefreshToken: "refresh-token",
+				ExpiresAt:    time.Now().Add(-time.Hour),
+			},
+			wantAccess: "new-token",
+		},
+		{
+			name: "refreshes token expiring soon",
+			token: &Token{
+				Endpoint:     server.URL,
+				AccessToken:  "expiring-soon-token",
+				RefreshToken: "refresh-token",
+				ExpiresAt:    time.Now().Add(10 * time.Second),
+			},
+			wantAccess: "new-token",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := maybeRefresh(context.Background(), tt.token)
+			if err != nil {
+				t.Fatalf("maybeRefresh() error = %v", err)
+			}
+			if got.AccessToken != tt.wantAccess {
+				t.Errorf("AccessToken = %q, want %q", got.AccessToken, tt.wantAccess)
+			}
+			if tt.wantSame && got != tt.token {
+				t.Errorf("token pointer changed for unexpired token")
+			}
+		})
+	}
+}
+
+func TestTransportRoundTrip(t *testing.T) {
+	tests := []struct {
+		name           string
+		token          *Token
+		persistErr     error
+		wantAuthHeader string
+		wantStoreCalls int
+	}{
+		{
+			name: "uses existing token without persisting",
+			token: &Token{
+				AccessToken: "valid-token",
+				ExpiresAt:   time.Now().Add(time.Hour),
+			},
+			wantAuthHeader: "Bearer valid-token",
+			wantStoreCalls: 0,
+		},
+		{
+			name: "persists refreshed token",
+			token: &Token{
+				AccessToken:  "expired-token",
+				RefreshToken: "refresh-token",
+				ExpiresAt:    time.Now().Add(-time.Hour),
+			},
+			wantAuthHeader: "Bearer new-token",
+			wantStoreCalls: 1,
+		},
+		{
+			name: "ignores persist failures",
+			token: &Token{
+				AccessToken:  "expired-token",
+				RefreshToken: "refresh-token",
+				ExpiresAt:    time.Now().Add(-time.Hour),
+			},
+			persistErr:     errors.New("persist failed"),
+			wantAuthHeader: "Bearer new-token",
+			wantStoreCalls: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.wantStoreCalls > 0 {
+				server := newRefreshServer(t, "new-token")
+				defer server.Close()
+				tt.token.Endpoint = server.URL
+			}
+
+			originalStoreFn := storeRefreshedTokenFn
+			defer func() { storeRefreshedTokenFn = originalStoreFn }()
+
+			var storeCalls int
+			var storedToken *Token
+			storeRefreshedTokenFn = func(_ context.Context, token *Token) error {
+				storeCalls++
+				storedToken = token
+				return tt.persistErr
+			}
+
+			var capturedAuth string
+			tr := &Transport{
+				Base: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+					capturedAuth = req.Header.Get("Authorization")
+					return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody}, nil
+				}),
+				Token: tt.token,
+			}
+
+			_, err := tr.RoundTrip(httptest.NewRequest(http.MethodGet, "http://example.com", nil))
+			if err != nil {
+				t.Fatalf("RoundTrip() error = %v", err)
+			}
+
+			if capturedAuth != tt.wantAuthHeader {
+				t.Errorf("Authorization = %q, want %q", capturedAuth, tt.wantAuthHeader)
+			}
+			if storeCalls != tt.wantStoreCalls {
+				t.Errorf("store calls = %d, want %d", storeCalls, tt.wantStoreCalls)
+			}
+			if tt.wantStoreCalls > 0 && (storedToken == nil || storedToken.AccessToken != "new-token") {
+				t.Errorf("stored token = %#v, want access token %q", storedToken, "new-token")
+			}
+		})
+	}
+}

--- a/internal/secrets/keyring.go
+++ b/internal/secrets/keyring.go
@@ -1,0 +1,77 @@
+package secrets
+
+import (
+	"context"
+	"strings"
+
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/zalando/go-keyring"
+)
+
+var ErrSecretNotFound = errors.New("secret not found")
+
+const serviceNamePrefix = "Sourcegraph CLI"
+
+type keyringStore struct {
+	ctx         context.Context
+	serviceName string
+}
+
+// Open opens the system keyring for the Sourcegraph CLI.
+func Open(ctx context.Context, endpoint string) (*keyringStore, error) {
+	endpoint = strings.TrimRight(strings.TrimSpace(endpoint), "/")
+	if endpoint == "" {
+		return nil, errors.New("endpoint cannot be empty")
+	}
+
+	serviceName := serviceNamePrefix + " <" + endpoint + ">"
+
+	return &keyringStore{ctx: ctx, serviceName: serviceName}, nil
+}
+
+// withContext runs fn in a goroutine and returns its result, or ctx.Err() if the context is cancelled first.
+func withContext[T any](ctx context.Context, fn func() (T, error)) (T, error) {
+	type result struct {
+		val T
+		err error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		val, err := fn()
+		ch <- result{val, err}
+	}()
+
+	select {
+	case <-ctx.Done():
+		var zero T
+		return zero, ctx.Err()
+	case r := <-ch:
+		return r.val, r.err
+	}
+}
+
+// Put stores a key-value pair in the keyring.
+func (k *keyringStore) Put(key string, data []byte) error {
+	_, err := withContext(k.ctx, func() (struct{}, error) {
+		err := keyring.Set(k.serviceName, key, string(data))
+		if err != nil {
+			return struct{}{}, errors.Wrap(err, "storing item in keyring")
+		}
+		return struct{}{}, nil
+	})
+	return err
+}
+
+// Get retrieves a value by key from the keyring.
+func (k *keyringStore) Get(key string) ([]byte, error) {
+	return withContext(k.ctx, func() ([]byte, error) {
+		secret, err := keyring.Get(k.serviceName, key)
+		if err != nil {
+			if err == keyring.ErrNotFound {
+				return nil, ErrSecretNotFound
+			}
+			return nil, errors.Wrap(err, "getting item from keyring")
+		}
+		return []byte(secret), nil
+	})
+}

--- a/internal/secrets/keyring_test.go
+++ b/internal/secrets/keyring_test.go
@@ -1,0 +1,58 @@
+package secrets
+
+import (
+	"context"
+	"testing"
+)
+
+func TestOpen(t *testing.T) {
+	tests := []struct {
+		name            string
+		endpoint        string
+		wantServiceName string
+		wantErr         bool
+	}{
+		{
+			name:            "normalized endpoint",
+			endpoint:        " https://sourcegraph.example.com/ ",
+			wantServiceName: "Sourcegraph CLI <https://sourcegraph.example.com>",
+		},
+		{
+			name:            "normalized endpoint with path",
+			endpoint:        " https://sourcegraph.example.com/sourcegraph/ ",
+			wantServiceName: "Sourcegraph CLI <https://sourcegraph.example.com/sourcegraph>",
+		},
+		{
+			name:            "normalized endpoint with nested path",
+			endpoint:        "https://sourcegraph.example.com/custom/path///",
+			wantServiceName: "Sourcegraph CLI <https://sourcegraph.example.com/custom/path>",
+		},
+		{
+			name:     "empty endpoint",
+			endpoint: " / ",
+			wantErr:  true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			store, err := Open(context.Background(), test.endpoint)
+			if test.wantErr {
+				if err == nil {
+					t.Fatal("Open() error = nil, want non-nil")
+				}
+				if store != nil {
+					t.Fatalf("Open() store = %v, want nil", store)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("Open() error = %v, want nil", err)
+			}
+			if got := store.serviceName; got != test.wantServiceName {
+				t.Fatalf("Open() serviceName = %q, want %q", got, test.wantServiceName)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This adds the flag `--oauth` to `login` command which then starts the OAuth device authentication flow. `gh` does the same flow when you authenticate from the cli with `gh auth login`.

- add package `internal/oauth`
- discover oauth configuration via path `.well-known/openid-configuration`
- add client to handle flow, in particular to discover the endpoints it should use and ultimately poll for the token once the user as authorized the application.

In https://github.com/sourcegraph/src-cli/pull/1228 we add a keyring to store the oauth credentials.

> [!IMPORTANT]
> A Follow up will remove the `--oauth` flag and make it dynamically decide to start the flow or not based on whether the access token is set.

### Test plan

- Unit tests
```
go test -v ./internal/oauthdevice/...
=== RUN   TestDiscover_Success
--- PASS: TestDiscover_Success (0.00s)
=== RUN   TestDiscover_Caching
--- PASS: TestDiscover_Caching (0.00s)
=== RUN   TestDiscover_Error
--- PASS: TestDiscover_Error (0.00s)
=== RUN   TestStart_Success
--- PASS: TestStart_Success (0.00s)
=== RUN   TestStart_WithScopes
--- PASS: TestStart_WithScopes (0.00s)
=== RUN   TestStart_Error
--- PASS: TestStart_Error (0.00s)
=== RUN   TestStart_NoDeviceEndpoint
--- PASS: TestStart_NoDeviceEndpoint (0.00s)
=== RUN   TestPoll_Success
--- PASS: TestPoll_Success (0.00s)
=== RUN   TestPoll_AuthorizationPending
--- PASS: TestPoll_AuthorizationPending (0.00s)
=== RUN   TestPoll_SlowDown
--- PASS: TestPoll_SlowDown (0.00s)
=== RUN   TestPoll_ExpiredToken
--- PASS: TestPoll_ExpiredToken (0.00s)
=== RUN   TestPoll_AccessDenied
--- PASS: TestPoll_AccessDenied (0.00s)
=== RUN   TestPoll_Timeout
--- PASS: TestPoll_Timeout (0.00s)
=== RUN   TestPoll_ContextCancellation
--- PASS: TestPoll_ContextCancellation (0.00s)
PASS
ok      github.com/sourcegraph/src-cli/internal/oauthdevice     0.625s
```
- Tested manually against my local SG

[Amp thread](https://ampcode.com/threads/T-1e7c987a-e92d-4f67-8be5-be08cfe4048a)
