### PR TITLE
fix/docs: Fix spelling errors in the documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ All notable changes to `src-cli` are documented in this file.
 
 ### Added
 
-- SBOM support: Added `--image` and `--exclude-image` flags to `src sbom fetch` for filtering which docker images SBOMs are fetched for. Both flags support glob patterns (e.g., `frontend`, `*api*`) and comma-separated lists. The `sourcegraph/` image name prefix is optional.
+- SBOM support: Added `--image` and `--exclude-image` flags to `src sbom fetch` for filtering which Docker images SBOMs are fetched for. Both flags support glob patterns (e.g., `frontend`, `*api*`) and comma-separated lists. The `sourcegraph/` image name prefix is optional.
 
 ### Changed
 
@@ -88,7 +88,7 @@ All notable changes to `src-cli` are documented in this file.
 ## 5.10.0
 
 - cody gateway benchmark changes
-- fix local builds for non sourcegraph team [1121](https://github.com/sourcegraph/src-cli/pull/1121)
+- fix local builds for non Sourcegraph team [1121](https://github.com/sourcegraph/src-cli/pull/1121)
 
 ## 5.9.1
 
@@ -166,7 +166,7 @@ All notable changes to `src-cli` are documented in this file.
 
 ### Fixed
 
-- The fork attribute in changesetTemplate is now acknowleged when creating a batch change via `src-cli`. [#58156](https://github.com/sourcegraph/sourcegraph/pull/58156)
+- The fork attribute in changesetTemplate is now acknowledged when creating a batch change via `src-cli`. [#58156](https://github.com/sourcegraph/sourcegraph/pull/58156)
 
 ## 5.2.0
 
@@ -182,7 +182,7 @@ All notable changes to `src-cli` are documented in this file.
 
 ### Fixed
 
-- The temporary docker volume created during workspace preparation is now cleaned up when failure occurs. [#1021](https://github.com/sourcegraph/src-cli/pull/1021).
+- The temporary Docker volume created during workspace preparation is now cleaned up when failure occurs. [#1021](https://github.com/sourcegraph/src-cli/pull/1021).
 
 ## 5.1.1
 
@@ -268,7 +268,7 @@ No noteworthy changes, mechanical release to match Sourcegraph release.
 
 ### Fixed
 
-- Fix network timeout in `src users clean` occuring in instances with many users [#901](https://github.com/sourcegraph/src-cli/pull/901)
+- Fix network timeout in `src users clean` occurring in instances with many users [#901](https://github.com/sourcegraph/src-cli/pull/901)
 - Aligned parsing of spec file parameter of `src batch repos` with other commands. [#919](https://github.com/sourcegraph/src-cli/pull/919)
 - Remove empty log outputs during batch spec execution. [#923](https://github.com/sourcegraph/src-cli/pull/923)
 
@@ -280,7 +280,7 @@ No noteworthy changes, mechanical release to match Sourcegraph release.
 
 ### Added
 
-- Batch Changes: Watchdog that checks for docker responsiveness while running commands has been added. [#898](https://github.com/sourcegraph/src-cli/pull/898)
+- Batch Changes: Watchdog that checks for Docker responsiveness while running commands has been added. [#898](https://github.com/sourcegraph/src-cli/pull/898)
 
 ## 4.2.1
 
@@ -309,7 +309,7 @@ No noteworthy changes, mechanical release to match Sourcegraph release.
 
 ### Changed
 
-- Improved output for failing docker pulls in batch change execution. [#880](https://github.com/sourcegraph/src-cli/pull/880)
+- Improved output for failing Docker pulls in batch change execution. [#880](https://github.com/sourcegraph/src-cli/pull/880)
 
 ## 4.1.0
 
@@ -796,7 +796,7 @@ Re-release of 3.29.3 for Sourcegraph 3.30.
 
 ### Fixed
 
-- When specifying `-skip-errors`, the batch spec would always be empty. This ix fixed and the intended behavior has been restored. [#539](https://github.com/sourcegraph/src-cli/pull/539)
+- When specifying `-skip-errors`, the batch spec would always be empty. This is fixed and the intended behavior has been restored. [#539](https://github.com/sourcegraph/src-cli/pull/539)
 
 ## 3.27.0
 
@@ -871,13 +871,13 @@ Re-release of 3.29.3 for Sourcegraph 3.30.
 
 ### Fixed
 
-- The homebrew recipe for `src-cli` contained the wrong binary name.
+- The Homebrew recipe for `src-cli` contained the wrong binary name.
 
 ## 3.24.6
 
 ### Fixed
 
-- Workspaces could sometimes fail with docker bind mount errors, due to a race condition of multiple workspaces accessing the same auxilliary files. [#468](https://github.com/sourcegraph/src-cli/pull/468)
+- Workspaces could sometimes fail with Docker bind mount errors, due to a race condition of multiple workspaces accessing the same auxiliary files. [#468](https://github.com/sourcegraph/src-cli/pull/468)
 
 ## 3.24.5
 
@@ -1153,7 +1153,7 @@ Re-release of 3.29.3 for Sourcegraph 3.30.
 
 - Add `--no-progress` flag to the `lsif upload` command to disable verbose output in non-TTY environments.
 - `SRC_HEADER_AUTHORIZATION="Bearer $(...)"` is now supported for authenticating `src` with custom auth proxies. See [auth proxy configuration docs](AUTH_PROXY.md) for more information. [#239](https://github.com/sourcegraph/src-cli/pull/239)
-- Pull missing docker images automatically. [#191](https://github.com/sourcegraph/src-cli/pull/191)
+- Pull missing Docker images automatically. [#191](https://github.com/sourcegraph/src-cli/pull/191)
 - Searches that result in errors will now display any alerts returned by Sourcegraph, including suggestions for how the search could be corrected. [#221](https://github.com/sourcegraph/src-cli/pull/221)
 
 ### Changed


### PR DESCRIPTION
Corrections were produced by running [codespell](https://github.com/codespell-project/codespell) over the repository's hand-written Markdown, then reviewing every proposed change in context so that code samples, CLI flags, config keys, YAML keys and values, URLs, identifiers, and quoted output were left untouched. Only spelling is changed; no wording, formatting, or content was otherwise altered.

Files that are generated or vendored are skipped, since fixes there would be overwritten. Where a generated file has a checked-in source, the source is corrected and the generated output is regenerated so the two stay in sync.

[_Created by a Sourcegraph agentic batch change._](https://sourcegraph.sourcegraph.com/batch-change-agents/1136)