### PR TITLE
fix/batches: prevent Git commondir config bypass

### DIFF
--- a/internal/batches/workspace/bind_workspace_test.go
+++ b/internal/batches/workspace/bind_workspace_test.go
@@ -195,7 +195,8 @@ func TestDockerBindWorkspace_DiffRestoresTrustedGitConfig(t *testing.T) {
 	}
 
 	dir := *workspace.WorkDir()
-	configPath := filepath.Join(dir, ".git", "config")
+	dotGit := filepath.Join(dir, ".git")
+	configPath := filepath.Join(dotGit, "config")
 	trustedConfig, err := os.ReadFile(configPath)
 	if err != nil {
 		t.Fatal(err)
@@ -208,6 +209,26 @@ func TestDockerBindWorkspace_DiffRestoresTrustedGitConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err := config.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// A commondir file redirects Git to the config in another directory. That
+	// config must not survive metadata restoration and reach host-side Git.
+	attackerCommon := filepath.Join(dir, "attacker-common")
+	if err := os.CopyFS(attackerCommon, os.DirFS(dotGit)); err != nil {
+		t.Fatal(err)
+	}
+	attackerConfig, err := os.OpenFile(filepath.Join(attackerCommon, "config"), os.O_APPEND|os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := attackerConfig.WriteString("[filter \"attack\"]\n\tclean = command-that-must-not-run\n\trequired = true\n"); err != nil {
+		t.Fatal(err)
+	}
+	if err := attackerConfig.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dotGit, "commondir"), []byte("../attacker-common\n"), 0644); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(dir, ".gitattributes"), []byte("*.txt filter=attack\n"), 0644); err != nil {
@@ -230,6 +251,9 @@ func TestDockerBindWorkspace_DiffRestoresTrustedGitConfig(t *testing.T) {
 	}
 	if !cmp.Equal(restoredConfig, trustedConfig) {
 		t.Fatalf("Git config was not restored:\n%s", cmp.Diff(string(trustedConfig), string(restoredConfig)))
+	}
+	if _, err := os.Stat(filepath.Join(dotGit, "commondir")); !os.IsNotExist(err) {
+		t.Fatalf("untrusted commondir was not removed: %v", err)
 	}
 }
 

--- a/internal/batches/workspace/git.go
+++ b/internal/batches/workspace/git.go
@@ -13,6 +13,7 @@ import (
 
 type gitMetadataSnapshot struct {
 	dotGit         *gitControlFile
+	commonDir      *gitControlFile
 	config         *gitControlFile
 	configWorktree *gitControlFile
 }
@@ -34,7 +35,10 @@ func snapshotGitMetadata(dir string) (*gitMetadataSnapshot, error) {
 	case info.Mode().IsRegular():
 		snapshot.dotGit, err = snapshotGitControlFile(dotGit)
 	case info.IsDir():
-		snapshot.config, err = snapshotGitControlFile(filepath.Join(dotGit, "config"))
+		snapshot.commonDir, err = snapshotOptionalGitControlFile(filepath.Join(dotGit, "commondir"))
+		if err == nil {
+			snapshot.config, err = snapshotGitControlFile(filepath.Join(dotGit, "config"))
+		}
 		if err == nil {
 			snapshot.configWorktree, err = snapshotOptionalGitControlFile(filepath.Join(dotGit, "config.worktree"))
 		}
@@ -86,6 +90,11 @@ func (s *gitMetadataSnapshot) restore(dir string) error {
 	}
 	if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
 		return fmt.Errorf("%s is no longer a directory", dotGit)
+	}
+	// commondir changes which repository config Git reads. Restore it before
+	// any host-side Git command can follow an attacker-controlled redirect.
+	if err := restoreGitControlFile(filepath.Join(dotGit, "commondir"), s.commonDir); err != nil {
+		return err
 	}
 	if err := restoreGitControlFile(filepath.Join(dotGit, "config"), s.config); err != nil {
 		return err


### PR DESCRIPTION
## Problem

A batch container can create a `.git/commondir` file that points Git to an attacker-controlled directory. The existing metadata restoration only restores `.git/config` and `.git/config.worktree`, so host-side Git commands can still read malicious configuration from the redirected directory. A malicious clean filter can then run code on the host outside the container.

This fixes [VULN-153](https://linear.app/sourcegraph/issue/VULN-153/gitcommondir-bypasses-git-config-restoration-and-achieves-host-rce).

## Solution

Snapshot `.git/commondir` with the other trusted Git control files and restore it before every host-side Git command. If the original repository did not have a `commondir` file, an injected file is removed before Git runs.

The regression test creates an attacker-controlled common directory with a malicious clean filter and verifies that diff generation uses the trusted Git configuration instead.

## Verification Evidence

- `go test ./internal/batches/workspace -count=1`
- `go test ./internal/batches/...`
- `git diff --check`