### PR TITLE
mcp: try primary and legacy mcp urls before returning an error

### DIFF
--- a/internal/mcp/mcp_request.go
+++ b/internal/mcp/mcp_request.go
@@ -13,7 +13,20 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-const MCPURLPath = ".api/mcp/v1"
+const (
+	MCPURLPath       = ".api/mcp"
+	MCPURLPathLegacy = ".api/mcp/v1"
+)
+
+func resolveMCPEndpoint(ctx context.Context, client api.Client) (string, error) {
+	for _, endpoint := range []string{MCPURLPath, MCPURLPathLegacy} {
+		_, err := doJSONRPC(ctx, client, endpoint, "tools/list", nil)
+		if err == nil {
+			return endpoint, nil
+		}
+	}
+	return "", errors.Newf("MCP endpoint not available: tried %s and %s", MCPURLPath, MCPURLPathLegacy)
+}
 
 func fetchToolDefinitions(ctx context.Context, client api.Client, endpoint string) (map[string]*ToolDef, error) {
 	resp, err := doJSONRPC(ctx, client, endpoint, "tools/list", nil)


### PR DESCRIPTION
We have two mcp endpoitns currently:
- latest url `.api/mcp` since 6.12
- legacy url `.api/mcp/v1` before 6.12

If neither work, we just return an error that the mcp endpoint is not available

### Test plan
Tested locally + unit tests