### PR TITLE
fix: still exit with non-zero when there is an unknown err

### DIFF
--- a/cmd/src/run_migration_compat.go
+++ b/cmd/src/run_migration_compat.go
@@ -66,19 +66,24 @@ func runMigrated() (int, error) {
 	ctx := context.Background()
 
 	err := migratedRootCommand().Run(ctx, os.Args)
-	if errors.HasType[*cmderrors.UsageError](err) {
-		return 2, nil
-	}
-	if e, ok := err.(*cmderrors.ExitCodeError); ok {
-		if e.HasError() {
-			return e.Code(), e
+	if err != nil {
+		if errors.HasType[*cmderrors.UsageError](err) {
+			return 2, nil
 		}
-		return e.Code(), nil
+		if e, ok := err.(*cmderrors.ExitCodeError); ok {
+			if e.HasError() {
+				return e.Code(), e
+			}
+			return e.Code(), nil
+		}
+		var exitErr cli.ExitCoder
+		if errors.AsInterface(err, &exitErr) {
+			return exitErr.ExitCode(), err
+		}
+
+		return 1, err
 	}
-	var exitErr cli.ExitCoder
-	if errors.AsInterface(err, &exitErr) {
-		return exitErr.ExitCode(), err
-	}
+
 	return 0, err
 }
 


### PR DESCRIPTION
If we returned an error whose type wasn't known we exited with exit code 0, instead of 1.

We now will always exit with code 1 at the very least if there is an error.

### Test plan
Tested locally