### PR TITLE
fix: print command help and provide an error for unknown command

### DIFF
--- a/internal/clicompat/help.go
+++ b/internal/clicompat/help.go
@@ -20,7 +20,13 @@ func Wrap(cmd *cli.Command) *cli.Command {
 	cmd.OnUsageError = OnUsageError
 	if cmd.Action == nil {
 		cmd.Action = func(ctx context.Context, cmd *cli.Command) error {
-			return cli.ShowSubcommandHelp(cmd)
+			if err := cli.ShowSubcommandHelp(cmd); err != nil {
+				return err
+			}
+			if cmd.Args().Len() > 0 {
+				return errors.Newf("Unknown subcommand: %s", cmd.Args().First())
+			}
+			return nil
 		}
 	} else {
 		cmd.Action = wrapWithHelpOnUsageError(cmd.Action)


### PR DESCRIPTION
If you ran src with some unknown command it wouldn't let you know that the command doesn't exist and just print the help.

We now detect when printing help that you typed some unknown command and print help, then the error is printed of `Unknown command: bogus`

### Test plan
Tested locally