### PR TITLE
chore: update Go to 1.26.3

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,0 @@
-golang     1.26.1
-shfmt      3.8.0
-shellcheck 0.10.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 #
 # Nothing fancy here: we copy in the source code and build on the Alpine Go
 # image. Refer to .dockerignore to get a sense of what we're not going to copy.
-FROM golang:1.25.4-alpine3.22@sha256:d3f0cf7723f3429e3f9ed846243970b20a2de7bae6a5b66fc5914e228d831bbb AS builder
+FROM golang:1.26.3-alpine3.22@sha256:be93003ee861b3b91b6ebcb22678524947e0cd786c2df3f32af520006b1e54f5 AS builder
 
 COPY . /src
 WORKDIR /src

--- a/dev/vendor-lib.sh
+++ b/dev/vendor-lib.sh
@@ -128,7 +128,7 @@ echo "Creating go.mod file..."
 cat > "$DEST_LIB/go.mod" <<EOF
 module github.com/sourcegraph/sourcegraph/lib
 
-go 1.23
+go 1.26.3
 EOF
 
 # Create README.md

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sourcegraph/src-cli
 
-go 1.26
+go 1.26.3
 
 require (
 	cloud.google.com/go/storage v1.50.0

--- a/lib/go.mod
+++ b/lib/go.mod
@@ -1,6 +1,6 @@
 module github.com/sourcegraph/sourcegraph/lib
 
-go 1.25.8
+go 1.26.3
 
 require (
 	github.com/Masterminds/semver v1.5.0

--- a/mise.toml
+++ b/mise.toml
@@ -1,4 +1,4 @@
 [tools]
-golang = "1.26.2"
+golang = "1.26.3"
 shfmt = "3.8.0"
 shellcheck = "0.10.0"


### PR DESCRIPTION
The repository has several Go version pins that should stay aligned so local development, CI, module metadata, and Docker builds use the same patch release.

Update the root and vendored `lib` module directives, `mise.toml`, the vendored-lib generation template, and the Docker builder image to Go 1.26.3. Remove `.tool-versions` so `mise.toml` is the single checked-in tool version source. The Docker builder image remains pinned by digest for reproducible builds.

## Test Plan

- `go version`
- `go test ./...`
- `cd lib && go test ./...`