### PR TITLE
chore: remove SOC2 comment in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,1 @@
 ### Test plan
-
-<!--
-  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
-  provide a "test plan". A test plan is a loose explanation of what you have done or
-  implemented to test this, as outlined in our Testing principles and guidelines:
-  https://docs.sourcegraph.com/dev/background-information/testing_principles
-  Write your test plan here after the "Test plan" header.
--->


### PR DESCRIPTION
We don't need the comment anymore