### PR TITLE
fix/batches: prevent workspace path injection

### DIFF
--- a/internal/batches/docker/mount.go
+++ b/internal/batches/docker/mount.go
@@ -1,0 +1,24 @@
+package docker
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+// BindMount returns a Docker bind mount specification after checking that its
+// values cannot inject fields into Docker's comma-delimited mount grammar.
+func BindMount(source, target string, readOnly bool) (string, error) {
+	for name, value := range map[string]string{"source": source, "target": target} {
+		if value == "" || strings.ContainsAny(value, ",\r\n\x00") {
+			return "", errors.Newf("invalid Docker mount %s %q", name, value)
+		}
+	}
+
+	mount := fmt.Sprintf("type=bind,source=%s,target=%s", source, target)
+	if readOnly {
+		mount += ",ro"
+	}
+	return mount, nil
+}

--- a/internal/batches/docker/mount_test.go
+++ b/internal/batches/docker/mount_test.go
@@ -1,0 +1,56 @@
+package docker
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBindMount(t *testing.T) {
+	tests := []struct {
+		name     string
+		source   string
+		target   string
+		readOnly bool
+		want     string
+		wantErr  bool
+	}{
+		{
+			name:   "writable",
+			source: "/tmp/workspace",
+			target: "/work",
+			want:   "type=bind,source=/tmp/workspace,target=/work",
+		},
+		{
+			name:     "read-only",
+			source:   "/tmp/archive",
+			target:   "/tmp/archive",
+			readOnly: true,
+			want:     "type=bind,source=/tmp/archive,target=/tmp/archive,ro",
+		},
+		{
+			name:    "source injection",
+			source:  "/tmp/archive,source=/etc",
+			target:  "/tmp/archive",
+			wantErr: true,
+		},
+		{
+			name:    "target injection",
+			source:  "/tmp/archive",
+			target:  "/tmp/archive,source=/etc",
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := BindMount(test.source, test.target, test.readOnly)
+			if test.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, test.want, got)
+		})
+	}
+}

--- a/internal/batches/executor/run_steps.go
+++ b/internal/batches/executor/run_steps.go
@@ -21,6 +21,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/batches/template"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 
+	"github.com/sourcegraph/src-cli/internal/batches/docker"
 	"github.com/sourcegraph/src-cli/internal/batches/log"
 	"github.com/sourcegraph/src-cli/internal/batches/repozip"
 	"github.com/sourcegraph/src-cli/internal/batches/util"
