### PR TITLE
fix/batches: reject Git metadata in repository archives

### DIFF
--- a/internal/batches/workspace/bind_workspace.go
+++ b/internal/batches/workspace/bind_workspace.go
@@ -206,6 +206,15 @@ func unzip(ctx context.Context, zipFile, dest string) error {
 			return fmt.Errorf("%s: illegal file path", fpath)
 		}
 
+		relativePath, err := filepath.Rel(dest, fpath)
+		if err != nil {
+			return err
+		}
+		firstPathElement, _, _ := strings.Cut(relativePath, string(os.PathSeparator))
+		if strings.EqualFold(firstPathElement, ".git") {
+			return fmt.Errorf("%s: repository archive contains Git metadata", f.Name)
+		}
+
 		if f.FileInfo().IsDir() {
 			if err := mkdirAll(dest, f.Name, 0777); err != nil {
 				return err

--- a/internal/batches/workspace/bind_workspace_test.go
+++ b/internal/batches/workspace/bind_workspace_test.go
@@ -143,6 +143,29 @@ func TestDockerBindWorkspaceCreator_Create(t *testing.T) {
 	})
 }
 
+func TestUnzipRejectsGitMetadata(t *testing.T) {
+	for _, name := range []string{
+		".git/config",
+		".git/hooks/pre-commit",
+		"dir/../.git/config",
+		".GIT/config",
+	} {
+		t.Run(name, func(t *testing.T) {
+			archivePath := zipUpFiles(t, t.TempDir(), map[string]string{name: "malicious"})
+			dest := t.TempDir()
+
+			err := unzip(context.Background(), archivePath, dest)
+			if err == nil || !strings.Contains(err.Error(), "repository archive contains Git metadata") {
+				t.Fatalf("expected Git metadata error, got %v", err)
+			}
+
+			if _, err := os.Stat(filepath.Join(dest, ".git")); !os.IsNotExist(err) {
+				t.Fatalf("expected .git not to be extracted, got %v", err)
+			}
+		})
+	}
+}
+
 func TestDockerBindWorkspace_ApplyDiff(t *testing.T) {
 	// Create a zip file for all the other tests to use.
 	fakeFilesTmpDir := t.TempDir()


### PR DESCRIPTION
## Problem

This was brought to our attention via [HackerOne](https://linear.app/sourcegraph/issue/VULN-142/a-repository-archive-containing-githookspre-commit-achieves-code).

A repository archive could include a `.git` directory. During bind workspace setup, src extracted this directory and then ran Git commands on the host. Malicious Git hooks or repository configuration could therefore run code on the host.

## Solution

Reject archive entries that resolve inside the root `.git` directory. The check also handles normalized paths and case-insensitive filesystems.

## Verification Evidence

- `go test ./internal/batches/workspace`
- `go test ./internal/batches/...`
- Added tests for malicious hooks, repository configuration, normalized paths, and case variants.