### PR TITLE
fix/security: do not serve arbitrary files over network with serve-git

### DIFF
--- a/internal/servegit/serve.go
+++ b/internal/servegit/serve.go
@@ -102,8 +102,6 @@ func (s *Serve) handler() http.Handler {
 		_ = enc.Encode(&resp)
 	})
 
-	safeFS := http.FS(s.RootFS.FS())
-	fs := http.FileServer(safeFS)
 	svc := &Handler{
 		Dir: func(_ context.Context, name string) (string, error) {
 			return filepath.Join(s.Root, filepath.FromSlash(name)), nil
@@ -123,14 +121,17 @@ func (s *Serve) handler() http.Handler {
 		RootFS: s.RootFS,
 	}
 	mux.Handle("/repos/", http.StripPrefix("/repos/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Use git service if git is trying to clone. Otherwise show http.FileServer for convenience
+		// Only serve the smart Git HTTP endpoints used for cloning/fetching.
+		// We deliberately do not fall back to a file server: doing so would
+		// expose arbitrary files under the served root to unauthenticated
+		// clients (see VULN-99 / HackerOne #3814799).
 		for _, suffix := range []string{"/info/refs", "/git-upload-pack"} {
 			if strings.HasSuffix(r.URL.Path, suffix) {
 				svc.ServeHTTP(w, r)
 				return
 			}
 		}
-		fs.ServeHTTP(w, r)
+		http.NotFound(w, r)
 	})))
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/servegit/serve_test.go
+++ b/internal/servegit/serve_test.go
@@ -97,14 +97,15 @@ func testReposHandler(t *testing.T, h http.Handler, repos []Repo) {
 		}
 	}
 
-	// repos page will list the top-level dirs
-	list := get("/repos/")
-	for _, repo := range repos {
-		if path.Dir(repo.URI) != "/repos" {
-			continue
-		}
-		if !strings.Contains(repo.Name, "/") && !strings.Contains(list, repo.Name) {
-			t.Errorf("repos page does not contain substring %q", repo.Name)
+	// Directory browsing under /repos/ is intentionally disabled to avoid
+	// exposing arbitrary files (VULN-99). Only smart Git HTTP endpoints are
+	// served; anything else returns 404.
+	if res, err := http.Get(ts.URL + "/repos/"); err != nil {
+		t.Fatal(err)
+	} else {
+		res.Body.Close()
+		if res.StatusCode != http.StatusNotFound {
+			t.Errorf("GET /repos/ status = %d, want %d", res.StatusCode, http.StatusNotFound)
 		}
 	}
 


### PR DESCRIPTION
# Summary

This PR removes a `http.FileServer` fallback in the `serve-git` command. This fallback allows anyone with network access to the machine running the server to read arbitrary files in the file root, even if they are gitignored or not in a git repository.

### Test plan
- CI
- local e2e test succeeded cloning all of my dev repos:
  - <img width="1051" height="1100" alt="Screenshot 2026-07-07 at 11 04 19 AM" src="https://github.com/user-attachments/assets/419c9a0d-2cbe-4ecb-9ea0-a28b2cc17ab8" />