@@ -353,7 +354,7 @@ func executeSingleStep(
 	if err := validateContainerTempPath(containerTemp); err != nil {
 		return bytes.Buffer{}, bytes.Buffer{}, errors.Wrap(err, "validating run script target")
 	}
-	runScriptMount, err := dockerBindMount(runScriptFile, containerTemp)
+	runScriptMount, err := docker.BindMount(runScriptFile, containerTemp, true)
 	if err != nil {
 		return bytes.Buffer{}, bytes.Buffer{}, errors.Wrap(err, "creating run script mount")
 	}
@@ -372,7 +373,7 @@ func executeSingleStep(
 	}
 
 	for target, source := range filesToMount {
-		mountArg, err := dockerBindMount(source.Name(), target)
+		mountArg, err := docker.BindMount(source.Name(), target, true)
 		if err != nil {
 			return bytes.Buffer{}, bytes.Buffer{}, errors.Wrap(err, "creating files mount")
 		}
@@ -385,7 +386,7 @@ func executeSingleStep(
 		if err != nil {
 			return bytes.Buffer{}, bytes.Buffer{}, err
 		}
-		mountArg, err := dockerBindMount(workspaceFilePath, mount.Mountpoint)
+		mountArg, err := docker.BindMount(workspaceFilePath, mount.Mountpoint, true)
 		if err != nil {
 			return bytes.Buffer{}, bytes.Buffer{}, errors.Wrap(err, "creating host mount")
 		}
@@ -567,15 +568,6 @@ func validateContainerTempPath(tempfile string) error {
 		return errors.Newf("mktemp returned invalid path %q", tempfile)
 	}
 	return nil
-}
-
-func dockerBindMount(source, target string) (string, error) {
-	for name, value := range map[string]string{"source": source, "target": target} {
-		if value == "" || strings.ContainsAny(value, ",\r\n\x00") {
-			return "", errors.Newf("invalid Docker mount %s %q", name, value)
-		}
-	}
-	return fmt.Sprintf("type=bind,source=%s,target=%s,ro", source, target), nil
 }
 
 // createFilesToMount creates temporary files with the contents of Step.Files

--- a/internal/batches/executor/run_steps_test.go
+++ b/internal/batches/executor/run_steps_test.go
@@ -56,11 +56,6 @@ func TestProbeImageForShellRejectsMountInjection(t *testing.T) {
 	require.Contains(t, err.Error(), "mktemp returned invalid path")
 }
 
-func TestDockerBindMountRejectsMountGrammar(t *testing.T) {
-	_, err := dockerBindMount("/tmp/script", "/tmp/x,source=/var/run/docker.sock")
-	require.Error(t, err)
-}
-
 func TestCreateFilesToMount_RejectsCommaInTargetPath(t *testing.T) {
 	step := batcheslib.Step{
 		Files: map[string]string{

--- a/internal/batches/workspace/bind_workspace.go
+++ b/internal/batches/workspace/bind_workspace.go
@@ -13,6 +13,7 @@ import (
 	batcheslib "github.com/sourcegraph/sourcegraph/lib/batches"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 
+	"github.com/sourcegraph/src-cli/internal/batches/docker"
 	"github.com/sourcegraph/src-cli/internal/batches/graphql"
 	"github.com/sourcegraph/src-cli/internal/batches/repozip"
 	"github.com/sourcegraph/src-cli/internal/batches/util"
@@ -77,6 +78,10 @@ func (wc *dockerBindWorkspaceCreator) unzipToWorkspace(ctx context.Context, repo
 
 func (wc *dockerBindWorkspaceCreator) copyToWorkspace(ctx context.Context, w *dockerBindWorkspace, files map[string]string) error {
 	for name, src := range files {
+		if err := validateWorkspaceFileName(name); err != nil {
+			return err
+		}
+
 		srcStat, err := os.Stat(src)
 		if err != nil {
 			return err
@@ -91,7 +96,7 @@ func (wc *dockerBindWorkspaceCreator) copyToWorkspace(ctx context.Context, w *do
 			return err
 		}
 
-		destPath := path.Join(w.dir, name)
+		destPath := filepath.Join(w.dir, filepath.FromSlash(name))
 
 		destFile, err := prepareCopyDestinationFile(srcStat, destPath)
 		if err != nil {
@@ -136,10 +141,27 @@ func (w *dockerBindWorkspace) Close(ctx context.Context) error {
 }
 
 func (w *dockerBindWorkspace) DockerRunOpts(ctx context.Context, target string) ([]string, error) {
+	mount, err := docker.BindMount(w.dir, target, false)
+	if err != nil {
+		return nil, err
+	}
 	return []string{
 		"--mount",
-		fmt.Sprintf("type=bind,source=%s,target=%s", w.dir, target),
+		mount,
 	}, nil
+}
+
+func validateWorkspaceFileName(name string) error {
+	clean := path.Clean(name)
+	if path.IsAbs(name) || clean == ".." || strings.HasPrefix(clean, "../") {
+		return errors.Newf("workspace file path %q is outside the workspace", name)
+	}
+
+	native := filepath.Clean(filepath.FromSlash(name))
+	if filepath.IsAbs(native) || filepath.VolumeName(native) != "" || native == ".." || strings.HasPrefix(native, ".."+string(os.PathSeparator)) {
+		return errors.Newf("workspace file path %q is outside the workspace", name)
+	}
+	return nil
 }
 
 func (w *dockerBindWorkspace) WorkDir() *string { return &w.dir }

--- a/internal/batches/workspace/bind_workspace_test.go
+++ b/internal/batches/workspace/bind_workspace_test.go
@@ -143,6 +143,41 @@ func TestDockerBindWorkspaceCreator_Create(t *testing.T) {
 	})
 }
 
+func TestCopyToWorkspaceRejectsPathTraversal(t *testing.T) {
+	root := t.TempDir()
+	workspaceDir := filepath.Join(root, "workspace")
+	if err := os.Mkdir(workspaceDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	victimDir := filepath.Join(root, "victim")
+	if err := os.Mkdir(victimDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	source := filepath.Join(root, "source")
+	if err := os.WriteFile(source, []byte("attacker content"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	creator := &dockerBindWorkspaceCreator{}
+	workspace := &dockerBindWorkspace{dir: workspaceDir}
+	err := creator.copyToWorkspace(context.Background(), workspace, map[string]string{
+		"../victim/.gitignore": source,
+	})
+	if err == nil || !strings.Contains(err.Error(), "outside the workspace") {
+		t.Fatalf("expected path traversal error, got %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(victimDir, ".gitignore")); !os.IsNotExist(err) {
+		t.Fatalf("file was written outside the workspace: %v", err)
+	}
+	info, err := os.Stat(victimDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0700 {
+		t.Fatalf("outside directory permissions changed: got %o, want 700", got)
+	}
+}
+
 func TestPrepareGitRepoRemovesUntrustedGitMetadata(t *testing.T) {
 	dir := t.TempDir()
 	dotGit := filepath.Join(dir, ".git")

--- a/internal/batches/workspace/bind_workspace_test.go
+++ b/internal/batches/workspace/bind_workspace_test.go
@@ -153,6 +153,10 @@ func TestCopyToWorkspaceRejectsPathTraversal(t *testing.T) {
 	if err := os.Mkdir(victimDir, 0700); err != nil {
 		t.Fatal(err)
 	}
+	before, err := os.Stat(victimDir)
+	if err != nil {
+		t.Fatal(err)
+	}
 	source := filepath.Join(root, "source")
 	if err := os.WriteFile(source, []byte("attacker content"), 0600); err != nil {
 		t.Fatal(err)
@@ -160,7 +164,7 @@ func TestCopyToWorkspaceRejectsPathTraversal(t *testing.T) {
 
 	creator := &dockerBindWorkspaceCreator{}
 	workspace := &dockerBindWorkspace{dir: workspaceDir}
-	err := creator.copyToWorkspace(context.Background(), workspace, map[string]string{
+	err = creator.copyToWorkspace(context.Background(), workspace, map[string]string{
 		"../victim/.gitignore": source,
 	})
 	if err == nil || !strings.Contains(err.Error(), "outside the workspace") {
@@ -173,8 +177,8 @@ func TestCopyToWorkspaceRejectsPathTraversal(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got := info.Mode().Perm(); got != 0700 {
-		t.Fatalf("outside directory permissions changed: got %o, want 700", got)
+	if got, want := info.Mode().Perm(), before.Mode().Perm(); got != want {
+		t.Fatalf("outside directory permissions changed: got %o, want %o", got, want)
 	}
 }
 

--- a/internal/batches/workspace/volume_workspace.go
+++ b/internal/batches/workspace/volume_workspace.go
@@ -111,6 +111,10 @@ git commit --quiet --all --allow-empty -m src-action-exec
 func (wc *dockerVolumeWorkspaceCreator) unzipRepoIntoVolume(ctx context.Context, w *dockerVolumeWorkspace, zip string) error {
 	// We want to mount that temporary file into a Docker container that has the
 	// workspace volume attached, and unzip it into the volume.
+	zipMount, err := docker.BindMount(zip, "/tmp/zip", true)
+	if err != nil {
+		return errors.Wrap(err, "creating archive mount")
+	}
 
 	// We need to keep a temporary file in the volume before unzipping for the
 	// permissions to persist because... reasons. Rather than reading the
@@ -156,7 +160,7 @@ func (wc *dockerVolumeWorkspaceCreator) unzipRepoIntoVolume(ctx context.Context,
 		"--rm",
 		"--init",
 		"--workdir", "/work",
-		"--mount", "type=bind,source=" + zip + ",target=/tmp/zip,ro",
+		"--mount", zipMount,
 	}, w.dockerRunOptsWithUser(w.uidGid, "/work")...)
 	opts = append(
 		opts,
@@ -194,12 +198,19 @@ func (wc *dockerVolumeWorkspaceCreator) copyFilesIntoVolumes(ctx context.Context
 
 	var copyArgs []string
 	for i, name := range names {
+		if err := validateWorkspaceFileName(name); err != nil {
+			return err
+		}
 		localPath := files[name]
 		// Names originate from the Sourcegraph instance. Keep them out of both
 		// Docker's comma-delimited mount grammar and the shell program.
 		mountTarget := fmt.Sprintf("/tmp/src-additional-file-%d", i)
+		mount, err := docker.BindMount(localPath, mountTarget, true)
+		if err != nil {
+			return errors.Wrap(err, "creating additional file mount")
+		}
 		opts = append(opts, []string{
-			"--mount", "type=bind,source=" + localPath + ",target=" + mountTarget + ",ro",
+			"--mount", mount,
 		}...)
 
 		copyArgs = append(copyArgs, mountTarget, "/work/"+name)
@@ -332,12 +343,17 @@ func (w *dockerVolumeWorkspace) runScript(ctx context.Context, target, script st
 		return nil, errors.Wrap(err, "generating run options")
 	}
 
+	scriptMount, err := docker.BindMount(name, "/run.sh", true)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating run script mount")
+	}
+
 	opts := append([]string{
 		"run",
 		"--rm",
 		"--init",
 		"--workdir", target,
-		"--mount", "type=bind,source=" + name + ",target=/run.sh,ro",
+		"--mount", scriptMount,
 	}, common...)
 	opts = append(opts, DockerVolumeWorkspaceImage, "sh", "/run.sh")
 

--- a/internal/batches/workspace/volume_workspace.go
+++ b/internal/batches/workspace/volume_workspace.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"os"
 	"sort"
-	"strings"
 
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 
@@ -177,6 +176,7 @@ func (wc *dockerVolumeWorkspaceCreator) copyFilesIntoVolumes(ctx context.Context
 	if len(files) == 0 {
 		return nil
 	}
+	const copyScript = `while test "$#" -gt 0; do cp "$1" "$2" || exit; shift 2; done`
 
 	opts := append([]string{
 		"run",
@@ -192,22 +192,27 @@ func (wc *dockerVolumeWorkspaceCreator) copyFilesIntoVolumes(ctx context.Context
 	}
 	sort.Strings(names)
 
-	var copyCmds []string
-	for _, name := range names {
+	var copyArgs []string
+	for i, name := range names {
 		localPath := files[name]
+		// Names originate from the Sourcegraph instance. Keep them out of both
+		// Docker's comma-delimited mount grammar and the shell program.
+		mountTarget := fmt.Sprintf("/tmp/src-additional-file-%d", i)
 		opts = append(opts, []string{
-			"--mount", "type=bind,source=" + localPath + ",target=/tmp/" + name + ",ro",
+			"--mount", "type=bind,source=" + localPath + ",target=" + mountTarget + ",ro",
 		}...)
 
-		copyCmds = append(copyCmds, "cp /tmp/"+name+" /work/"+name)
+		copyArgs = append(copyArgs, mountTarget, "/work/"+name)
 	}
 
 	opts = append(
 		opts,
 		DockerVolumeWorkspaceImage,
 		"sh", "-c",
-		strings.Join(copyCmds, " && ")+";",
+		copyScript,
+		"copy-additional-files",
 	)
+	opts = append(opts, copyArgs...)
 
 	if out, err := exec.CommandContext(ctx, "docker", opts...).CombinedOutput(); err != nil {
 		return errors.Wrapf(err, "unzip output:\n\n%s\n\n", string(out))

--- a/internal/batches/workspace/volume_workspace_test.go
+++ b/internal/batches/workspace/volume_workspace_test.go
@@ -338,10 +338,13 @@ func TestVolumeWorkspaceCreator(t *testing.T) {
 					"--workdir", "/work",
 					"--user", "0:0",
 					"--mount", "type=volume,source="+volumeID+",target=/work",
-					"--mount", "type=bind,source="+archiveWithAdditionalFiles.mockAdditionalFilePaths[".gitignore"]+",target=/tmp/.gitignore,ro",
-					"--mount", "type=bind,source="+archiveWithAdditionalFiles.mockAdditionalFilePaths["another-file"]+",target=/tmp/another-file,ro",
+					"--mount", "type=bind,source="+archiveWithAdditionalFiles.mockAdditionalFilePaths[".gitignore"]+",target=/tmp/src-additional-file-0,ro",
+					"--mount", "type=bind,source="+archiveWithAdditionalFiles.mockAdditionalFilePaths["another-file"]+",target=/tmp/src-additional-file-1,ro",
 					DockerVolumeWorkspaceImage,
-					"sh", "-c", "cp /tmp/.gitignore /work/.gitignore && cp /tmp/another-file /work/another-file;",
+					"sh", "-c", `while test "$#" -gt 0; do cp "$1" "$2" || exit; shift 2; done`,
+					"copy-additional-files",
+					"/tmp/src-additional-file-0", "/work/.gitignore",
+					"/tmp/src-additional-file-1", "/work/another-file",
 				),
 				expect.NewGlob(
 					expect.Success,
@@ -382,6 +385,34 @@ func TestVolumeWorkspaceCreator(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestCopyFilesIntoVolumesDoesNotInterpolateNames(t *testing.T) {
+	const maliciousName = "x,ro,type=bind,source=/var/run/docker.sock,target=/h1sock;touch /work/injected;/.gitignore"
+
+	expect.Commands(
+		t,
+		expect.NewGlob(
+			expect.Success,
+			"docker", "run", "--rm", "--init", "--workdir", "/work",
+			"--user", "0:0",
+			"--mount", "type=volume,source="+volumeID+",target=/work",
+			"--mount", "type=bind,source=/tmp/additional-file,target=/tmp/src-additional-file-0,ro",
+			DockerVolumeWorkspaceImage,
+			"sh", "-c", `while test "$#" -gt 0; do cp "$1" "$2" || exit; shift 2; done`,
+			"copy-additional-files",
+			"/tmp/src-additional-file-0", "/work/"+maliciousName,
+		),
+	)
+
+	wc := &dockerVolumeWorkspaceCreator{}
+	w := &dockerVolumeWorkspace{volume: volumeID}
+	err := wc.copyFilesIntoVolumes(context.Background(), w, map[string]string{
+		maliciousName: "/tmp/additional-file",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/internal/batches/workspace/volume_workspace_test.go
+++ b/internal/batches/workspace/volume_workspace_test.go
@@ -416,6 +416,37 @@ func TestCopyFilesIntoVolumesDoesNotInterpolateNames(t *testing.T) {
 	}
 }
 
+func TestCopyFilesIntoVolumesRejectsUnsafePaths(t *testing.T) {
+	tests := map[string]map[string]string{
+		"workspace traversal": {
+			"../etc/.gitignore": "/tmp/additional-file",
+		},
+		"mount source injection": {
+			".gitignore": "/tmp/additional-file,source=/etc",
+		},
+	}
+
+	for name, files := range tests {
+		t.Run(name, func(t *testing.T) {
+			expect.Commands(t)
+			wc := &dockerVolumeWorkspaceCreator{}
+			w := &dockerVolumeWorkspace{volume: volumeID}
+			if err := wc.copyFilesIntoVolumes(context.Background(), w, files); err == nil {
+				t.Fatal("expected unsafe path to be rejected")
+			}
+		})
+	}
+}
+
+func TestUnzipRepoIntoVolumeRejectsMountSourceInjection(t *testing.T) {
+	expect.Commands(t)
+	wc := &dockerVolumeWorkspaceCreator{}
+	w := &dockerVolumeWorkspace{volume: volumeID}
+	if err := wc.unzipRepoIntoVolume(context.Background(), w, "/tmp/archive,source=/etc"); err == nil {
+		t.Fatal("expected unsafe mount source to be rejected")
+	}
+}
+
 func TestVolumeWorkspace_Close(t *testing.T) {
 	ctx := context.Background()
 	w := &dockerVolumeWorkspace{volume: volumeID}


### PR DESCRIPTION
## Problem

In volume workspace mode, `src batch` put a workspace file name directly into a Docker mount specification and a shell command. Workspace paths can come from directory names in repository content. A crafted directory name could therefore change the mount specification and run shell commands during workspace setup.

The same server-provided data was also trusted in two related places:

- In bind workspace mode, a path containing `..` could copy `.gitignore` or `.gitattributes` outside the workspace and change permissions on a host directory.
- Docker bind mount source paths were joined into mount specifications without validation. A comma in server-provided repository metadata could add or replace mount fields.

This fixes [VULN-143](https://linear.app/sourcegraph/issue/VULN-143/src-batch-volume-mode-a-server-supplied-workspacepath-is-concatenated) and the related issues identified while verifying the fix.

## Solution

Use fixed, generated paths for temporary Docker mounts and pass workspace destination names as shell arguments instead of adding them to the shell command.

Reject additional workspace file paths that resolve outside the workspace in both bind and volume modes.

Move Docker bind mount construction into a shared helper that validates every source and target before building the mount specification. Use that helper for all bind mounts in the batches code.

## Verification Evidence

- The reporter verified the original fix before and after, including an end-to-end run against a stock Sourcegraph instance and the original proof-of-concept payloads.
- Added regression coverage for Docker mount injection and shell injection through workspace file names.
- Added a bind-mode traversal test that confirms no file is written outside the workspace and existing directory permissions are unchanged.
- Added tests that reject unsafe archive paths, additional-file paths, and Docker mount sources and targets.
- Ran `go test ./internal/batches/...` successfully.
