### PR TITLE
fix/config: merge env additional headers over config file headers

### DIFF
--- a/cmd/src/main.go
+++ b/cmd/src/main.go
@@ -337,7 +337,23 @@ func readConfig() (*config, error) {
 		}
 	}
 
-	cfg.additionalHeaders = parseAdditionalHeaders()
+	// Merge additional headers from the environment on top of any headers loaded
+	// from the config file, rather than overwriting them. Environment-provided
+	// headers take precedence, consistent with how the access token and endpoint
+	// are overridden above. parseAdditionalHeaders always returns a non-nil map.
+	// Config-file keys are used verbatim, but parseAdditionalHeaders always
+	// lowercases its keys, so normalize the config keys too. Otherwise a
+	// differently-cased config key (e.g. "Authorization") would neither be
+	// overridden by its environment counterpart nor be caught by the
+	// authorization-conflict check below.
+	envHeaders := parseAdditionalHeaders()
+	for k, v := range cfg.additionalHeaders {
+		lk := strings.ToLower(k)
+		if _, ok := envHeaders[lk]; !ok {
+			envHeaders[lk] = v
+		}
+	}
+	cfg.additionalHeaders = envHeaders
 	// Ensure that we're not clashing additonal headers
 	_, hasAuthorizationAdditonalHeader := cfg.additionalHeaders["authorization"]
 	if cfg.accessToken != "" && hasAuthorizationAdditonalHeader {

--- a/cmd/src/main.go
+++ b/cmd/src/main.go
@@ -337,15 +337,8 @@ func readConfig() (*config, error) {
 		}
 	}
 
-	// Merge additional headers from the environment on top of any headers loaded
-	// from the config file, rather than overwriting them. Environment-provided
-	// headers take precedence, consistent with how the access token and endpoint
-	// are overridden above. parseAdditionalHeaders always returns a non-nil map.
-	// Config-file keys are used verbatim, but parseAdditionalHeaders always
-	// lowercases its keys, so normalize the config keys too. Otherwise a
-	// differently-cased config key (e.g. "Authorization") would neither be
-	// overridden by its environment counterpart nor be caught by the
-	// authorization-conflict check below.
+	// Merge config-file headers under the env headers (which take precedence),
+	// lowercasing config keys to match the env-header convention.
 	envHeaders := parseAdditionalHeaders()
 	for k, v := range cfg.additionalHeaders {
 		lk := strings.ToLower(k)

--- a/cmd/src/main_test.go
+++ b/cmd/src/main_test.go
@@ -358,6 +358,63 @@ func TestReadConfig(t *testing.T) {
 				inCI:              true,
 			},
 		},
+		{
+			name: "config file additional headers preserved when endpoint/token from environment",
+			fileContents: &configFromFile{
+				Endpoint:          "https://example.com/",
+				AccessToken:       "deadbeef",
+				AdditionalHeaders: map[string]string{"x-proxy-token": "secret"},
+			},
+			envToken:    "abc",
+			envEndpoint: "https://override.com",
+			want: &config{
+				endpointURL:       &url.URL{Scheme: "https", Host: "override.com"},
+				accessToken:       "abc",
+				additionalHeaders: map[string]string{"x-proxy-token": "secret"},
+			},
+		},
+		{
+			name: "config file additional headers merged with environment headers",
+			fileContents: &configFromFile{
+				Endpoint:          "https://example.com/",
+				AccessToken:       "deadbeef",
+				AdditionalHeaders: map[string]string{"x-proxy-token": "secret"},
+			},
+			envFooHeader: "bar",
+			want: &config{
+				endpointURL:       &url.URL{Scheme: "https", Host: "example.com"},
+				accessToken:       "deadbeef",
+				additionalHeaders: map[string]string{"x-proxy-token": "secret", "foo": "bar"},
+			},
+		},
+		{
+			name: "environment headers override config file headers",
+			fileContents: &configFromFile{
+				Endpoint:          "https://example.com/",
+				AccessToken:       "deadbeef",
+				AdditionalHeaders: map[string]string{"foo": "from-config"},
+			},
+			envFooHeader: "from-env",
+			want: &config{
+				endpointURL:       &url.URL{Scheme: "https", Host: "example.com"},
+				accessToken:       "deadbeef",
+				additionalHeaders: map[string]string{"foo": "from-env"},
+			},
+		},
+		{
+			name: "environment headers override differently-cased config file headers",
+			fileContents: &configFromFile{
+				Endpoint:          "https://example.com/",
+				AccessToken:       "deadbeef",
+				AdditionalHeaders: map[string]string{"Foo": "from-config"},
+			},
+			envFooHeader: "from-env",
+			want: &config{
+				endpointURL:       &url.URL{Scheme: "https", Host: "example.com"},
+				accessToken:       "deadbeef",
+				additionalHeaders: map[string]string{"foo": "from-env"},
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Closes CPL-690

Previously, additional headers provided via the environment (`SRC_HEADER_*` / `SRC_HEADERS`) overwrote any `additionalHeaders` loaded from the config file entirely, silently dropping them. This merges the two sources instead — environment headers take precedence, consistent with how the access token and endpoint are already overridden. Config-file header keys are normalized to lowercase to match the env-header convention, so an environment header correctly overrides a differently-cased config key and the existing authorization-conflict check reliably detects a config-supplied `Authorization` header. The header keys are ultimately applied via `http.Header.Set`, which canonicalizes them, so lowercasing the map keys has no effect on the outgoing request.

### Test plan

Added `TestReadConfig` cases covering: config headers preserved when endpoint/token come from the environment, config and env headers merged together, env headers overriding config headers, and env headers overriding a differently-cased config key. `go test ./cmd/src/` passes.