### PR TITLE
fix(search-jobs): add timeout to authenticated HTTP requests

### DIFF
--- a/cmd/src/search_jobs_logs.go
+++ b/cmd/src/search_jobs_logs.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/sourcegraph/src-cli/internal/api"
 	"github.com/sourcegraph/src-cli/internal/cmderrors"
@@ -24,7 +25,8 @@ func fetchJobLogs(jobID string, logURL string) (io.ReadCloser, error) {
 
 	req.Header.Add("Authorization", "token "+cfg.accessToken)
 
-	resp, err := http.DefaultClient.Do(req)
+	client := &http.Client{Timeout: 60 * time.Second}
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/src/search_jobs_results.go
+++ b/cmd/src/search_jobs_results.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/sourcegraph/src-cli/internal/api"
 	"github.com/sourcegraph/src-cli/internal/cmderrors"
@@ -24,7 +25,8 @@ func fetchJobResults(jobID string, resultsURL string) (io.ReadCloser, error) {
 
 	req.Header.Add("Authorization", "token "+cfg.accessToken)
 
-	resp, err := http.DefaultClient.Do(req)
+	client := &http.Client{Timeout: 60 * time.Second}
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
fetchJobLogs and fetchJobResults both issue authenticated GETs via http.DefaultClient, which has no timeout. A slow or unresponsive Sourcegraph instance will stall the CLI indefinitely while the connection stays open with the caller's access token attached. Replaced the bare DefaultClient with a local http.Client{Timeout: 60 * time.Second} in both callers.