### PR TITLE
mcp: output tool schema as raw json

### DIFF
--- a/cmd/src/mcp.go
+++ b/cmd/src/mcp.go
@@ -94,16 +94,20 @@ func mcpMain(args []string) error {
 }
 
 func printSchemas(tool *mcp.ToolDef) error {
-	input, err := json.Marshal(tool.InputSchema)
+	var schema = struct {
+		Name   string `json:"tool"`
+		Input  any    `json:"inputSchema"`
+		Output any    `json:"outputSchema"`
+	}{
+		Name:   tool.Name,
+		Input:  tool.InputSchema,
+		Output: tool.OutputSchema,
+	}
+	jsonVal, err := json.Marshal(schema)
 	if err != nil {
 		return err
 	}
-	output, err := json.Marshal(tool.OutputSchema)
-	if err != nil {
-		return err
-	}
-
-	fmt.Printf("Input:\n%v\nOutput:\n%v\n", string(input), string(output))
+	fmt.Println(string(jsonVal))
 	return nil
 }
 


### PR DESCRIPTION
Previously when the schema was printed for a tool it would do
```
input:
<json>
output:
<json>
```

We don't need to do this and agents just prefer straight json. This PR updates printing of the schema to be
```
{
  "tool": "tool-name"
  "inputSchema": <schema json>,
  "outputSchema": <schema json>,
}
```

### Test plan
Executed locally
```
{"tool":"read-file","inputSchema":{"type":"object","description":"","required":["repo","path"],"properties":{"endLine":{"type":"integer","description":"The 1-based line number to end reading at. If not specified, reads to the end of the file."},"path":{"type":"string","description":"The path to the file within the repository."},"repo":{"type":"string","description":"The name of the repository containing the file. For example, \"github.com/sveltejs/svelte\"."},"revision":{"type":"string","description":"The revision to read the file from. If not specified, reads from the default branch. This can be a commit hash or a branch name"},"startLine":{"type":"integer","description":"The 1-based line number to start reading from. If not specified, starts from the beginning of the file."}}},"outputSchema":{"type":"object","description":"","required":["content"],"properties":{"content":{"type":"string","description":""}}}}
```