### PR TITLE
chore: remove clicompat help templates and use urfave/cli defaults

### DIFF
--- a/cmd/src/run_migration_compat.go
+++ b/cmd/src/run_migration_compat.go
@@ -50,7 +50,7 @@ func migratedRootCommand() *cli.Command {
 		commands = append(commands, migratedCommands[name])
 	}
 
-	return clicompat.WrapRoot(&cli.Command{
+	return clicompat.Wrap(&cli.Command{
 		Name:        "src",
 		HideVersion: true,
 		Commands:    commands,

--- a/cmd/src/version.go
+++ b/cmd/src/version.go
@@ -17,20 +17,21 @@ import (
 	"github.com/urfave/cli/v3"
 )
 
-const versionExamples = `Examples:
+const versionExamples = `
+Display and compare the src-cli version against the recommended version for your instance
 
-  Get the src-cli version and the Sourcegraph instance's recommended version:
+Examples:
 
-    	$ src version
+Get the src-cli version and the Sourcegraph instance's recommended version:
+
+$ src version
 `
 
 var versionCommand = clicompat.Wrap(&cli.Command{
 	Name:         "version",
-	Usage:        "display and compare the src-cli version against the recommended version for your instance",
 	UsageText:    "src version [options]",
 	OnUsageError: clicompat.OnUsageError,
-	Description: `
-` + versionExamples,
+	Description:  versionExamples,
 	Flags: clicompat.WithAPIFlags(
 		&cli.BoolFlag{
 			Name:  "client-only",

--- a/internal/clicompat/help.go
+++ b/internal/clicompat/help.go
@@ -2,55 +2,12 @@ package clicompat
 
 import "github.com/urfave/cli/v3"
 
-// LegacyCommandHelpTemplate formats leaf command help in a style closer to the
-// existing flag.FlagSet-based help output.
-const LegacyCommandHelpTemplate = `Usage of '{{.FullName}}':
-{{range .VisibleFlags}} {{printf "  -%s\n\t\t\t\t%s\n" .Name .Usage}}{{end}}{{if .Description}}
-  {{trim .Description}}
-{{end}}
-`
-
-// LegacyRootCommandHelpTemplate formats root command help while preserving a
-// command's UsageText when it is provided.
-const LegacyRootCommandHelpTemplate = `{{if .UsageText}}{{trim .UsageText}}
-{{else}}Usage of '{{.FullName}}':
-{{end}}{{if .VisibleFlags}}{{range .VisibleFlags}}{{println .}}{{end}}{{end}}{{if .VisibleCommands}}
-{{range .VisibleCommands}}{{printf "\t%s\t%s\n" .Name .Usage}}{{end}}{{end}}{{if .Description}}
-{{trim .Description}}
-{{end}}
-`
-
 // Wrap sets common options on a sub commands to ensure consistency for help and error handling
 func Wrap(cmd *cli.Command) *cli.Command {
 	if cmd == nil {
 		return nil
 	}
 
-	cmd.CustomHelpTemplate = LegacyCommandHelpTemplate
 	cmd.OnUsageError = OnUsageError
-	return cmd
-}
-
-// WrapRoot sets common options on a root command to ensure consistency for help and error handling
-func WrapRoot(cmd *cli.Command) *cli.Command {
-	if cmd == nil {
-		return nil
-	}
-
-	cmd.CustomRootCommandHelpTemplate = LegacyRootCommandHelpTemplate
-	cmd.OnUsageError = OnUsageError
-	return cmd
-}
-
-// WithLegacyHelp applies both root and leaf legacy help templates.
-func WithLegacyHelp(cmd *cli.Command) *cli.Command {
-	if cmd == nil {
-		return nil
-	}
-
-	cmd.CustomHelpTemplate = LegacyCommandHelpTemplate
-	cmd.CustomRootCommandHelpTemplate = LegacyRootCommandHelpTemplate
-	cmd.OnUsageError = OnUsageError
-
 	return cmd
 }


### PR DESCRIPTION
When migrating the `abc` command, it became apparent that the help rendering can quickly become annoying. It's better for us to just rely on the urfave/cli defaults.

Yes, there will be some visible inconsistency in help outputs now but in the long run I think it helps, since it requires less cognitive load to review + migrate a command.

### Changes
- remove custom help templates
- remote WrapRoot and WithLegacyHelp
- fixup version command to have better help formatting with urfave defaults

### Test plan
`src version` old
```
Usage of 'src version':
  -client-only
        If true, only the client version will be printed.
  -dump-requests
        Log GraphQL requests and responses to stdout
  -get-curl
        Print the curl command for executing this query and exit (WARNING: includes printing your access token!)
  -insecure-skip-verify
        Skip validation of TLS certificates against trusted chains
  -trace
        Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing
  -user-agent-telemetry
        Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph (default true)

Examples:

  Get the src-cli version and the Sourcegraph instance's recommended version:

        $ src version
```
`src version` new
```
go run ./cmd/src version -h
NAME:
   src version

USAGE:
   src version [options]

DESCRIPTION:

   Display and compare the src-cli version against the recommended version for your instance

   Examples:

   Get the src-cli version and the Sourcegraph instance's recommended version:

   $ src version


OPTIONS:
   --client-only           If true, only the client version will be printed.
   --dump-requests         Log GraphQL requests and responses to stdout
   --get-curl              Print the curl command for executing this query and exit (WARNING: includes printing your access token!)
   --trace                 Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing
   --insecure-skip-verify  Skip validation of TLS certificates against trusted chains
   --user-agent-telemetry  Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph
   --help, -h              show help
```