### PR TITLE
fix/batches: prevent repository archives from enabling Git hooks

### DIFF
--- a/internal/batches/workspace/bind_workspace.go
+++ b/internal/batches/workspace/bind_workspace.go
@@ -190,6 +190,15 @@ func unzip(ctx context.Context, zipFile, dest string) error {
 	}
 	defer r.Close()
 
+	for _, f := range r.File {
+		// ZIP paths use forward slashes on every platform. Reject backslashes
+		// rather than letting Windows reinterpret a filename from a Unix
+		// repository as a directory hierarchy.
+		if strings.ContainsRune(f.Name, '\\') {
+			return fmt.Errorf("%q: illegal file path", f.Name)
+		}
+	}
+
 	outputBase := filepath.Clean(dest) + string(os.PathSeparator)
 
 	for _, f := range r.File {

--- a/internal/batches/workspace/bind_workspace_test.go
+++ b/internal/batches/workspace/bind_workspace_test.go
@@ -166,6 +166,54 @@ func TestUnzipRejectsGitMetadata(t *testing.T) {
 	}
 }
 
+func TestUnzipRejectsUnsafeArchivePaths(t *testing.T) {
+	tests := []string{
+		`.git\config`,
+		`hooks\pre-commit`,
+	}
+
+	for _, name := range tests {
+		t.Run(name, func(t *testing.T) {
+			archivePath := zipUpFiles(t, t.TempDir(), map[string]string{name: "malicious"})
+			dest := t.TempDir()
+
+			if err := unzip(context.Background(), archivePath, dest); err == nil {
+				t.Fatal("expected unsafe archive path to be rejected")
+			}
+
+			entries, err := os.ReadDir(dest)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(entries) != 0 {
+				t.Fatalf("archive was partially extracted: %v", entries)
+			}
+		})
+	}
+}
+
+func TestUnzipAllowsSafeControlPaths(t *testing.T) {
+	files := map[string]string{
+		".git_config":      "config",
+		"hooks_pre-commit": "hook",
+	}
+	archivePath := zipUpFiles(t, t.TempDir(), files)
+	dest := t.TempDir()
+
+	if err := unzip(context.Background(), archivePath, dest); err != nil {
+		t.Fatal(err)
+	}
+	for name, want := range files {
+		have, err := os.ReadFile(filepath.Join(dest, name))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(have) != want {
+			t.Errorf("%s: got %q, want %q", name, have, want)
+		}
+	}
+}
+
 func TestDockerBindWorkspace_ApplyDiff(t *testing.T) {
 	// Create a zip file for all the other tests to use.
 	fakeFilesTmpDir := t.TempDir()

--- a/internal/batches/workspace/git.go
+++ b/internal/batches/workspace/git.go
@@ -9,6 +9,9 @@ import (
 )
 
 func runGitCmd(ctx context.Context, dir string, args ...string) ([]byte, error) {
+	// Repository contents are untrusted. Keep hooks disabled even if a command
+	// encounters an attacker-controlled local Git configuration.
+	args = append([]string{"-c", "core.hooksPath=/dev/null"}, args...)
 	cmd := exec.CommandContext(ctx, "git", args...)
 	cmd.Env = []string{
 		// Don't use the system wide git config.

--- a/internal/batches/workspace/git_test.go
+++ b/internal/batches/workspace/git_test.go
@@ -1,0 +1,46 @@
+package workspace
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRunGitCmdDisablesHooks(t *testing.T) {
+	dir := t.TempDir()
+	ctx := context.Background()
+
+	if _, err := runGitCmd(ctx, dir, "init", "--quiet"); err != nil {
+		t.Fatal(err)
+	}
+	config, err := os.OpenFile(filepath.Join(dir, ".git", "config"), os.O_APPEND|os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := config.WriteString("[core]\n\thooksPath = hooks\n"); err != nil {
+		t.Fatal(err)
+	}
+	if err := config.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(dir, "hooks"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "hooks", "pre-commit"), []byte("#!/bin/sh\necho hook-ran > hook-ran\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("test\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := runGitCmd(ctx, dir, "add", "README.md"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runGitCmd(ctx, dir, "commit", "--quiet", "-m", "test"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "hook-ran")); !os.IsNotExist(err) {
+		t.Fatalf("pre-commit hook ran: %v", err)
+	}
+}


### PR DESCRIPTION
## Problem

This issue was brought to our attention via [HackerOne](https://linear.app/sourcegraph/issue/VULN-146/i-can-turn-committed-backslash-filenames-into-host-git-hooks-on).

On Windows, Git repository archive names can contain backslashes that are treated as directory separators during extraction. This can place repository files in Git metadata paths and allow a host-side Git hook to run before the batch step starts.

## Solution

Reject archive names that contain backslashes before extracting any files. Also disable hooks for every host-side Git command as a second layer of protection.

This change is intended to merge after #1366, which rejects archive entries that resolve to `.git` paths.

## Verification Evidence

- `go test ./internal/batches/...`
- Windows test binary cross-compiled with `GOOS=windows GOARCH=amd64 go test -c ./internal/batches/workspace`