### PR TITLE
remove pointless condition due to os.Exit

### DIFF
--- a/cmd/src/main.go
+++ b/cmd/src/main.go
@@ -102,9 +102,7 @@ func main() {
 	}
 
 	// if we didn't run a migrated command, then lets try running the legacy version
-	if !ranMigratedCmd {
-		commands.run(flag.CommandLine, "src", usageText, normalizeDashHelp(os.Args[1:]))
-	}
+	commands.run(flag.CommandLine, "src", usageText, normalizeDashHelp(os.Args[1:]))
 }
 
 // normalizeDashHelp converts --help to -help since Go's flag parser only supports single dash.


### PR DESCRIPTION
Condition is pointless

Context
https://github.com/sourcegraph/src-cli/pull/1292/changes/BASE..349b951a84e5dd29293b98d3d29b2d644078e320#r3085411142
