### PR TITLE
Fix `.gitignore` being misinterpreted by ripgrep

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 cmd/src/src
 *.zip
 release
-./vendor
+/vendor
 .idea
 .env
 .envrc


### PR DESCRIPTION
`/` at the beginning of a line signals that the pattern starts at repo root. The currently used syntax messes up ripgrep.

### Test plan
N/A