### PR TITLE
go: upgrade to Go 1.26 and modernize

### DIFF
--- a/lib/batches/batch_spec.go
+++ b/lib/batches/batch_spec.go
@@ -45,8 +45,8 @@ type BatchSpec struct {
 // Hooks declares side-effect actions to run at well-defined changeset
 // lifecycle events. Only allowed when Version is 3.
 type ChangesetHooks struct {
-	OnCIFailure     ChangesetHookAction `json:"onCIFailure,omitempty" yaml:"onCIFailure,omitempty"`
-	OnMergeConflict ChangesetHookAction `json:"onMergeConflict,omitempty" yaml:"onMergeConflict,omitempty"`
+	OnCIFailure     ChangesetHookAction `json:"onCIFailure" yaml:"onCIFailure,omitempty"`
+	OnMergeConflict ChangesetHookAction `json:"onMergeConflict" yaml:"onMergeConflict,omitempty"`
 }
 
 // HookAction is a single action attached to a changeset lifecycle event.


### PR DESCRIPTION
Upgrades this repository to the latest Go 1.26 release (go1.26.4) across its build,
CI, and release configuration, then runs `go fix ./...` twice (Go 1.26's analyzer-based
modernizers) to apply safe, automatic modernizations enabled by the new language version.

Generated this change with a Sourcegraph batch change.

[_Created by Sourcegraph agentic batch change._](https://sourcegraph.sourcegraph.com/batch-change-agents/172)