### PR TITLE
feat(auth): migrate src auth to urfave/cli

### DIFF
--- a/cmd/src/auth.go
+++ b/cmd/src/auth.go
@@ -1,37 +1,38 @@
 package main
 
 import (
-	"flag"
-	"fmt"
+	"context"
+
+	"github.com/sourcegraph/src-cli/internal/clicompat"
+	"github.com/urfave/cli/v3"
 )
 
-var authCommands commander
+const authExamples = `
+Authentication-related helper commands.
 
-func init() {
-	usage := `'src auth' provides authentication-related helper commands.
+Examples:
 
-Usage:
+Print the active auth token:
 
-	src auth command [command options]
+$ src auth token
+sgp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
-The commands are:
+Print the current Authorization header:
 
-	token   prints the current authentication token or Authorization header
-
-Use "src auth [command] -h" for more information about a command.
+$ src auth token --header
+Authorization: token sgp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 `
 
-	flagSet := flag.NewFlagSet("auth", flag.ExitOnError)
-	handler := func(args []string) error {
-		authCommands.run(flagSet, "src auth", usage, args)
-		return nil
-	}
-
-	commands = append(commands, &command{
-		flagSet: flagSet,
-		handler: handler,
-		usageFunc: func() {
-			fmt.Println(usage)
-		},
-	})
-}
+var authCommand = clicompat.Wrap(&cli.Command{
+	Name:        "auth",
+	Usage:       "authentication helper commands",
+	UsageText:   "src auth [command options]",
+	Description: authExamples,
+	HideVersion: true,
+	Commands: []*cli.Command{
+		authTokenCommand,
+	},
+	Action: func(ctx context.Context, cmd *cli.Command) error {
+		return cli.ShowSubcommandHelp(cmd)
+	},
+})

--- a/cmd/src/auth_token.go
+++ b/cmd/src/auth_token.go
@@ -2,12 +2,13 @@ package main
 
 import (
 	"context"
-	"flag"
 	"fmt"
 
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 
+	"github.com/sourcegraph/src-cli/internal/clicompat"
 	"github.com/sourcegraph/src-cli/internal/oauth"
+	"github.com/urfave/cli/v3"
 )
 
 var (
@@ -21,37 +22,52 @@ type oauthTokenRefresher interface {
 	GetToken(ctx context.Context) (oauth.Token, error)
 }
 
-func init() {
-	flagSet := flag.NewFlagSet("token", flag.ExitOnError)
-	header := flagSet.Bool("header", false, "print the token as an Authorization header")
-	usageFunc := func() {
-		fmt.Fprintf(flag.CommandLine.Output(), "Usage of 'src auth token':\n\n")
-		fmt.Fprintf(flag.CommandLine.Output(), "Print the current authentication token.\n")
-		fmt.Fprintf(flag.CommandLine.Output(), "Use --header to print a complete Authorization header instead.\n\n")
-		flagSet.PrintDefaults()
-	}
+const authTokenExamples = `
+Print the current authentication token.
 
-	handler := func(args []string) error {
-		if err := flagSet.Parse(args); err != nil {
-			return err
-		}
+Use --header to print a complete Authorization header instead.
 
-		token, err := resolveAuthToken(context.Background(), cfg)
+Examples:
+
+Raw token output:
+
+$ src auth token
+sgp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+Authorization header output:
+
+$ src auth token --header
+Authorization: token sgp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+If you are authenticated with OAuth instead of SRC_ACCESS_TOKEN, the header uses the Bearer scheme:
+
+$ src auth token --header
+Authorization: Bearer eyJhbGciOi...
+`
+
+var authTokenCommand = clicompat.Wrap(&cli.Command{
+	Name:        "token",
+	Usage:       "prints the current authentication token or Authorization header",
+	UsageText:   "src auth token [options]",
+	Description: authTokenExamples,
+	HideVersion: true,
+	Flags: []cli.Flag{
+		&cli.BoolFlag{
+			Name:  "header",
+			Usage: "print the token as an Authorization header",
+		},
+	},
+	Action: func(ctx context.Context, cmd *cli.Command) error {
+		token, err := resolveAuthToken(ctx, cfg)
 		if err != nil {
 			return err
 		}
 
-		token = formatAuthTokenOutput(token, cfg.AuthMode(), *header)
-		fmt.Println(token)
-		return nil
-	}
-
-	authCommands = append(authCommands, &command{
-		flagSet:   flagSet,
-		handler:   handler,
-		usageFunc: usageFunc,
-	})
-}
+		token = formatAuthTokenOutput(token, cfg.AuthMode(), cmd.Bool("header"))
+		_, err = fmt.Fprintln(cmd.Writer, token)
+		return err
+	},
+})
 
 func resolveAuthToken(ctx context.Context, cfg *config) (string, error) {
 	if err := cfg.requireCIAccessToken(); err != nil {

--- a/cmd/src/auth_token_test.go
+++ b/cmd/src/auth_token_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"net/url"
@@ -123,6 +124,32 @@ func TestResolveAuthToken(t *testing.T) {
 			t.Fatal("expected error")
 		}
 	})
+}
+
+func TestAuthTokenCommand(t *testing.T) {
+	reset := stubAuthTokenDependencies(t)
+	defer reset()
+
+	prevCfg := cfg
+	defer func() { cfg = prevCfg }()
+
+	cfg = &config{
+		accessToken: "access-token",
+		endpointURL: mustParseURL(t, "https://example.com"),
+	}
+
+	var out bytes.Buffer
+	cmd := *authTokenCommand
+	cmd.Writer = &out
+	cmd.ErrWriter = &out
+
+	err := cmd.Run(context.Background(), []string{"token", "--header"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.String() != "Authorization: token access-token\n" {
+		t.Fatalf("output = %q, want %q", out.String(), "Authorization: token access-token\n")
+	}
 }
 
 func TestFormatAuthTokenOutput(t *testing.T) {

--- a/cmd/src/run_migration_compat.go
+++ b/cmd/src/run_migration_compat.go
@@ -17,6 +17,7 @@ import (
 
 var migratedCommands = map[string]*cli.Command{
 	"abc":     abcCommand,
+	"auth":    authCommand,
 	"version": versionCommand,
 }
 


### PR DESCRIPTION
Migrate `src auth` to use `urfave/cli` and drop the legacy commander usage.

### Test plan
Unit tests + tested locally