### PR TITLE
fix/batch-changes: ignore per-job env vars in cache key

### DIFF
--- a/lib/batches/execution/cache/cache.go
+++ b/lib/batches/execution/cache/cache.go
@@ -47,6 +47,13 @@ func (key CacheKey) mountsMetadata() ([]MountMetadata, error) {
 	return nil, nil
 }
 
+// perJobEnvVars resolve to per-job values and must be stripped from
+// cache keys. Mirrored in sourcegraph/sourcegraph/lib/batches/execution/cache/cache.go.
+var perJobEnvVars = []string{
+	"SRC_BATCHES_MODEL_PROVIDER_TOKEN",
+	"SRC_BATCHES_JOB_ID",
+}
+
 // resolveStepsEnvironment returns a slice of environments for each of the steps,
 // containing only the env vars that are actually used.
 func resolveStepsEnvironment(globalEnv []string, steps []batches.Step) ([]map[string]string, error) {
@@ -63,6 +70,9 @@ func resolveStepsEnvironment(globalEnv []string, steps []batches.Step) ([]map[st
 		env, err := step.Env.Resolve(globalEnv)
 		if err != nil {
 			return nil, errors.Wrapf(err, "resolving environment for step %d", i)
+		}
+		for _, name := range perJobEnvVars {
+			delete(env, name)
 		}
 		envs[i] = env
 	}

--- a/lib/batches/execution/cache/cache.go
+++ b/lib/batches/execution/cache/cache.go
@@ -47,11 +47,12 @@ func (key CacheKey) mountsMetadata() ([]MountMetadata, error) {
 	return nil, nil
 }
 
-// perJobEnvVars resolve to per-job values and must be stripped from
-// cache keys. Mirrored in sourcegraph/sourcegraph/lib/batches/execution/cache/cache.go.
+// perJobEnvVars resolve to per-job or per-executor values and must be
+// stripped from cache keys. Mirrored in sourcegraph/sourcegraph/lib/batches/execution/cache/cache.go.
 var perJobEnvVars = []string{
-	"SRC_BATCHES_MODEL_PROVIDER_TOKEN",
-	"SRC_BATCHES_JOB_ID",
+	"SRC_EXECUTOR_JOB_TOKEN",
+	"SRC_EXECUTOR_JOB_ID",
+	"SRC_EXECUTOR_NAME",
 }
 
 // resolveStepsEnvironment returns a slice of environments for each of the steps,

--- a/lib/batches/execution/cache/cache.go
+++ b/lib/batches/execution/cache/cache.go
@@ -47,9 +47,10 @@ func (key CacheKey) mountsMetadata() ([]MountMetadata, error) {
 	return nil, nil
 }
 
-// perJobEnvVars resolve to per-job or per-executor values and must be
-// stripped from cache keys. Mirrored in sourcegraph/sourcegraph/lib/batches/execution/cache/cache.go.
-var perJobEnvVars = []string{
+// perRunEnvVars resolve to per-job or per-executor values that change on
+// every dequeue and must be stripped from cache keys. Mirrored in
+// sourcegraph/sourcegraph/lib/batches/execution/cache/cache.go.
+var perRunEnvVars = []string{
 	"SRC_EXECUTOR_JOB_TOKEN",
 	"SRC_EXECUTOR_JOB_ID",
 	"SRC_EXECUTOR_NAME",
@@ -72,7 +73,7 @@ func resolveStepsEnvironment(globalEnv []string, steps []batches.Step) ([]map[st
 		if err != nil {
 			return nil, errors.Wrapf(err, "resolving environment for step %d", i)
 		}
-		for _, name := range perJobEnvVars {
+		for _, name := range perRunEnvVars {
 			delete(env, name)
 		}
 		envs[i] = env

--- a/lib/batches/execution/cache/cache_test.go
+++ b/lib/batches/execution/cache/cache_test.go
@@ -1,0 +1,30 @@
+package cache
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcegraph/sourcegraph/lib/batches"
+	"github.com/sourcegraph/sourcegraph/lib/batches/env"
+)
+
+func TestKeyer_Key_PerJobEnvVarsIgnored(t *testing.T) {
+	var stepEnv env.Environment
+	require.NoError(t, json.Unmarshal(
+		[]byte(`["SRC_BATCHES_MODEL_PROVIDER_TOKEN", "SRC_BATCHES_JOB_ID"]`),
+		&stepEnv,
+	))
+	step := batches.Step{Run: "foo", Env: stepEnv}
+	repo := batches.Repository{ID: "r", Name: "r"}
+
+	unset, err := (&CacheKey{Repository: repo, Steps: []batches.Step{step}, StepIndex: 0}).Key()
+	require.NoError(t, err)
+	resolved, err := (&CacheKey{Repository: repo, Steps: []batches.Step{step}, StepIndex: 0, GlobalEnv: []string{
+		"SRC_BATCHES_MODEL_PROVIDER_TOKEN=tok",
+		"SRC_BATCHES_JOB_ID=42",
+	}}).Key()
+	require.NoError(t, err)
+	require.Equal(t, unset, resolved)
+}

--- a/lib/batches/execution/cache/cache_test.go
+++ b/lib/batches/execution/cache/cache_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/batches/env"
 )
 
-func TestKeyer_Key_PerJobEnvVarsIgnored(t *testing.T) {
+func TestKeyer_Key_PerRunEnvVarsIgnored(t *testing.T) {
 	var stepEnv env.Environment
 	require.NoError(t, json.Unmarshal(
 		[]byte(`["SRC_EXECUTOR_JOB_TOKEN", "SRC_EXECUTOR_JOB_ID", "SRC_EXECUTOR_NAME"]`),

--- a/lib/batches/execution/cache/cache_test.go
+++ b/lib/batches/execution/cache/cache_test.go
@@ -13,7 +13,7 @@ import (
 func TestKeyer_Key_PerJobEnvVarsIgnored(t *testing.T) {
 	var stepEnv env.Environment
 	require.NoError(t, json.Unmarshal(
-		[]byte(`["SRC_BATCHES_MODEL_PROVIDER_TOKEN", "SRC_BATCHES_JOB_ID"]`),
+		[]byte(`["SRC_EXECUTOR_JOB_TOKEN", "SRC_EXECUTOR_JOB_ID", "SRC_EXECUTOR_NAME"]`),
 		&stepEnv,
 	))
 	step := batches.Step{Run: "foo", Env: stepEnv}
@@ -22,8 +22,9 @@ func TestKeyer_Key_PerJobEnvVarsIgnored(t *testing.T) {
 	unset, err := (&CacheKey{Repository: repo, Steps: []batches.Step{step}, StepIndex: 0}).Key()
 	require.NoError(t, err)
 	resolved, err := (&CacheKey{Repository: repo, Steps: []batches.Step{step}, StepIndex: 0, GlobalEnv: []string{
-		"SRC_BATCHES_MODEL_PROVIDER_TOKEN=tok",
-		"SRC_BATCHES_JOB_ID=42",
+		"SRC_EXECUTOR_JOB_TOKEN=tok",
+		"SRC_EXECUTOR_JOB_ID=42",
+		"SRC_EXECUTOR_NAME=executor-abc",
 	}}).Key()
 	require.NoError(t, err)
 	require.Equal(t, unset, resolved)

--- a/lib/go.mod
+++ b/lib/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/sourcegraph/conc v0.3.0
 	github.com/sourcegraph/go-diff v0.7.0
 	github.com/sourcegraph/log v0.0.0-20250923023806-517b6960b55b
+	github.com/stretchr/testify v1.11.1
 	github.com/urfave/cli/v3 v3.8.0
 	github.com/xeipuuv/gojsonschema v1.2.0
 	github.com/xlab/treeprint v1.2.0
@@ -46,6 +47,7 @@ require (
 	github.com/charmbracelet/x/term v0.2.1 // indirect
 	github.com/clipperhouse/uax29/v2 v2.2.0 // indirect
 	github.com/cockroachdb/logtags v0.0.0-20230118201751-21c54148d20b // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dlclark/regexp2 v1.11.0 // indirect
 	github.com/fatih/color v1.18.0 // indirect
 	github.com/getsentry/sentry-go v0.27.0 // indirect
@@ -64,6 +66,7 @@ require (
 	github.com/microcosm-cc/bluemonday v1.0.27 // indirect
 	github.com/muesli/reflow v0.3.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	github.com/sourcegraph/beaut v0.0.0-20240611013027-627e4c25335a // indirect


### PR DESCRIPTION
With sourcegraph/sourcegraph#12503, Sourcegraph desugars v3 `codingAgent` steps server-side and declares per-job env-var forwards on `step.Env`. Their resolved values change every dequeue, so including them in cache-key inputs would invalidate the cache on every run.

Strip them before hashing:

- `SRC_EXECUTOR_JOB_TOKEN` — per-job bearer token
- `SRC_EXECUTOR_JOB_ID` — numeric job ID
- `SRC_EXECUTOR_NAME` — dequeueing executor's hostname

The bare-string declarations still influence the key via the serialized `step.Env`, so spec-change invalidation still works. The list is mirrored in sourcegraph/sourcegraph; a comment on each side points at the other.

End-to-end test plan: see sourcegraph/sourcegraph#12503.