### PR TITLE
test: add unit tests for version-check comparison and skip logic

### DIFF
--- a/cmd/src/version_check_test.go
+++ b/cmd/src/version_check_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/sourcegraph/src-cli/internal/version"
+)
+
+func TestIsOutdated(t *testing.T) {
+	tests := []struct {
+		name         string
+		current      string
+		recommended  string
+		wantOutdated bool
+		wantOK       bool
+	}{
+		{"older patch", "4.3.0", "4.3.1", true, true},
+		{"older minor", "4.3.0", "4.4.0", true, true},
+		{"older major", "3.43.0", "4.0.0", true, true},
+		{"equal", "4.4.0", "4.4.0", false, true},
+		{"newer", "4.5.0", "4.4.0", false, true},
+		{"v-prefixed current", "v4.3.0", "4.4.0", true, true},
+		{"prerelease, same base, not outdated", "4.4.0-rc.1", "4.4.0", false, true},
+		{"prerelease, older base, outdated", "4.3.0-rc.1", "4.4.0", true, true},
+		{"unparseable current", "dev", "4.4.0", false, false},
+		{"empty recommended", "4.3.0", "", false, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotOutdated, gotOK := isOutdated(tt.current, tt.recommended)
+			if gotOutdated != tt.wantOutdated || gotOK != tt.wantOK {
+				t.Errorf("isOutdated(%q, %q) = (%v, %v), want (%v, %v)",
+					tt.current, tt.recommended, gotOutdated, gotOK, tt.wantOutdated, tt.wantOK)
+			}
+		})
+	}
+}
+
+func TestShouldSkipVersionCheck(t *testing.T) {
+	// pretend this is a real release build for the duration of the test, since the
+	// default BuildTag ("dev") would otherwise short-circuit every case.
+	orig := version.BuildTag
+	version.BuildTag = "4.3.0"
+	t.Cleanup(func() { version.BuildTag = orig })
+
+	t.Run("skips for no-op subcommands", func(t *testing.T) {
+		for _, sub := range []string{"", "help", "version", "-h", "--help"} {
+			if !shouldSkipVersionCheck(sub) {
+				t.Errorf("shouldSkipVersionCheck(%q) = false, want true", sub)
+			}
+		}
+	})
+
+	t.Run("runs for normal subcommands", func(t *testing.T) {
+		for _, sub := range []string{"search", "batch", "api"} {
+			if shouldSkipVersionCheck(sub) {
+				t.Errorf("shouldSkipVersionCheck(%q) = true, want false", sub)
+			}
+		}
+	})
+
+	t.Run("skips when opt-out env var is set", func(t *testing.T) {
+		t.Setenv(envSkipVersionCheck, "1")
+		if !shouldSkipVersionCheck("search") {
+			t.Errorf("shouldSkipVersionCheck with %s set = false, want true", envSkipVersionCheck)
+		}
+	})
+
+	t.Run("skips for dev builds", func(t *testing.T) {
+		version.BuildTag = version.DefaultBuildTag
+		defer func() { version.BuildTag = "4.3.0" }()
+		if !shouldSkipVersionCheck("search") {
+			t.Error("shouldSkipVersionCheck for dev build = false, want true")
+		}
+	})
+}


### PR DESCRIPTION
Hey Sourcegraph, 

This change adds `cmd/src/version_check_test.go`, covering both pieces of thenew logic with table-driven unit tests. The functions under test are pure and have no network or filesystem dependencies, so the suite runs fast and
deterministically.

### `isOutdated`

Verifies the version comparison that decides whether a warning should fire:

- **Major / minor / patch comparison** — confirms an older patch (`4.3.0` vs
  `4.3.1`), older minor (`4.3.0` vs `4.4.0`), and older major (`3.43.0` vs
  `4.0.0`) are each reported as outdated, while equal (`4.4.0` vs `4.4.0`) and
  newer (`4.5.0` vs `4.4.0`) versions are not.
- **`v`-prefixes** — checks that a leading `v` (`v4.3.0`) parses correctly and
  compares the same as its bare form, so the result doesn't depend on how the
  version string is formatted.
- **Prereleases** — ensures comparison is limited to the major/minor/patch
  components: a prerelease on the same base (`4.4.0-rc.1` vs `4.4.0`) is *not*
  flagged as outdated, while a prerelease on an older base (`4.3.0-rc.1` vs
  `4.4.0`) still is. This guards against spurious warnings for users running
  release candidates.
- **Unparseable input** — confirms the function returns `ok = false` (rather
  than guessing) when the current version can't be parsed (`dev`) or the
  recommended version is empty, so callers know to stay silent instead of
  warning on bad data.

### `shouldSkipVersionCheck`

Verifies the guard that decides when to run the check at all:

- **No-op subcommands** — confirms the check is skipped for `version`, `help`,
  an empty subcommand, and flag-only invocations like `-h` / `--help`, where a
  warning would be noise (and where `version` already reports this information
  itself).
- **Normal subcommands** — confirms the check *does* run for representative
  real commands (`search`, `batch`, `api`), so the feature isn't accidentally
  disabled.
- **`SRC_SKIP_VERSION_CHECK` opt-out** — confirms setting the environment
  variable suppresses the check, covering the documented escape hatch for CI
  and scripts.
- **Dev builds** — confirms the check is skipped when `version.BuildTag` is the
  default `dev` value, so local and development builds don't warn on every
  invocation.

Because `shouldSkipVersionCheck` reads the package-level `version.BuildTag`, the test temporarily overrides it to a real release value (`4.3.0`) and restores it via `t.Cleanup`, keeping the cases isolated from the build-time version.