### PR TITLE
fix/serve-git: reject gitdir file repository targets

### DIFF
--- a/internal/servegit/gitservice.go
+++ b/internal/servegit/gitservice.go
@@ -105,11 +105,16 @@ func (s *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "invalid path specified: "+err.Error(), http.StatusBadRequest)
 		return
 	}
-	if _, err = s.RootFS.Stat(relDir); os.IsNotExist(err) {
+	info, err := s.RootFS.Stat(relDir)
+	if os.IsNotExist(err) {
 		http.Error(w, "repository not found", http.StatusNotFound)
 		return
 	} else if err != nil {
 		http.Error(w, "failed to stat repo: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if !info.IsDir() {
+		http.Error(w, "repository not found", http.StatusNotFound)
 		return
 	}
 

--- a/internal/servegit/serve_test.go
+++ b/internal/servegit/serve_test.go
@@ -69,6 +69,52 @@ func TestReposHandler(t *testing.T) {
 	}
 }
 
+func TestHandlerRejectsGitdirFile(t *testing.T) {
+	root := t.TempDir()
+	servedRoot := filepath.Join(root, "served")
+	publicRepo := filepath.Join(servedRoot, "public")
+	privateRepo := filepath.Join(root, "private")
+	for _, repo := range []string{publicRepo, privateRepo} {
+		if err := os.MkdirAll(repo, 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	gitInit(t, publicRepo)
+	gitInit(t, privateRepo)
+
+	pointer := filepath.Join(publicRepo, "gitdir-pointer")
+	if err := os.WriteFile(pointer, []byte("gitdir: ../../private/.git\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	runCmd(t, publicRepo, "git", "add", "gitdir-pointer")
+	runCmd(t, publicRepo, "git", "commit", "-m", "add gitdir pointer")
+	runCmd(t, privateRepo, "git", "commit", "--allow-empty", "-m", "private commit")
+	// Git accepts this ordinary tracked file as a repository and follows its
+	// gitdir pointer outside servedRoot.
+	runCmd(t, publicRepo, "git", "upload-pack", "--strict", "--advertise-refs", pointer)
+
+	rootFS, err := os.OpenRoot(servedRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { rootFS.Close() })
+
+	h := (&Serve{
+		Info:   testLogger(t),
+		Debug:  discardLogger,
+		Addr:   testAddress,
+		Root:   servedRoot,
+		RootFS: rootFS,
+	}).handler()
+	req := httptest.NewRequest(http.MethodGet, "/repos/public/gitdir-pointer/info/refs?service=git-upload-pack", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("gitdir file status = %d, want %d; body: %s", rec.Code, http.StatusNotFound, rec.Body.String())
+	}
+}
+
 func testReposHandler(t *testing.T, h http.Handler, repos []Repo) {
 	ts := httptest.NewServer(h)
 	t.Cleanup(ts.Close)


### PR DESCRIPTION
## Problem
This was brought to our attention via a [HackerOne](https://linear.app/sourcegraph/issue/VULN-137/a-tracked-gitdir-file-escapes-the-serve-git-root-and-exposes-a-private) report.

`src serve-git` accepted regular files as repository targets. Git can interpret a regular file containing a `gitdir:` pointer and follow it outside the configured serve root, which could expose a private repository.

## Solution

Require smart HTTP repository targets to be directories before invoking Git. Return a not-found response for regular files, including `gitdir:` pointer files.

Add a regression test that confirms Git accepts the pointer file directly but `src serve-git` rejects the same file over HTTP.

## Verification Evidence

- `go test ./internal/servegit -count=1`
- `go test ./cmd/src -run '^$'`