### PR TITLE
fix/batches: prevent executor environment leakage to steps

### DIFF
--- a/internal/batches/executor/run_steps.go
+++ b/internal/batches/executor/run_steps.go
@@ -316,8 +316,9 @@ func executeSingleStep(
 	}
 	defer cleanup()
 
-	// Resolve step.Env given the current environment.
-	stepEnv, err := step.Env.Resolve(opts.GlobalEnv)
+	// Resolve step.Env given the current environment. Executor control values
+	// must never be selectable by an author-controlled step.
+	stepEnv, err := step.Env.Resolve(withoutReservedExecutorEnv(opts.GlobalEnv))
 	if err != nil {
 		err = errors.Wrap(err, "resolving step environment")
 		opts.UI.StepPreparingFailed(stepIdx+1, err)
@@ -462,6 +463,17 @@ func executeSingleStep(
 
 	opts.Logger.Logf("[Step %d] complete in %s", stepIdx+1, elapsed)
 	return stdout, stderr, nil
+}
+
+func withoutReservedExecutorEnv(env []string) []string {
+	filtered := make([]string, 0, len(env))
+	for _, variable := range env {
+		name, _, found := strings.Cut(variable, "=")
+		if !found || !strings.HasPrefix(name, "SRC_EXECUTOR_") {
+			filtered = append(filtered, variable)
+		}
+	}
+	return filtered
 }
 
 func setOutputs(stepOutputs batcheslib.Outputs, global map[string]any, stepCtx *template.StepContext) error {

--- a/internal/batches/executor/run_steps_test.go
+++ b/internal/batches/executor/run_steps_test.go
@@ -2,6 +2,7 @@ package executor
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -10,8 +11,39 @@ import (
 	"github.com/stretchr/testify/require"
 
 	batcheslib "github.com/sourcegraph/sourcegraph/lib/batches"
+	batchenv "github.com/sourcegraph/sourcegraph/lib/batches/env"
 	"github.com/sourcegraph/sourcegraph/lib/batches/template"
 )
+
+func TestWithoutReservedExecutorEnv(t *testing.T) {
+	env := []string{
+		"ALLOWED=value",
+		"SRC_EXECUTOR_JOB_TOKEN=secret",
+		"SRC_EXECUTOR_FUTURE_SECRET=secret",
+		"VALUE=contains-SRC_EXECUTOR_JOB_TOKEN",
+		"MALFORMED",
+	}
+
+	require.Equal(t, []string{
+		"ALLOWED=value",
+		"VALUE=contains-SRC_EXECUTOR_JOB_TOKEN",
+		"MALFORMED",
+	}, withoutReservedExecutorEnv(env))
+
+	var stepEnv batchenv.Environment
+	require.NoError(t, json.Unmarshal([]byte(`[
+		"ALLOWED",
+		"SRC_EXECUTOR_JOB_TOKEN",
+		"SRC_EXECUTOR_FUTURE_SECRET"
+	]`), &stepEnv))
+	resolved, err := stepEnv.Resolve(withoutReservedExecutorEnv(env[:4]))
+	require.NoError(t, err)
+	require.Equal(t, map[string]string{
+		"ALLOWED":                    "value",
+		"SRC_EXECUTOR_JOB_TOKEN":     "",
+		"SRC_EXECUTOR_FUTURE_SECRET": "",
+	}, resolved)
+}
 
 func TestParseContainerTempPath(t *testing.T) {
 	for _, valid := range []string{"/tmp/tmp.abc-123_456", "/tmp/tmp.abc-123_456\n"} {


### PR DESCRIPTION
## Problem

Batch steps can request environment variables by name. The executor passed its full process environment into this resolver, so a step could request reserved `SRC_EXECUTOR_*` values. These values include executor control credentials that must not be available inside an ordinary batch step.

This fixes [VULN-141](https://linear.app/sourcegraph/issue/VULN-141/i-can-use-a-reserved-executor-bearer-from-a-normal-v2-batch-step-to).

## Solution

Filter the reserved `SRC_EXECUTOR_*` namespace from the outer environment before resolving step variables. The filter is applied at the step execution boundary, so it covers every caller and also protects future variables in the reserved namespace. Normal environment variables and explicit step values continue to work.

## Verification Evidence

- Added a regression test showing that normal outer variables still resolve.
- Added coverage showing that current and future `SRC_EXECUTOR_*` outer variables resolve to empty values.
- `go test ./internal/batches/...`
- `go test ./cmd/src`