### PR TITLE
chore: update Go to 1.26.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 #
 # Nothing fancy here: we copy in the source code and build on the Alpine Go
 # image. Refer to .dockerignore to get a sense of what we're not going to copy.
-FROM golang:1.26.4-alpine3.22@sha256:727cfc3c40be55cd1bc9a4a059406b28a059857e3be752aa9d09531e12c20c56 AS builder
+FROM golang:1.26.5-alpine3.23@sha256:622e56dbc11a8cfe87cafa2331e9a201877271cbff918af53d3be315f3da88cc AS builder
 
 COPY . /src
 WORKDIR /src

--- a/dev/vendor-lib.sh
+++ b/dev/vendor-lib.sh
@@ -136,7 +136,7 @@ echo "Creating go.mod file..."
 cat > "$DEST_LIB/go.mod" <<EOF
 module github.com/sourcegraph/sourcegraph/lib
 
-go 1.26.4
+go 1.26.5
 EOF
 
 # Create README.md

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sourcegraph/src-cli
 
-go 1.26.4
+go 1.26.5
 
 require (
 	cloud.google.com/go/storage v1.50.0

--- a/lib/go.mod
+++ b/lib/go.mod
@@ -1,6 +1,6 @@
 module github.com/sourcegraph/sourcegraph/lib
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/Masterminds/semver v1.5.0

--- a/mise.toml
+++ b/mise.toml
@@ -1,4 +1,4 @@
 [tools]
-golang = "1.26.4"
+golang = "1.26.5"
 shfmt = "3.8.0"
 shellcheck = "0.10.0"


### PR DESCRIPTION
Go 1.26.5 fixes CVE-2026-39822 (`os`: root escape via symlink plus trailing slash on Unix) and CVE-2026-42505 (`crypto/tls`), both of which image scans flag against binaries built with Go 1.26.4 — including the `src-cli` binary vendored into the executor images.

This updates the Go version in `mise.toml` (which CI derives its Go version from), `go.mod`, `lib/go.mod`, `dev/vendor-lib.sh`, and the Dockerfile builder image. The `golang:1.26.5` Alpine image is only published on Alpine 3.23, so the builder stage moves from `alpine3.22` to `alpine3.23`; the runtime stage is unchanged.

## Test Plan

- `go build ./cmd/src`
- `go test ./...` passes with Go 1.26.5