### PR TITLE
feat/dev: introduce integration smoke tests

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -52,6 +52,16 @@ Or just a single package with:
 go test ./internal/batches/workspace
 ```
 
+### Manual smoke test script
+
+For quick end-to-end CLI sanity checks against a live Sourcegraph instance, run:
+
+```sh
+./dev/smoke.sh
+```
+
+This script intentionally uses your currently exported `SRC_*` environment variables, is not hooked up to CI, and is meant for manual regression checks (for example, to catch issues like `src users list` failing unexpectedly).
+
 We adhere to the [general Sourcegraph principles for testing](https://docs.sourcegraph.com/dev/background-information/testing_principles), as well as [the Go specific directions](https://docs.sourcegraph.com/dev/background-information/languages/testing_go_code), at least to the extent they apply to a standalone tool like `src`.
 
 ## Releasing

--- a/dev/smoke.sh
+++ b/dev/smoke.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+unset CDPATH
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+SRC_CMD=(go run ./cmd/src)
+
+run() {
+  echo
+  echo "+ $*"
+  "$@"
+}
+
+# This script intentionally relies on the currently exported SRC_* envvars.
+
+echo "Running src-cli smoke checks with current SRC_* environment"
+
+run "${SRC_CMD[@]}" version
+run "${SRC_CMD[@]}" api -query 'query { site { buildVersion } }'
+run "${SRC_CMD[@]}" api -query 'query { currentUser { username } }'
+run "${SRC_CMD[@]}" users list -first=1 -f '{{.Username}}'
+run "${SRC_CMD[@]}" orgs list -first=1 -f '{{.Name}}'
+run "${SRC_CMD[@]}" repos list -first=1 -f '{{.Name}}'
+run "${SRC_CMD[@]}" search -less=false -json 'type:repo count:1'
+
+echo
+echo "Smoke checks completed successfully."


### PR DESCRIPTION
This is something lightweight you can run to ensure no major breakages to "src" when speaking to a sourcegraph instance.