### PR TITLE
chore: set node version to 24.16.0 in goreleaser action

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -247,9 +247,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 16
+          node-version: 24.16.0
           registry-url: 'https://registry.npmjs.org'
       - run: echo "VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
       - run: echo "Releasing version ${{ env.version }}"


### PR DESCRIPTION
see title

### Test plan
Hard to test, so we will have to run the action