### PR TITLE
fix(mcp): handle -repos flag values that are JSON arrays

### DIFF
--- a/internal/mcp/mcp_args.go
+++ b/internal/mcp/mcp_args.go
@@ -1,6 +1,7 @@
 package mcp
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
 	"reflect"
@@ -16,6 +17,16 @@ type strSliceFlag struct {
 }
 
 func (s *strSliceFlag) Set(v string) error {
+	// The MCP Array properties accept JSON arrays so, if we get a value starting with "["
+	// it's probably a JSON array
+	if strings.HasPrefix(v, "[") {
+		var arr []string
+		if err := json.Unmarshal([]byte(v), &arr); err == nil {
+			s.vals = append(s.vals, arr...)
+			return nil
+		}
+	}
+	// Otherwise treat as a single value
 	s.vals = append(s.vals, v)
 	return nil
 }

--- a/internal/mcp/mcp_args_test.go
+++ b/internal/mcp/mcp_args_test.go
@@ -1,6 +1,7 @@
 package mcp
 
 import (
+	"slices"
 	"testing"
 )
 
@@ -58,20 +59,22 @@ func TestFlagSetParse(t *testing.T) {
 		t.Fatalf("vars from buildArgFlagSet should not be empty")
 	}
 
-	args := []string{"-repos=A", "-repos=B", "-count=10", "-boolFlag", "-tag=testTag"}
+	args := []string{"-repos=A", "-repos=B", `-repos=["repo1", "repo2"]`, "-count=10", "-boolFlag", "-tag=testTag"}
 
 	if err := flagSet.Parse(args); err != nil {
 		t.Fatalf("flagset parsing failed: %v", err)
 	}
 	DerefFlagValues(flagSet, vars)
 
-	if v, ok := vars["repos"].([]string); ok {
-		if len(v) != 2 {
-			t.Fatalf("expected flag 'repos' values to have length %d but got %d", 2, len(v))
-		}
-	} else {
-		t.Fatalf("expected flag 'repos' to have type of []string but got %T", v)
+	expectedRepos := []string{"A", "B", "repo1", "repo2"}
+	actualRepos, ok := vars["repos"].([]string)
+	if !ok {
+		t.Fatalf("failed to cast repos to []string, got %T", actualRepos)
 	}
+	if !slices.Equal(expectedRepos, actualRepos) {
+		t.Fatalf("expected repos %v, got %v", expectedRepos, vars["repos"])
+	}
+
 	if v, ok := vars["tag"].(string); ok {
 		if v != "testTag" {
 			t.Fatalf("expected flag 'tag' values to have value %q but got %q", "testTag", v)


### PR DESCRIPTION
The MCP description shows that you can give a JSON array as a value for the `-repos` flag ie. '["repo1", "repo2"]'. 

Previously we just appended two strings together, now we test if the value is a JSON array and marshal it to a string array and then add it.

### Test plan
Unit tests and tested manually