### PR TITLE
go: upgrade to Go 1.26 and modernize

### DIFF
--- a/cmd/src/code_intel_upload_vendored.go
+++ b/cmd/src/code_intel_upload_vendored.go
@@ -176,7 +176,6 @@ func uploadMultipartIndexParts(ctx context.Context, httpClient upload.Client, op
 	}
 
 	for i, reader := range readers {
-		i, reader := i, reader
 
 		pool.Go(func(ctx context.Context) error {
 			// Determine size of this reader. If we're not the last reader in the slice,

--- a/cmd/src/snapshot_upload.go
+++ b/cmd/src/snapshot_upload.go
@@ -292,8 +292,6 @@ func uploadFilesToBucket(client *gcsClient, args *uploadArgs, openedFiles []uplo
 	// Upload each file in parallel
 	for fileIndex, openedFile := range openedFiles {
 
-		openedFile := openedFile
-
 		uploadPool.Go(func(ctx context.Context) error {
 			progressFn := func(bytesWritten int64) { progress.SetValue(fileIndex, float64(bytesWritten)) }
 

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"os"
 	"runtime"
+	"strings"
 
 	ioaux "github.com/jig/teereadcloser"
 	"github.com/kballard/go-shellquote"
@@ -371,18 +372,19 @@ func (r *request) curlCmd() (string, error) {
 		return "", err
 	}
 
-	s := "curl \\\n"
+	var s strings.Builder
+	s.WriteString("curl \\\n")
 	if r.client.opts.AccessToken != "" {
-		s += fmt.Sprintf("   %s \\\n", shellquote.Join("-H", "Authorization: token "+r.client.opts.AccessToken))
+		s.WriteString(fmt.Sprintf("   %s \\\n", shellquote.Join("-H", "Authorization: token "+r.client.opts.AccessToken)))
 	}
 	// Preserve overrides if Content-Type is set
 	if r.client.opts.AdditionalHeaders["Content-Type"] == "" {
 		r.client.opts.AdditionalHeaders["Content-Type"] = "application/json"
 	}
 	for k, v := range r.client.opts.AdditionalHeaders {
-		s += fmt.Sprintf("   %s \\\n", shellquote.Join("-H", k+": "+v))
+		s.WriteString(fmt.Sprintf("   %s \\\n", shellquote.Join("-H", k+": "+v)))
 	}
-	s += fmt.Sprintf("   %s \\\n", shellquote.Join("-d", string(data)))
-	s += fmt.Sprintf("   %s", shellquote.Join(r.client.opts.EndpointURL.JoinPath(".api/graphql").String()))
-	return s, nil
+	s.WriteString(fmt.Sprintf("   %s \\\n", shellquote.Join("-d", string(data))))
+	s.WriteString(fmt.Sprintf("   %s", shellquote.Join(r.client.opts.EndpointURL.JoinPath(".api/graphql").String())))
+	return s.String(), nil
 }

--- a/internal/api/proxy_test.go
+++ b/internal/api/proxy_test.go
@@ -266,10 +266,10 @@ func TestBuildTransport_WithProxyURL(t *testing.T) {
 	insecure := true
 	flags := &Flags{
 		insecureSkipVerify: &insecure,
-		dump:               boolPtr(false),
-		getCurl:            boolPtr(false),
-		trace:              boolPtr(false),
-		userAgentTelemetry: boolPtr(false),
+		dump:               new(false),
+		getCurl:            new(false),
+		trace:              new(false),
+		userAgentTelemetry: new(false),
 	}
 	opts := ClientOpts{
 		ProxyURL: proxyURL,
@@ -296,10 +296,10 @@ func TestBuildTransport_WithProxyPath(t *testing.T) {
 	insecure := true
 	flags := &Flags{
 		insecureSkipVerify: &insecure,
-		dump:               boolPtr(false),
-		getCurl:            boolPtr(false),
-		trace:              boolPtr(false),
-		userAgentTelemetry: boolPtr(false),
+		dump:               new(false),
+		getCurl:            new(false),
+		trace:              new(false),
+		userAgentTelemetry: new(false),
 	}
 	opts := ClientOpts{
 		ProxyPath: socketPath,
@@ -324,10 +324,10 @@ func TestBuildTransport_NoProxyPreservesProxyFunc(t *testing.T) {
 	insecure := true
 	flags := &Flags{
 		insecureSkipVerify: &insecure,
-		dump:               boolPtr(false),
-		getCurl:            boolPtr(false),
-		trace:              boolPtr(false),
-		userAgentTelemetry: boolPtr(false),
+		dump:               new(false),
+		getCurl:            new(false),
+		trace:              new(false),
+		userAgentTelemetry: new(false),
 	}
 	opts := ClientOpts{} // no ProxyURL or ProxyPath
 
@@ -353,10 +353,10 @@ func TestBuildTransport_NOPROXYOverridesHTTPSPROXY(t *testing.T) {
 	insecure := true
 	flags := &Flags{
 		insecureSkipVerify: &insecure,
-		dump:               boolPtr(false),
-		getCurl:            boolPtr(false),
-		trace:              boolPtr(false),
-		userAgentTelemetry: boolPtr(false),
+		dump:               new(false),
+		getCurl:            new(false),
+		trace:              new(false),
+		userAgentTelemetry: new(false),
 	}
 	opts := ClientOpts{} // no ProxyURL or ProxyPath
 
@@ -386,10 +386,10 @@ func TestBuildTransport_ExplicitProxyURLOverridesNOPROXY(t *testing.T) {
 	insecure := true
 	flags := &Flags{
 		insecureSkipVerify: &insecure,
-		dump:               boolPtr(false),
-		getCurl:            boolPtr(false),
-		trace:              boolPtr(false),
-		userAgentTelemetry: boolPtr(false),
+		dump:               new(false),
+		getCurl:            new(false),
+		trace:              new(false),
+		userAgentTelemetry: new(false),
 	}
 	opts := ClientOpts{
 		ProxyURL: proxyURL,
@@ -404,4 +404,5 @@ func TestBuildTransport_ExplicitProxyURLOverridesNOPROXY(t *testing.T) {
 	}
 }
 
-func boolPtr(b bool) *bool { return &b }
+//go:fix inline
+func boolPtr(b bool) *bool { return new(b) }

--- a/internal/api/test_unix_socket_server.go
+++ b/internal/api/test_unix_socket_server.go
@@ -57,9 +57,7 @@ func StartUnixSocketServer(socketPath string) (*Server, error) {
 		StopChan: make(chan struct{}),
 	}
 
-	server.Wg.Add(1)
-	go func() {
-		defer server.Wg.Done()
+	server.Wg.Go(func() {
 		for {
 			conn, err := server.Listener.Accept()
 			if err != nil {
@@ -96,7 +94,7 @@ func StartUnixSocketServer(socketPath string) (*Server, error) {
 				}
 			}(conn)
 		}
-	}()
+	})
 
 	return server, nil
 }

--- a/internal/batches/service/service.go
+++ b/internal/batches/service/service.go
@@ -337,9 +337,7 @@ func (svc *Service) EnsureDockerImages(
 	}
 	var wg sync.WaitGroup
 	for i := 0; i < parallelism; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			for {
 				select {
 				case <-workerCtx.Done():
@@ -363,7 +361,7 @@ func (svc *Service) EnsureDockerImages(
 					}
 				}
 			}
-		}()
+		})
 	}
 
 	go func() {

--- a/internal/streaming/client.go
+++ b/internal/streaming/client.go
@@ -59,13 +59,13 @@ func (rr Decoder) ReadAll(r io.Reader) error {
 		// event: $event\n
 		// data: json($data)\n\n
 		data := scanner.Bytes()
-		nl := bytes.Index(data, []byte("\n"))
-		if nl < 0 {
+		before, after, ok := bytes.Cut(data, []byte("\n"))
+		if !ok {
 			return fmt.Errorf("malformed event, no newline: %s", data)
 		}
 
-		eventK, event := splitColon(data[:nl])
-		dataK, data := splitColon(data[nl+1:])
+		eventK, event := splitColon(before)
+		dataK, data := splitColon(after)
 
 		if !bytes.Equal(eventK, []byte("event")) {
 			return fmt.Errorf("malformed event, expected event: %s", eventK)
@@ -137,11 +137,11 @@ func (rr Decoder) ReadAll(r io.Reader) error {
 }
 
 func splitColon(data []byte) ([]byte, []byte) {
-	i := bytes.Index(data, []byte(":"))
-	if i < 0 {
+	before, after, ok := bytes.Cut(data, []byte(":"))
+	if !ok {
 		return bytes.TrimSpace(data), nil
 	}
-	return bytes.TrimSpace(data[:i]), bytes.TrimSpace(data[i+1:])
+	return bytes.TrimSpace(before), bytes.TrimSpace(after)
 }
 
 type eventMatchUnmarshaller struct {


### PR DESCRIPTION
Upgrades this repository to the latest Go 1.26 release (go1.26.4) across its build,
CI, and release configuration, then runs `go fix ./...` twice (Go 1.26's analyzer-based
modernizers) to apply safe, automatic modernizations enabled by the new language version.

Generated this change with a Sourcegraph batch change.

[_Created by Sourcegraph agentic batch change._](https://sourcegraph.sourcegraph.com/batch-change-agents/172)